### PR TITLE
fix(api): replace Mistral SDK dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,9 @@ jobs:
     needs: [changes]
     steps:
       - uses: actions/checkout@v4
-        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
       - name: Setup Docker
-        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         uses: docker/setup-buildx-action@v3
       - name: Typecheck UI
         if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
@@ -229,16 +229,16 @@ jobs:
         if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
         run: make build-ext-vscode
       - name: Build UI image
-        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         run: make build-ui-image
       - name: Save UI image as artifact
-        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         run: make save-ui
       - name: Test UI
         if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
         run: make test-ui
       - name: Upload UI image artifact
-        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: ui-image
@@ -290,9 +290,9 @@ jobs:
         with:
           name: api-image
           path: .
-      - name: Load API image from artifact
-        if: steps.check-api-image.outcome == 'failure'
-        run: make load-api
+      - name: Load UI image from artifact
+        if: steps.check-ui-image.outcome == 'failure'
+        run: make load-ui
       - name: Pull if UI image is up to date
         id: check-ui-image
         run: make pull-ui-image

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -12,7 +12,6 @@
         "@aws-sdk/client-s3": "^3.980.0",
         "@hono/node-server": "^1.19.13",
         "@hono/zod-validator": "^0.7.6",
-        "@mistralai/mistralai": "^1.15.1",
         "@simplewebauthn/server": "^13.2.2",
         "@xmldom/xmldom": "0.9.10",
         "better-queue": "^3.8.12",
@@ -2193,16 +2192,6 @@
       "resolved": "https://registry.npmjs.org/@levischuck/tiny-cbor/-/tiny-cbor-0.2.11.tgz",
       "integrity": "sha512-llBRm4dT4Z89aRsm6u2oEZ8tfwL/2l6BwpZ7JcyieouniDECM5AqNgr/y08zalEIvW3RSK4upYyybDcmjXqAow==",
       "license": "MIT"
-    },
-    "node_modules/@mistralai/mistralai": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-1.15.1.tgz",
-      "integrity": "sha512-fb995eiz3r0KsBGtRjFV+/iLbX+UpfalxpF+YitT3R6ukrPD4PN+FGwwmYcRFhNAzVzDUtTVxQYnjQWEnwV5nw==",
-      "dependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-to-json-schema": "^3.24.1"
-      }
     },
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.97",
@@ -8050,27 +8039,6 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
-    "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -8136,15 +8104,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/api/package.json
+++ b/api/package.json
@@ -47,7 +47,6 @@
     "@sentropic/llm-mesh": "file:../packages/llm-mesh",
     "@hono/node-server": "^1.19.13",
     "@hono/zod-validator": "^0.7.6",
-    "@mistralai/mistralai": "^1.15.1",
     "@simplewebauthn/server": "^13.2.2",
     "@xmldom/xmldom": "0.9.10",
     "better-queue": "^3.8.12",

--- a/api/src/services/providers/mistral-provider.ts
+++ b/api/src/services/providers/mistral-provider.ts
@@ -1,4 +1,3 @@
-import { Mistral } from '@mistralai/mistralai';
 import { env } from '../../config/env';
 import type {
   CredentialValidationResult,
@@ -11,6 +10,8 @@ import {
   buildRuntimeProviderDescriptor,
   listRuntimeModelsByProvider,
 } from '../provider-runtime';
+
+const MISTRAL_CHAT_COMPLETIONS_URL = 'https://api.mistral.ai/v1/chat/completions';
 
 export type MistralGenerateRequest = {
   mode: 'chat-completions';
@@ -41,6 +42,18 @@ export type MistralStreamGenerateRequest = {
   credential?: string;
   signal?: AbortSignal;
 };
+
+class MistralHttpError extends Error {
+  readonly status?: number;
+  readonly code?: string;
+
+  constructor(message: string, options: { status?: number; code?: string } = {}) {
+    super(message);
+    this.name = 'MistralHttpError';
+    this.status = options.status;
+    this.code = options.code;
+  }
+}
 
 export class MistralProviderRuntime implements ProviderRuntime {
   readonly provider: ProviderDescriptor;
@@ -99,8 +112,12 @@ export class MistralProviderRuntime implements ProviderRuntime {
       throw new Error('MistralProviderRuntime.generate: unsupported mode');
     }
 
-    const client = this.getClient(payload.credential);
-    return await client.chat.complete(payload.requestOptions);
+    const apiKey = this.getApiKey(payload.credential);
+    return await this.postChatCompletions(
+      apiKey,
+      this.normalizeRequestOptions(payload.requestOptions),
+      payload.signal,
+    );
   }
 
   async streamGenerate(request: unknown): Promise<AsyncIterable<unknown>> {
@@ -109,26 +126,208 @@ export class MistralProviderRuntime implements ProviderRuntime {
       throw new Error('MistralProviderRuntime.streamGenerate: unsupported mode');
     }
 
-    const client = this.getClient(payload.credential);
-    const stream = await client.chat.stream(payload.requestOptions);
-
-    return this.toAsyncIterable(stream);
+    const apiKey = this.getApiKey(payload.credential);
+    return await this.postChatCompletionsStream(
+      apiKey,
+      {
+        ...this.normalizeRequestOptions(payload.requestOptions),
+        stream: true,
+      },
+      payload.signal,
+    );
   }
 
-  private getClient(apiKeyOverride?: string): Mistral {
+  private getApiKey(apiKeyOverride?: string): string {
     const validation = this.validateCredential(apiKeyOverride);
     if (!validation.ok) {
       throw new Error(validation.message || 'Mistral API key is not configured');
     }
 
-    return new Mistral({ apiKey: apiKeyOverride || env.MISTRAL_API_KEY });
+    return apiKeyOverride || env.MISTRAL_API_KEY;
   }
 
-  private async *toAsyncIterable(
-    stream: AsyncIterable<unknown>,
+  private normalizeRequestOptions(
+    requestOptions: Record<string, unknown>,
+  ): Record<string, unknown> {
+    const normalized: Record<string, unknown> = { ...requestOptions };
+
+    this.moveOption(normalized, 'responseFormat', 'response_format');
+    this.moveOption(normalized, 'toolChoice', 'tool_choice');
+    this.moveOption(normalized, 'maxTokens', 'max_tokens');
+
+    const messages = normalized.messages;
+    if (Array.isArray(messages)) {
+      normalized.messages = messages.map((message) =>
+        this.normalizeMessage(message as Record<string, unknown>),
+      );
+    }
+
+    return normalized;
+  }
+
+  private normalizeMessage(message: Record<string, unknown>): Record<string, unknown> {
+    const normalized: Record<string, unknown> = { ...message };
+    this.moveOption(normalized, 'toolCalls', 'tool_calls');
+    this.moveOption(normalized, 'toolCallId', 'tool_call_id');
+    return normalized;
+  }
+
+  private moveOption(
+    options: Record<string, unknown>,
+    source: string,
+    target: string,
+  ): void {
+    if (Object.prototype.hasOwnProperty.call(options, source)) {
+      if (!Object.prototype.hasOwnProperty.call(options, target)) {
+        options[target] = options[source];
+      }
+      delete options[source];
+    }
+  }
+
+  private async postChatCompletions(
+    apiKey: string,
+    requestOptions: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    const response = await fetch(MISTRAL_CHAT_COMPLETIONS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestOptions),
+      signal,
+    });
+
+    if (!response.ok) {
+      throw await this.toHttpError(response);
+    }
+
+    return await response.json();
+  }
+
+  private async postChatCompletionsStream(
+    apiKey: string,
+    requestOptions: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<AsyncIterable<unknown>> {
+    const response = await fetch(MISTRAL_CHAT_COMPLETIONS_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestOptions),
+      signal,
+    });
+
+    if (!response.ok) {
+      throw await this.toHttpError(response);
+    }
+
+    if (!response.body) {
+      throw new MistralHttpError('Mistral stream response was empty', {
+        status: response.status,
+      });
+    }
+
+    return this.parseSseStream(response.body);
+  }
+
+  private async *parseSseStream(
+    stream: ReadableStream<Uint8Array>,
   ): AsyncGenerator<unknown> {
-    for await (const event of stream) {
-      yield event;
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (value) {
+          buffer += decoder.decode(value, { stream: true });
+          buffer = buffer.replace(/\r\n/g, '\n');
+        }
+        if (done) {
+          buffer += decoder.decode();
+          buffer = buffer.replace(/\r\n/g, '\n');
+        }
+
+        let boundary = buffer.indexOf('\n\n');
+        while (boundary >= 0) {
+          const rawEvent = buffer.slice(0, boundary);
+          buffer = buffer.slice(boundary + 2);
+
+          const parsed = this.parseSseEvent(rawEvent);
+          if (parsed.done) return;
+          if ('value' in parsed) yield parsed.value;
+
+          boundary = buffer.indexOf('\n\n');
+        }
+
+        if (done) break;
+      }
+
+      const tail = buffer.trim();
+      if (tail.length > 0) {
+        const parsed = this.parseSseEvent(tail);
+        if (!parsed.done && 'value' in parsed) yield parsed.value;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
+  private parseSseEvent(rawEvent: string): { done: boolean; value?: unknown } {
+    const data = rawEvent
+      .split('\n')
+      .map((line) => line.trimEnd())
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).trimStart())
+      .join('\n')
+      .trim();
+
+    if (data.length === 0) return { done: false };
+    if (data === '[DONE]') return { done: true };
+
+    try {
+      return { done: false, value: JSON.parse(data) as unknown };
+    } catch {
+      throw new MistralHttpError('Mistral stream returned invalid JSON');
+    }
+  }
+
+  private async toHttpError(response: Response): Promise<MistralHttpError> {
+    const fallback = `Mistral request failed with status ${response.status}`;
+    const text = await response.text().catch(() => '');
+    const parsed = this.parseErrorPayload(text, fallback);
+
+    return new MistralHttpError(parsed.message, {
+      status: response.status,
+      ...(parsed.code ? { code: parsed.code } : {}),
+    });
+  }
+
+  private parseErrorPayload(
+    text: string,
+    fallback: string,
+  ): { message: string; code?: string } {
+    if (text.trim().length === 0) return { message: fallback };
+
+    try {
+      const payload = JSON.parse(text) as Record<string, unknown>;
+      const error = payload.error as Record<string, unknown> | undefined;
+      const rawMessage = error?.message ?? payload.message;
+      const rawCode = error?.code ?? payload.code;
+      const message = typeof rawMessage === 'string' && rawMessage
+        ? rawMessage
+        : fallback;
+      const code = typeof rawCode === 'string' && rawCode ? rawCode : undefined;
+
+      return code ? { message, code } : { message };
+    } catch {
+      return { message: text.slice(0, 500) || fallback };
     }
   }
 }

--- a/api/src/services/providers/mistral-provider.ts
+++ b/api/src/services/providers/mistral-provider.ts
@@ -50,8 +50,8 @@ class MistralHttpError extends Error {
   constructor(message: string, options: { status?: number; code?: string } = {}) {
     super(message);
     this.name = 'MistralHttpError';
-    this.status = options.status;
-    this.code = options.code;
+    if (typeof options.status === 'number') this.status = options.status;
+    if (options.code) this.code = options.code;
   }
 }
 
@@ -143,7 +143,12 @@ export class MistralProviderRuntime implements ProviderRuntime {
       throw new Error(validation.message || 'Mistral API key is not configured');
     }
 
-    return apiKeyOverride || env.MISTRAL_API_KEY;
+    const apiKey = apiKeyOverride || env.MISTRAL_API_KEY;
+    if (!apiKey) {
+      throw new Error('Mistral API key is not configured');
+    }
+
+    return apiKey;
   }
 
   private normalizeRequestOptions(

--- a/api/tests/unit/llm-runtime-stream.test.ts
+++ b/api/tests/unit/llm-runtime-stream.test.ts
@@ -41,12 +41,6 @@ vi.mock('@anthropic-ai/sdk', () => ({
   })),
 }));
 
-vi.mock('@mistralai/mistralai', () => ({
-  Mistral: vi.fn().mockImplementation(() => ({
-    chat: { complete: vi.fn(), stream: vi.fn() },
-  })),
-}));
-
 vi.mock('cohere-ai', () => ({
   CohereClient: vi.fn().mockImplementation(() => ({
     v2: { chat: vi.fn(), chatStream: vi.fn() },

--- a/api/tests/unit/mistral-provider.test.ts
+++ b/api/tests/unit/mistral-provider.test.ts
@@ -1,20 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
-// Mock the Mistral SDK before importing the provider
-const mockMistralComplete = vi.fn();
-const mockMistralStream = vi.fn();
-
-vi.mock('@mistralai/mistralai', () => {
-  class MockMistral {
-    chat = {
-      complete: mockMistralComplete,
-      stream: mockMistralStream,
-    };
-  }
-  return {
-    Mistral: MockMistral,
-  };
-});
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mock env to control API key presence
 vi.mock('../../src/config/env', () => ({
@@ -25,12 +9,45 @@ vi.mock('../../src/config/env', () => ({
 
 import { MistralProviderRuntime } from '../../src/services/providers/mistral-provider';
 
+const originalFetch = globalThis.fetch;
+const mockFetch = vi.fn();
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}) =>
+  new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+    ...init,
+  });
+
+const sseResponse = (events: unknown[]) => {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+      }
+      controller.enqueue(encoder.encode('data: [DONE]\n\n'));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+};
+
 describe('MistralProviderRuntime', () => {
   let runtime: MistralProviderRuntime;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
     runtime = new MistralProviderRuntime();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
   });
 
   describe('provider descriptor', () => {
@@ -128,10 +145,10 @@ describe('MistralProviderRuntime', () => {
       ).rejects.toThrow('unsupported mode');
     });
 
-    it('should call Mistral chat.complete', async () => {
-      mockMistralComplete.mockResolvedValue({
+    it('should call the Mistral chat completions endpoint', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({
         choices: [{ message: { content: 'Hello' } }],
-      });
+      }));
 
       const result = await runtime.generate({
         mode: 'chat-completions',
@@ -141,7 +158,15 @@ describe('MistralProviderRuntime', () => {
         },
       });
 
-      expect(mockMistralComplete).toHaveBeenCalled();
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://api.mistral.ai/v1/chat/completions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer test-mistral-key',
+          }),
+        }),
+      );
       expect(result).toEqual({ choices: [{ message: { content: 'Hello' } }] });
     });
   });
@@ -160,11 +185,7 @@ describe('MistralProviderRuntime', () => {
         { data: { choices: [{ delta: { content: ' world' }, finish_reason: 'stop' }] } },
       ];
 
-      mockMistralStream.mockResolvedValue({
-        [Symbol.asyncIterator]: async function* () {
-          for (const e of events) yield e;
-        },
-      });
+      mockFetch.mockResolvedValue(sseResponse(events));
 
       const iterable = await runtime.streamGenerate({
         mode: 'chat-completions',


### PR DESCRIPTION
Fixes the main CI blocker from npm audit by removing the compromised @mistralai/mistralai package and using Mistral's OpenAI-compatible HTTP/SSE chat completions endpoint directly.\n\nContext:\n- main CI failed before publish-llm-mesh because e2e Docker builds run npm audit --audit-level=high --omit=dev\n- npm audit now reports GHSA-3q49-cfcf-g5fm as critical malware for @mistralai/mistralai with no fix available\n- this keeps Mistral provider behavior but removes the audited package from api dependencies and lockfile