### PR TITLE
fix(ci): e2e-vscode blocks API deployment on API-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       workers: ${{ steps.filter.outputs.workers }}
       ui: ${{ steps.filter.outputs.ui }}
       ai: ${{ steps.filter.outputs.ai }}
-      vscode: ${{ steps.filter.outputs.vscode }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -37,11 +36,6 @@ jobs:
               - 'api/**'
             ui:
               - 'ui/**'
-            vscode:
-              - 'ui/vscode-ext/**'
-              - 'e2e/tests/vscode/**'
-              - 'docker-compose.e2e-vscode.yml'
-              - '.github/workflows/ci.yml'
 
   # Build E2E Docker image
   build-e2e:
@@ -285,7 +279,7 @@ jobs:
   e2e-vscode:
     runs-on: ubuntu-latest
     needs: [changes, typecheck-lint-ui, typecheck-lint-api, build-api-image, build-ui, build-e2e, security-sast-sca]
-    if: needs.changes.outputs.vscode == 'true' || needs.changes.outputs.global == 'true'
+    if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
     env:
       DOCKER_USERNAME: nologin
       DOCKER_PASSWORD: ${{ secrets.SCW_SECRET_KEY }}


### PR DESCRIPTION
## Summary
- Remove dedicated `vscode` path filter output from CI changes job
- `e2e-vscode` now uses the same trigger conditions as `test-e2e`: `ui || api || global`
- Previously, API-only changes skipped `e2e-vscode`, which blocked `publish-api-image` and `deploy-api` via the `needs` chain

## Root cause
`e2e-vscode` only triggered on `vscode == true || global == true`. The `vscode` filter matched `ui/vscode-ext/**` and `e2e/tests/vscode/**` — but not `api/**`. Since `publish-api-image` depends on `e2e-vscode`, API-only PRs could never publish/deploy.

## Test plan
- [ ] Merge and verify that an API-only change triggers the full CI pipeline including e2e-vscode
- [ ] Verify the smithy fix (PR #88) deploys successfully after this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)