### PR TITLE
Fix/admin workspace

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -6,14 +6,14 @@ Remove legacy admin workspace scope logic and align admin_app access with worksp
 ## Plan / Todo
 - [x] Commit 1: Allow admin_app workspace management + remove legacy share_with_admin checks
 - [x] Commit 2: Remove admin scope store and API comment
-- [ ] Commit 3: Remove admin workspaces endpoint and spec refs
+- [x] Commit 3: Remove admin workspaces endpoint and spec refs
 
 ## Commits & Progress
 - [x] **Commit 1**: API workspace access cleanup
 - [x] **Commit 2**: UI admin scope cleanup
-- [ ] **Commit 3**: Remove admin workspaces endpoint + docs
+- [x] **Commit 3**: Remove admin workspaces endpoint + docs
 
 ## Status
-- **Progress**: 2/3 tasks completed
-- **Current**: Remove admin workspaces endpoint + docs
-- **Next**: Remove /admin/workspaces in API and specs
+- **Progress**: 3/3 tasks completed
+- **Current**: All planned commits done
+- **Next**: Review for any remaining legacy references

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,19 @@
+# Feature: Admin workspace cleanup
+
+## Objective
+Remove legacy admin workspace scope logic and align admin_app access with workspace memberships.
+
+## Plan / Todo
+- [x] Commit 1: Allow admin_app workspace management + remove legacy share_with_admin checks
+- [ ] Commit 2: Remove admin scope store and API comment
+- [ ] Commit 3: Remove admin workspaces endpoint and spec refs
+
+## Commits & Progress
+- [x] **Commit 1**: API workspace access cleanup
+- [ ] **Commit 2**: UI admin scope cleanup
+- [ ] **Commit 3**: Remove admin workspaces endpoint + docs
+
+## Status
+- **Progress**: 1/3 tasks completed
+- **Current**: Commit UI admin scope cleanup
+- **Next**: Remove admin scope store and API comment

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -5,15 +5,15 @@ Remove legacy admin workspace scope logic and align admin_app access with worksp
 
 ## Plan / Todo
 - [x] Commit 1: Allow admin_app workspace management + remove legacy share_with_admin checks
-- [ ] Commit 2: Remove admin scope store and API comment
+- [x] Commit 2: Remove admin scope store and API comment
 - [ ] Commit 3: Remove admin workspaces endpoint and spec refs
 
 ## Commits & Progress
 - [x] **Commit 1**: API workspace access cleanup
-- [ ] **Commit 2**: UI admin scope cleanup
+- [x] **Commit 2**: UI admin scope cleanup
 - [ ] **Commit 3**: Remove admin workspaces endpoint + docs
 
 ## Status
-- **Progress**: 1/3 tasks completed
-- **Current**: Commit UI admin scope cleanup
-- **Next**: Remove admin scope store and API comment
+- **Progress**: 2/3 tasks completed
+- **Current**: Remove admin workspaces endpoint + docs
+- **Next**: Remove /admin/workspaces in API and specs

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -4,9 +4,13 @@
 Remove legacy admin workspace scope logic and align admin_app access with workspace memberships.
 
 ## Plan / Todo
-- [x] Commit 1: Allow admin_app workspace management + remove legacy share_with_admin checks
-- [x] Commit 2: Remove admin scope store and API comment
-- [x] Commit 3: Remove admin workspaces endpoint and spec refs
+- [x] Allow admin_app workspace management + remove legacy share_with_admin checks
+- [x] Remove admin scope store and API comment
+- [x] Remove admin workspaces endpoint and spec refs
+- [x] make lint typecheck 
+- [x] make test-ui test-api
+- [x] make build-ui-image build-api && make clean test e2e
+
 
 ## Commits & Progress
 - [x] **Commit 1**: API workspace access cleanup

--- a/api/src/routes/api/admin.ts
+++ b/api/src/routes/api/admin.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { zValidator } from '@hono/zod-validator';
 import { db } from '../../db/client';
-import { folders, organizations, useCases, userSessions, users, workspaces, workspaceMemberships } from '../../db/schema';
+import { folders, organizations, useCases, userSessions, users, workspaces } from '../../db/schema';
 import { and, desc, eq, inArray, sql } from 'drizzle-orm';
 import {
   chatGenerationTraces,
@@ -135,28 +135,6 @@ adminRouter.get('/users', async (c) => {
   });
 
   return c.json({ items });
-});
-
-adminRouter.get('/workspaces', async (c) => {
-  const admin = c.get('user');
-  // List all workspaces (admin_app can see all), attach membership role if any.
-  const rows = await db
-    .select({
-      id: workspaces.id,
-      name: workspaces.name,
-      ownerUserId: workspaces.ownerUserId,
-      ownerEmail: users.email,
-      role: workspaceMemberships.role,
-    })
-    .from(workspaces)
-    .leftJoin(users, eq(workspaces.ownerUserId, users.id))
-    .leftJoin(
-      workspaceMemberships,
-      and(eq(workspaceMemberships.workspaceId, workspaces.id), eq(workspaceMemberships.userId, admin.userId))
-    )
-    .orderBy(desc(workspaces.createdAt));
-
-  return c.json({ items: rows });
 });
 
 const approveSchema = z.object({

--- a/api/src/routes/api/workspaces.ts
+++ b/api/src/routes/api/workspaces.ts
@@ -68,7 +68,6 @@ const createWorkspaceSchema = z.object({
 // Create workspace: creator becomes admin member
 workspacesRouter.post('/', requireEditor, zValidator('json', createWorkspaceSchema), async (c) => {
   const user = c.get('user') as { userId: string; role: string };
-  if (user.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const { name } = c.req.valid('json');
   const id = createId();
@@ -104,7 +103,6 @@ const updateWorkspaceSchema = z.object({
 
 workspacesRouter.put('/:id', requireEditor, zValidator('json', updateWorkspaceSchema), async (c) => {
   const user = c.get('user') as { userId: string; role: string };
-  if (user.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const workspaceId = c.req.param('id');
   try {
@@ -126,7 +124,6 @@ workspacesRouter.put('/:id', requireEditor, zValidator('json', updateWorkspaceSc
 
 workspacesRouter.post('/:id/hide', requireEditor, async (c) => {
   const user = c.get('user') as { userId: string; role: string };
-  if (user.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const workspaceId = c.req.param('id');
   try {
@@ -143,7 +140,6 @@ workspacesRouter.post('/:id/hide', requireEditor, async (c) => {
 
 workspacesRouter.post('/:id/unhide', requireEditor, async (c) => {
   const user = c.get('user') as { userId: string; role: string };
-  if (user.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const workspaceId = c.req.param('id');
   try {
@@ -161,7 +157,6 @@ workspacesRouter.post('/:id/unhide', requireEditor, async (c) => {
 // Hard delete (only if hidden)
 workspacesRouter.delete('/:id', requireEditor, async (c) => {
   const user = c.get('user') as { userId: string; role: string };
-  if (user.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const workspaceId = c.req.param('id');
   try {
@@ -250,7 +245,6 @@ const addMemberSchema = z.object({
 
 workspacesRouter.post('/:id/members', requireEditor, zValidator('json', addMemberSchema), async (c) => {
   const actor = c.get('user') as { userId: string; role: string };
-  if (actor.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const workspaceId = c.req.param('id');
   try {
@@ -289,7 +283,6 @@ const updateMemberSchema = z.object({
 
 async function updateMemberRoleHandler(c: Context) {
   const actor = c.get('user') as { userId: string; role: string };
-  if (actor.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const workspaceId = c.req.param('id');
   const targetUserId = c.req.param('userId');
@@ -322,7 +315,6 @@ workspacesRouter.put('/:id/members/:userId', requireEditor, zValidator('json', u
 
 workspacesRouter.delete('/:id/members/:userId', requireEditor, async (c) => {
   const actor = c.get('user') as { userId: string; role: string };
-  if (actor.role === 'admin_app') return c.json({ error: 'Insufficient permissions' }, 403);
 
   const workspaceId = c.req.param('id');
   const targetUserId = c.req.param('userId');

--- a/api/src/utils/workspace-scope.ts
+++ b/api/src/utils/workspace-scope.ts
@@ -1,0 +1,29 @@
+import { ADMIN_WORKSPACE_ID } from '../db/schema';
+import { getWorkspaceRole } from '../services/workspace-access';
+
+/**
+ * Resolve a workspace scope for admin_app reads.
+ * - Non-admins: always own workspace
+ * - admin_app: can request another workspace only if they are a member (or Admin Workspace)
+ */
+export async function resolveReadableWorkspaceId(params: {
+  user: { role?: string; workspaceId: string; userId: string };
+  requested?: string | null;
+}): Promise<string> {
+  const { user, requested } = params;
+  const req = (requested ?? '').trim();
+
+  if (!req) return user.workspaceId;
+  if (user.role !== 'admin_app') return user.workspaceId;
+  if (req === ADMIN_WORKSPACE_ID) return req;
+
+  const role = await getWorkspaceRole(user.userId, req);
+  if (!role) {
+    // opaque (avoid information leaks)
+    throw new Error('Workspace not accessible');
+  }
+
+  return req;
+}
+
+

--- a/e2e/tests/fixtures/spec-concat.md
+++ b/e2e/tests/fixtures/spec-concat.md
@@ -1178,7 +1178,6 @@ This must be immediate and irreversible (no recycle bin).
 - `GET /api/v1/admin/users/:userId/objects/*` (only if workspace is shared; read-only)
 
 Workspace switcher support:
-- `GET /api/v1/admin/workspaces`
   - list workspaces that are either:
     - admin workspace, or
     - shared by their owner (`shareWithAdmin=true`)

--- a/spec/SPEC_ADMIN_USERS.md
+++ b/spec/SPEC_ADMIN_USERS.md
@@ -207,7 +207,6 @@ This must be immediate and irreversible (no recycle bin).
 - `GET /api/v1/admin/users/:userId/objects/*` (only if workspace is shared; read-only)
 
 Workspace switcher support:
-- `GET /api/v1/admin/workspaces`
   - list workspaces that are either:
     - admin workspace, or
     - shared by their owner (`shareWithAdmin=true`)

--- a/ui/src/lib/utils/api.ts
+++ b/ui/src/lib/utils/api.ts
@@ -33,8 +33,6 @@ export async function apiRequest<T = any>(
   const rawUrl = endpoint.startsWith('http') ? endpoint : `${API_BASE_URL}${endpoint}`;
 
   // Attach workspace scope (stored in localStorage) as `workspace_id` query param.
-  // - admin_app uses admin scope store
-  // - regular users use workspace scope store
   const scoped = getScopedWorkspaceIdForUser();
   const url = (() => {
     if (!scoped) return rawUrl;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Admin workspace cleanup (membership-based)**
> 
> - Remove legacy `GET /api/v1/admin/workspaces` endpoint and related spec/e2e references
> - In workspace routes, drop blanket `admin_app` blocks; enforce mutations via `requireWorkspaceAdmin` (membership-based)
> - Add `resolveReadableWorkspaceId` to gate admin reads to Admin Workspace or workspaces where the admin is a member
> - Minor cleanup: unused imports removed; UI API util comment simplified (scoping via stored `workspace_id` unchanged)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e513cd8172942a233ca6d15ef34ce3a0371b6d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->