### PR TITLE
docs(plan): enrich catalog with descriptions, mark BR-06 done, BR-09 deferred

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,31 +1,30 @@
 # PLAN - Orchestrated Roadmap
 
-Status: Updated 2026-04-07 — BR-04B done, next: BR-23 (framework comparison), BR-25 (rules audit)
-Previous window (2026-02-23 → 2026-03-08) closed. New timeline driven by BR-04/04B scope.
+Status: Updated 2026-04-17 — BR-06 merged (`62de15ad`), next priorities TBD (see §5 Scheduling).
 
 ## 1) Current state
 
-**Completed branches:**
-- BR-00 `feat/roadmap-stabilization` — done
-- BR-01 `feat/model-runtime-openai-gemini` — done, merged
-- BR-02 `feat/sso-chatgpt` — done (product pivot, docs only)
-- BR-03 `feat/todo-steering-workflow-core` — done, merged
-- BR-05 `feat/vscode-plugin-v1` — done, merged
-- BR-13 `feat/chrome-plugin-download-distribution` — done, merged
+**Completed branches (merged):**
+- BR-00 `feat/roadmap-stabilization`
+- BR-01 `feat/model-runtime-openai-gemini`
+- BR-02 `feat/sso-chatgpt` (product pivot, docs only)
+- BR-03 `feat/todo-steering-workflow-core`
+- BR-04 `feat/workspace-template-catalog` (workspace type system, initiative rename, multi-workflow registry, extended objects, gate system)
+- BR-04B `feat/workspace-template-catalog` continuation (template-driven rendering, generic workflow runtime, freeform DOCX, chat tools wiring)
+- BR-05 `feat/vscode-plugin-v1`
+- BR-06 `feat/chrome-upstream-v1` — **merged 2026-04-17** (`62de15ad`). Webapp tab_read/tab_action to Chrome tabs via extension + in-memory Tab Registry.
+- BR-08 `feat/model-runtime-claude-mistral-cohere` (scope extended: +Cohere)
+- BR-13 `feat/chrome-plugin-download-distribution`
 
-**Completed branches (continued):**
-- BR-04 `feat/workspace-template-catalog` — done, merged (workspace type system, initiative rename, multi-workflow registry, extended objects, gate system)
-
-**Completed branches (continued):**
-- BR-04B `feat/workspace-template-catalog` (continuation) — **done, merged**. Template-driven rendering, config UX alignment, chat tools wiring, generic workflow runtime, freeform DOCX generation. See `plan/done/04B-BRANCH_feat-workspace-template-catalog.md`.
-
-**Next branches:**
+**Next branches (explicitly queued):**
 - BR-23 `feat/multi-agent-framework-comparison` — compare LangGraph/Agno/Temporal. See `plan/23-BRANCH_feat-multi-agent-framework-comparison.md`.
 - BR-25 `chore/rules-skills-audit` — absorb BR-04B audit learnings. See `plan/25-BRANCH_chore-rules-skills-audit.md`.
 
-**Pending branches (unblocked by BR-04B completion):**
-- BR-06 through BR-12 — not started, now unblocked.
-- BR-14, BR-16, BR-17, BR-20, BR-21, BR-22 — identified during BR-04 scope expansion and follow-up UAT/debug tracks.
+**Pending branches (unblocked):**
+- BR-07, BR-10, BR-11, BR-12, BR-14, BR-14b, BR-15, BR-16, BR-17, BR-18, BR-19, BR-20, BR-21, BR-22 — see §3 catalog for descriptions, dependencies, and priorities.
+
+**Deferred:**
+- BR-09 `feat/sso-google` — deferred post-refacto (OOM resolution required before SSO Google work; exact target TBD by conductor).
 
 ## 2) BR-04/04B as structural branch
 
@@ -50,32 +49,35 @@ Full spec: `spec/SPEC_EVOL_WORKSPACE_TYPES.md`
 
 ## 3) Branch catalog
 
-| ID | Branch | Status | Depends on | BR-04 impact |
-|---|---|---|---|---|
-| BR-00 | `feat/roadmap-stabilization` | done | — | — |
-| BR-01 | `feat/model-runtime-openai-gemini` | done | BR-00 | — |
-| BR-02 | `feat/sso-chatgpt` | done | BR-00 | — |
-| BR-03 | `feat/todo-steering-workflow-core` | done | BR-00 | — |
-| BR-04 | `feat/workspace-template-catalog` | done | BR-03, BR-05 | — |
-| BR-04B | `feat/workspace-template-catalog` (continuation) | **done** | BR-04 | — |
-| BR-05 | `feat/vscode-plugin-v1` | done | BR-01, BR-03 | — |
-| BR-06 | `feat/chrome-upstream-v1` | plan | BR-00 | low (contextType rename) |
-| BR-07 | `feat/release-ui-npm-and-pretest` | plan | BR-00, **BR-14** | none (blocked: npm export requires modular ChatWidget) |
-| BR-08 | `feat/model-runtime-claude-mistral-cohere` | done | BR-01 | none (scope extended: +Cohere) |
-| BR-09 | `feat/sso-google` | plan | BR-00 | none |
-| BR-10 | `feat/vscode-plugin-v2-multi-agent` | plan | BR-05, BR-08, **BR-04** | **high** (workspace-type-aware agents) |
-| BR-11 | `feat/chrome-upstream-multitab-voice` | plan | BR-06, BR-08 | low (contextType rename) |
-| BR-12 | `feat/release-chrome-vscode-ci-publish` | plan | BR-05, BR-06, BR-07, BR-13 | none |
-| BR-13 | `feat/chrome-plugin-download-distribution` | done | BR-06 | — |
-| BR-14 | `feat/chat-modularization` | plan | BR-04 (low) | low (ChatPanel/ChatWidget refactoring) |
-| BR-15 | `feat/spectral-site-tools` | API capture + auto-generated per-site tools via Spectral-like analysis | plan | BR-06 | `plan/15-BRANCH_feat-spectral-site-tools.md` |
-| BR-16 | `feat/document-connectors` | plan | BR-04 (low) | low (initiative rename in contextType) |
-| BR-17 | `feat/rag-documents` | plan | BR-16 (optional), BR-08 (Cohere embeddings) | none |
-| BR-18 | `feat/sortable-list-views` | Sortable columns for all list views (folders, initiatives, workspaces) | plan | none | none |
-| BR-19 | `feat/agent-sandbox-skills` | V8 sandbox for tool execution + skill catalog replacing hardcoded tool dispatch | plan | BR-04 | **high** (replaces tool dispatch in chat-service, queue-manager, ChatPanel tool toggles) |
-| BR-20 | `refacto/entity-page-neutral-config` | plan | BR-04 | **high** (follow-up: neutral entity route + config-driven view templates) |
-| BR-21 | `feat/cv-transpose-profiles` | plan | BR-04 | medium (depends on TemplateRenderer/proposals from BR-04B) |
-| BR-22 | `fix/rich-markdown-list-stabilization` | plan | BR-04 | medium (post-merge stabilization of TemplateRenderer/TipTap rich list editing) |
+| ID     | Branch                                           | Description                                                                                                                        | Status                                       | Depends on                                  |
+|--------|--------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------|---------------------------------------------|
+| BR-00  | `feat/roadmap-stabilization`                     | Roadmap stabilization, rules/workflow bootstrap.                                                                                   | done                                         | —                                           |
+| BR-01  | `feat/model-runtime-openai-gemini`               | Model runtime v1: OpenAI + Gemini providers.                                                                                       | done                                         | BR-00                                       |
+| BR-02  | `feat/sso-chatgpt`                               | ChatGPT SSO (product pivot, docs only).                                                                                            | done                                         | BR-00                                       |
+| BR-03  | `feat/todo-steering-workflow-core`               | TODO + steering + workflow core engine.                                                                                            | done                                         | BR-00                                       |
+| BR-04  | `feat/workspace-template-catalog`                | Workspace types, initiative rename, multi-workflow registry, extended objects, gate system.                                        | done                                         | BR-03, BR-05                                |
+| BR-04B | `feat/workspace-template-catalog` (continuation) | Template-driven rendering, generic executable workflow runtime, freeform DOCX, chat tools wiring.                                  | done                                         | BR-04                                       |
+| BR-05  | `feat/vscode-plugin-v1`                          | VSCode plugin v1 (chat sidepanel, single agent).                                                                                   | done                                         | BR-01, BR-03                                |
+| BR-06  | `feat/chrome-upstream-v1`                        | Webapp dispatches tab_read/tab_action to Chrome tabs via extension (in-memory Tab Registry).                                       | **done**                                     | BR-00                                       |
+| BR-07  | `feat/release-ui-npm-and-pretest`                | UI npm publish + packaged debug assistant with CI artifacts (screens/videos/logs).                                                 | plan                                         | BR-00, **BR-14**                            |
+| BR-08  | `feat/model-runtime-claude-mistral-cohere`       | Model runtime v2: Claude + Mistral + Cohere providers.                                                                             | done                                         | BR-01                                       |
+| BR-09  | `feat/sso-google`                                | Google SSO for admin + standard users, account linking, session compat.                                                            | **deferred** (post-refacto / OOM resolution) | BR-00                                       |
+| BR-10  | `feat/vscode-plugin-v2-multi-agent`              | VSCode v2 multi-agent/multi-model + detached tool lifecycle.                                                                       | plan                                         | BR-05, BR-08, **BR-04**                     |
+| BR-11  | `feat/chrome-upstream-multitab-voice`            | Extend upstream to multi-tab orchestration + voice commands with consent gates.                                                    | plan                                         | BR-06, BR-08                                |
+| BR-12  | `feat/release-chrome-vscode-ci-publish`          | CI publishing for Chrome + VSCode plugins with release gating.                                                                     | plan                                         | BR-05, BR-06, BR-07, BR-13                  |
+| BR-13  | `feat/chrome-plugin-download-distribution`       | Chrome extension build + download/distribution flow.                                                                               | done                                         | BR-06                                       |
+| BR-14  | `feat/chat-modularization`                       | Decompose ChatPanel (59K) + ChatWidget (37K) into modular subcomponents (unblocks BR-07 npm export).                               | plan                                         | BR-04 (low)                                 |
+| BR-14b | `refacto/llm-runtime`                            | Refactor monolithic LLM runtime into provider-agnostic architecture + per-model capability matrix.                                 | plan                                         | BR-08                                       |
+| BR-15  | `feat/spectral-site-tools`                       | HTTP traffic capture + LLM analysis → auto-generated per-site API tools (complement to DOM tab_read/tab_action).                   | plan                                         | BR-06, BR-19                                |
+| BR-16  | `feat/document-connectors`                       | Connector abstraction for external doc sources (Google Drive/Docs/Sheets, SharePoint/OneDrive) alongside local upload.             | plan                                         | BR-04 (low)                                 |
+| BR-17  | `feat/rag-documents`                             | RAG on context-attached documents: retrieve semantically relevant chunks instead of full-document summaries.                       | plan                                         | BR-16 (optional), BR-08 (Cohere embeddings) |
+| BR-18  | `feat/sortable-list-views`                       | Sortable columns for all list views (folders, initiatives, workspaces).                                                            | plan                                         | none                                        |
+| BR-19  | `feat/agent-sandbox-skills`                      | V8 sandbox for tool execution + skill catalog replacing hardcoded tool dispatch.                                                   | plan                                         | BR-04                                       |
+| BR-20  | `refacto/entity-page-neutral-config`             | Neutral entity route + config-driven view templates (follow-up absorbing BR-04B learnings).                                        | plan                                         | BR-04                                       |
+| BR-21  | `feat/cv-transpose-profiles`                     | CV transpose: upload → extract profiles (officeparser + LLM) → edit → export DOCX/PPTX; proposal + staffing integration.           | plan                                         | BR-04                                       |
+| BR-22  | `fix/rich-markdown-list-stabilization`           | Stabilize rich markdown list rendering/editing (freeze on initiative `cc884370…` in `constraints` field).                          | plan                                         | BR-04                                       |
+| BR-23  | `feat/multi-agent-framework-comparison`          | Compare LangGraph / Agno / Temporal; recommendation + runtime extension plan.                                                      | plan                                         | BR-04B                                      |
+| BR-25  | `chore/rules-skills-audit`                       | Absorb BR-04B audit learnings (2 agents, 13 sessions, 400+ incidents) into rules + skills. Mechanical enforcement over text rules. | plan                                         | BR-04B                                      |
 
 ## 4) Dependency graph
 


### PR DESCRIPTION
## Objective
Make the §3 branch catalog in `PLAN.md` self-sufficient so the conductor and subagents do not need to open each `plan/NN-BRANCH_*.md` to know what a branch is about. Also record the BR-06 merge and the BR-09 post-OOM deferral.

## Plan
- Rebuild §3 Branch catalog as a padded table `| ID | Branch | Description | Status | Depends on |` with descriptions extracted verbatim from each `plan/NN-BRANCH_*.md` Objective section. Add BR-14b, BR-23, BR-25.
- Mark BR-06 `**done**` (merged 2026-04-17 as `62de15ad`).
- Mark BR-09 `**deferred** (post-refacto / OOM resolution)`.
- Update §1 Current state and Status line to reflect the 2026-04-17 snapshot.
- Docs-only change. No workflow, no code, no spec.