### PR TITLE
fix(ui): cancel chat returns to 'Préparation' loading state

### DIFF
--- a/ui/src/lib/components/StreamMessage.svelte
+++ b/ui/src/lib/components/StreamMessage.svelte
@@ -206,7 +206,7 @@
     };
   };
 
-  const isTerminalStatus = (s?: string) => s === 'completed' || s === 'failed' || s === 'done';
+  const isTerminalStatus = (s?: string) => s === 'completed' || s === 'failed' || s === 'done' || s === 'cancelled';
 
   // Limite d'historique: sur les cartes/jobs on veut souvent un historique court,
   // tandis que sur le chat on garde davantage d'étapes.
@@ -856,7 +856,7 @@
     hasAcknowledgement =
       typeof acknowledgementText === 'string' &&
       acknowledgementText.trim().length > 0;
-    showStartup = !!st.sawStarted && !hasSteps && !hasContent && !finalText;
+    showStartup = !!st.sawStarted && !hasSteps && !hasContent && !finalText && !isTerminalStatus(status);
     toolsCount = st.toolCallIds.size;
     const passiveHistoryShell = summarizePassiveHistoryShell(runtimeSummary);
     hasPassiveHistoryShell =


### PR DESCRIPTION
## Summary
When user cancels an in-progress chat, the UI keeps showing the 'Préparation' (stream.preparing) loading indicator instead of transitioning to a cancelled state.

## Root cause
`ui/src/lib/components/StreamMessage.svelte` :
- L209 isTerminalStatus did not include 'cancelled'
- L859 showStartup did not gate on terminal status

Backend correctly sets status='cancelled' (packages/chat-core/src/runtime-messages.ts:118). Bug pre-existed since 2026-03-30 commit a6c6b11b. Discovered during BR-14b UAT 2026-05-16.

## Fix (2 lines)
- Add 'cancelled' to terminal status list
- Add `!isTerminalStatus(status)` to showStartup computation

## Test plan
- [x] make typecheck-ui passes
- [x] make lint-ui passes
- [ ] CI all green
- [ ] Manual UAT : cancel mid-stream -> UI shows cancelled state, no 'Préparation'

Generated with Claude Code