### PR TITLE
fix(api): upgrade hono 4.12.8 — security vulnerabilities

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -42,7 +42,7 @@
         "@vitest/ui": "^4.0.18",
         "drizzle-kit": "^0.28.1",
         "eslint": "^10.0.2",
-        "hono": "4.12.5",
+        "hono": "^4.12.8",
         "prettier": "^3.2.5",
         "tsx": "^4.7.2",
         "typescript": "^5.4.5",
@@ -5604,9 +5604,10 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.8",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
+      "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
+      "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -75,7 +75,7 @@
     "@vitest/ui": "^4.0.18",
     "drizzle-kit": "^0.28.1",
     "eslint": "^10.0.2",
-    "hono": "4.12.5",
+    "hono": "^4.12.8",
     "prettier": "^3.2.5",
     "tsx": "^4.7.2",
     "typescript": "^5.4.5",


### PR DESCRIPTION
## Summary
- Upgrades hono from 4.12.6 to 4.12.8
- Fixes 4 high/moderate security vulnerabilities (cookie injection, SSE injection, file access, prototype pollution)

## Test plan
- [ ] `npm audit` shows no hono vulnerabilities
- [ ] API starts and responds normally
- [ ] CI passes

