### PR TITLE
Feature: Gemini 3.5 Flash catalog replacement

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -104,5 +104,5 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
   - [x] Review `git diff --stat` and scope boundaries.
   - [x] Run targeted verification commands.
   - [x] Commit runtime/docs alignment with `make commit MSG="test: align gemini flash runtime coverage"`.
-  - [ ] Push branch before UAT.
-  - [ ] Hand off UAT instructions to the user.
+  - [x] Push branch before UAT.
+  - [x] Hand off UAT instructions to the user.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,109 @@
+# Feature: Gemini 3.5 Flash catalog replacement
+
+## Objective
+Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a global roadmap branch number.
+
+## Scope / Guardrails
+- Scope limited to model catalog metadata, model-selection tests, chat context budget metadata, and matching specs.
+- No database migration.
+- Make-only workflow for build, quality, tests, and commits.
+- Root workspace `/home/antoinefa/src/sentropic` is reserved for user dev/UAT and must remain stable.
+- Branch development happens in isolated worktree `tmp/fix-gemini-35-flash`.
+- Automated test campaigns run on `ENV=test-fix-gemini-35-flash`, never on `ENV=dev`.
+- In every `make` command, `ENV=test-fix-gemini-35-flash` must be passed as the last argument when the target accepts an environment.
+- All new text in English.
+
+## Branch Scope Boundaries (MANDATORY)
+- **Allowed Paths (implementation scope)**:
+  - `BRANCH.md`
+  - `packages/llm-mesh/src/catalog.ts`
+  - `packages/llm-mesh/src/providers.ts`
+  - `packages/llm-mesh/tests/facade.test.ts`
+  - `api/src/services/chat-service.ts`
+  - `api/src/services/model-selection-legacy.ts`
+  - `api/tests/api/*.test.ts`
+  - `api/tests/unit/*.test.ts`
+  - `ui/tests/**/*.test.ts`
+  - `packages/chat-core/tests/**/*.test.ts`
+  - `spec/SPEC_CHATBOT.md`
+  - `spec/SPEC_EVOL_LLM_MESH.md`
+- **Forbidden Paths (must not change in this branch)**:
+  - `Makefile`
+  - `docker-compose*.yml`
+  - `.cursor/rules/**`
+  - `PLAN.md`
+  - `plan/NN-BRANCH_*.md`
+  - `plan/done/**`
+- **Conditional Paths (allowed only with explicit exception when not already listed in Allowed Paths)**:
+  - `api/drizzle/*.sql`
+  - `.github/workflows/**`
+- **Exception process**:
+  - Declare exception ID `QG35-EXn` in `## Feedback Loop` before touching any conditional or forbidden path.
+  - Include reason, impact, and rollback strategy.
+
+## Feedback Loop
+- [ ] No active blocker.
+
+## AI Flaky tests
+- [ ] No AI flaky test accepted.
+
+## Orchestration Mode (AI-selected)
+- [x] **Mono-branch + cherry-pick** (default for orthogonal tasks; single final test cycle)
+- [ ] **Multi-branch** (only if sub-workstreams require independent CI or long-running validation)
+- Rationale: Single catalog replacement with tightly scoped tests and no independent sub-workstreams.
+
+## UAT Management (in orchestration context)
+- **Mono-branch**: UAT is performed on the integrated branch only.
+- UAT checkpoints are listed inside Lot N-2.
+- Execution flow:
+  - [x] Develop and run tests in `tmp/fix-gemini-35-flash`.
+  - [ ] Push branch before UAT.
+  - [ ] Run user UAT from root workspace on the pushed branch or deployment target selected by the user.
+  - [ ] Switch back to `tmp/fix-gemini-35-flash` after UAT.
+
+## Plan / Todo (lot-based)
+- [ ] **Lot 0 — Baseline & constraints**
+  - [x] Read `rules/MASTER.md`.
+  - [x] Read `rules/workflow.md`.
+  - [x] Read `README.md`, `TODO.md`, and `PLAN.md`.
+  - [x] Create isolated worktree `tmp/fix-gemini-35-flash`.
+  - [x] Confirm branch is `fix/gemini-35-flash`.
+  - [x] Copy root `.env` into the worktree.
+  - [x] Capture Makefile targets needed for debug/testing.
+  - [x] Define environment mapping: `ENV=test-fix-gemini-35-flash`; UAT ports if needed: API `8795`, UI `5185`, Maildev UI `1085`.
+  - [x] Confirm command style: `make ... ENV=test-fix-gemini-35-flash` with `ENV` last.
+  - [x] Confirm scope boundaries.
+
+- [ ] **Lot 1 — Replace Gemini Pro catalog entry**
+  - [ ] Add failing tests that expect Gemini catalog to expose `gemini-3.5-flash` and no longer expose `gemini-3.1-pro-preview-customtools`.
+  - [ ] Replace the llm-mesh Gemini Pro profile with Gemini 3.5 Flash.
+  - [ ] Update chat-service context budget metadata for the new model id.
+  - [ ] Add a legacy cutover from `gemini-3.1-pro-preview-customtools` to `gemini-3.5-flash`.
+  - [ ] Update API/UI/package tests that reference the replaced Gemini model.
+  - [ ] Update specs that document the active Gemini catalog.
+  - [ ] Lot gate:
+    - [ ] Red test observed before implementation.
+    - [ ] `make test-llm-mesh ENV=test-fix-gemini-35-flash`
+    - [ ] `make test-api-unit SCOPE=tests/unit/model-selection-legacy.test.ts ENV=test-fix-gemini-35-flash`
+    - [ ] `make test-api-endpoints SCOPE=tests/api/models.test.ts ENV=test-fix-gemini-35-flash`
+    - [ ] `make test-api-endpoints SCOPE=tests/api/me.test.ts ENV=test-fix-gemini-35-flash`
+    - [ ] `make test-ui SCOPE=tests/utils/user-ai-settings-events.test.ts ENV=test-fix-gemini-35-flash`
+    - [ ] `make typecheck-llm-mesh ENV=test-fix-gemini-35-flash`
+    - [ ] `make typecheck-api ENV=test-fix-gemini-35-flash`
+    - [ ] `make lint-api ENV=test-fix-gemini-35-flash`
+
+- [ ] **Lot N-2 — UAT**
+  - [ ] Web app settings: model selector shows `Gemini 3.5 Flash` under Gemini.
+  - [ ] Web app settings: model selector does not show `Gemini 3.1 Pro`.
+  - [ ] Chat model picker shows `Gemini 3.5 Flash` and can save it as the user default.
+  - [ ] Existing Gemini Flash Lite remains available.
+
+- [ ] **Lot N-1 — Docs consolidation**
+  - [ ] Update existing specs only; no temporary branch spec required.
+
+- [ ] **Lot N — Final validation**
+  - [ ] Review `git diff --stat` and scope boundaries.
+  - [ ] Run targeted verification commands.
+  - [ ] Commit with `make commit MSG="fix: replace gemini pro with flash"`.
+  - [ ] Push branch before UAT.
+  - [ ] Hand off UAT instructions to the user.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -57,7 +57,7 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
 - UAT checkpoints are listed inside Lot N-2.
 - Execution flow:
   - [x] Develop and run tests in `tmp/fix-gemini-35-flash`.
-  - [ ] Push branch before UAT.
+  - [x] Push branch before UAT.
   - [ ] Run user UAT from root workspace on the pushed branch or deployment target selected by the user.
   - [ ] Switch back to `tmp/fix-gemini-35-flash` after UAT.
 

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -74,19 +74,19 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
   - [x] Confirm command style: `make ... ENV=test-fix-gemini-35-flash` with `ENV` last.
   - [x] Confirm scope boundaries.
 
-- [ ] **Lot 1 — Replace Gemini Pro catalog entry**
+- [x] **Lot 1 — Replace Gemini Pro catalog entry**
   - [x] Add failing tests that expect Gemini catalog to expose `gemini-3.5-flash` and no longer expose `gemini-3.1-pro-preview-customtools`.
   - [x] Replace the llm-mesh Gemini Pro profile with Gemini 3.5 Flash.
   - [x] Update chat-service context budget metadata for the new model id.
   - [x] Add a legacy cutover from `gemini-3.1-pro-preview-customtools` to `gemini-3.5-flash`.
-  - [ ] Update API/UI/package tests that reference the replaced Gemini model.
-  - [ ] Update specs that document the active Gemini catalog.
-  - [ ] Lot gate:
+  - [x] Update API/UI/package tests that reference the replaced Gemini model.
+  - [x] Update specs that document the active Gemini catalog.
+  - [x] Lot gate:
     - [x] Red test observed before implementation: `make test-llm-mesh ENV=test-fix-gemini-35-flash` failed on missing `gemini-3.5-flash` catalog profile.
     - [x] `make test-llm-mesh ENV=test-fix-gemini-35-flash`
-    - [ ] `make test-api-unit SCOPE="tests/unit/model-selection-legacy.test.ts tests/unit/gemini-tool-handoff.test.ts tests/unit/llm-runtime-stream.test.ts tests/unit/chat-service-tools.test.ts" API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
+    - [x] `make test-api-unit SCOPE="tests/unit/model-selection-legacy.test.ts tests/unit/gemini-tool-handoff.test.ts tests/unit/llm-runtime-stream.test.ts tests/unit/chat-service-tools.test.ts" API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
     - [x] `make test-api-endpoints SCOPE="tests/api/models.test.ts tests/api/me.test.ts" API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
-    - [ ] `make test-ui SCOPE=tests/utils/user-ai-settings-events.test.ts API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
+    - [x] `make test-ui SCOPE=tests/utils/user-ai-settings-events.test.ts API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
     - [x] `make typecheck-llm-mesh ENV=test-fix-gemini-35-flash`
     - [x] `make typecheck-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
     - [x] `make lint-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
@@ -97,12 +97,12 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
   - [ ] Chat model picker shows `Gemini 3.5 Flash` and can save it as the user default.
   - [ ] Existing Gemini Flash Lite remains available.
 
-- [ ] **Lot N-1 — Docs consolidation**
-  - [ ] Update existing specs only; no temporary branch spec required.
+- [x] **Lot N-1 — Docs consolidation**
+  - [x] Update existing specs only; no temporary branch spec required.
 
 - [ ] **Lot N — Final validation**
-  - [ ] Review `git diff --stat` and scope boundaries.
-  - [ ] Run targeted verification commands.
-  - [ ] Commit with `make commit MSG="fix: replace gemini pro with flash"`.
+  - [x] Review `git diff --stat` and scope boundaries.
+  - [x] Run targeted verification commands.
+  - [x] Commit runtime/docs alignment with `make commit MSG="test: align gemini flash runtime coverage"`.
   - [ ] Push branch before UAT.
   - [ ] Hand off UAT instructions to the user.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -75,22 +75,21 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
   - [x] Confirm scope boundaries.
 
 - [ ] **Lot 1 — Replace Gemini Pro catalog entry**
-  - [ ] Add failing tests that expect Gemini catalog to expose `gemini-3.5-flash` and no longer expose `gemini-3.1-pro-preview-customtools`.
-  - [ ] Replace the llm-mesh Gemini Pro profile with Gemini 3.5 Flash.
-  - [ ] Update chat-service context budget metadata for the new model id.
-  - [ ] Add a legacy cutover from `gemini-3.1-pro-preview-customtools` to `gemini-3.5-flash`.
+  - [x] Add failing tests that expect Gemini catalog to expose `gemini-3.5-flash` and no longer expose `gemini-3.1-pro-preview-customtools`.
+  - [x] Replace the llm-mesh Gemini Pro profile with Gemini 3.5 Flash.
+  - [x] Update chat-service context budget metadata for the new model id.
+  - [x] Add a legacy cutover from `gemini-3.1-pro-preview-customtools` to `gemini-3.5-flash`.
   - [ ] Update API/UI/package tests that reference the replaced Gemini model.
   - [ ] Update specs that document the active Gemini catalog.
   - [ ] Lot gate:
-    - [ ] Red test observed before implementation.
-    - [ ] `make test-llm-mesh ENV=test-fix-gemini-35-flash`
-    - [ ] `make test-api-unit SCOPE=tests/unit/model-selection-legacy.test.ts ENV=test-fix-gemini-35-flash`
-    - [ ] `make test-api-endpoints SCOPE=tests/api/models.test.ts ENV=test-fix-gemini-35-flash`
-    - [ ] `make test-api-endpoints SCOPE=tests/api/me.test.ts ENV=test-fix-gemini-35-flash`
-    - [ ] `make test-ui SCOPE=tests/utils/user-ai-settings-events.test.ts ENV=test-fix-gemini-35-flash`
-    - [ ] `make typecheck-llm-mesh ENV=test-fix-gemini-35-flash`
-    - [ ] `make typecheck-api ENV=test-fix-gemini-35-flash`
-    - [ ] `make lint-api ENV=test-fix-gemini-35-flash`
+    - [x] Red test observed before implementation: `make test-llm-mesh ENV=test-fix-gemini-35-flash` failed on missing `gemini-3.5-flash` catalog profile.
+    - [x] `make test-llm-mesh ENV=test-fix-gemini-35-flash`
+    - [ ] `make test-api-unit SCOPE="tests/unit/model-selection-legacy.test.ts tests/unit/gemini-tool-handoff.test.ts tests/unit/llm-runtime-stream.test.ts tests/unit/chat-service-tools.test.ts" API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
+    - [x] `make test-api-endpoints SCOPE="tests/api/models.test.ts tests/api/me.test.ts" API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
+    - [ ] `make test-ui SCOPE=tests/utils/user-ai-settings-events.test.ts API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
+    - [x] `make typecheck-llm-mesh ENV=test-fix-gemini-35-flash`
+    - [x] `make typecheck-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
+    - [x] `make lint-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
 
 - [ ] **Lot N-2 — UAT**
   - [ ] Web app settings: model selector shows `Gemini 3.5 Flash` under Gemini.

--- a/api/src/services/chat-service.ts
+++ b/api/src/services/chat-service.ts
@@ -564,8 +564,8 @@ const MODEL_CONTEXT_BUDGETS: Record<string, number> = {
   'gpt-4.1':       1_000_000,
   'gpt-4.1-nano':  1_000_000,
   // Gemini
-  'gemini-3.1-pro-preview-customtools': 1_000_000,
-  'gemini-3.1-flash-lite-preview':      1_000_000,
+  'gemini-3.5-flash':              1_000_000,
+  'gemini-3.1-flash-lite-preview':  1_000_000,
   // Anthropic
   'claude-sonnet-4-6': 1_000_000,
   'claude-opus-4-7':   1_000_000,

--- a/api/src/services/model-selection-legacy.ts
+++ b/api/src/services/model-selection-legacy.ts
@@ -17,6 +17,11 @@ const LEGACY_MODEL_CUTOVER_RULES: LegacyModelCutoverRule[] = [
     fromModelId: 'gemini-2.5-flash-lite',
     toModelId: 'gemini-3.1-flash-lite-preview',
   },
+  {
+    providerId: 'gemini',
+    fromModelId: 'gemini-3.1-pro-preview-customtools',
+    toModelId: 'gemini-3.5-flash',
+  },
 ];
 
 const LEGACY_MODEL_CUTOVER_BY_MODEL = new Map(

--- a/api/tests/api/me.test.ts
+++ b/api/tests/api/me.test.ts
@@ -49,13 +49,13 @@ describe('Me API', () => {
       'PUT',
       '/api/v1/me/ai-settings',
       user.sessionToken!,
-      { defaultModel: 'gemini-3.1-pro-preview-customtools' }
+      { defaultModel: 'gemini-3.5-flash' }
     );
     expect(update.status).toBe(200);
     const updateData = await update.json();
     expect(updateData.settings.defaultProviderId).toBe('gemini');
     expect(updateData.settings.defaultModel).toBe(
-      'gemini-3.1-pro-preview-customtools'
+      'gemini-3.5-flash'
     );
 
     const rows = await db
@@ -68,7 +68,7 @@ describe('Me API', () => {
         )
       );
     expect(rows).toHaveLength(1);
-    expect(rows[0].value).toBe('gemini-3.1-pro-preview-customtools');
+    expect(rows[0].value).toBe('gemini-3.5-flash');
 
     const anotherUser = await createAuthenticatedUser('editor');
     const anotherSettings = await authenticatedRequest(
@@ -124,6 +124,27 @@ describe('Me API', () => {
     const geminiData = await geminiResponse.json();
     expect(geminiData.defaultProviderId).toBe('gemini');
     expect(geminiData.defaultModel).toBe('gemini-3.1-flash-lite-preview');
+
+    await settingsService.set('default_provider_id', 'gemini', 'legacy provider', {
+      userId: user.id,
+    });
+    await settingsService.set(
+      'default_model',
+      'gemini-3.1-pro-preview-customtools',
+      'legacy model',
+      { userId: user.id }
+    );
+
+    const geminiProResponse = await authenticatedRequest(
+      app,
+      'GET',
+      '/api/v1/me/ai-settings',
+      user.sessionToken!
+    );
+    expect(geminiProResponse.status).toBe(200);
+    const geminiProData = await geminiProResponse.json();
+    expect(geminiProData.defaultProviderId).toBe('gemini');
+    expect(geminiProData.defaultModel).toBe('gemini-3.5-flash');
   });
 
   it('should delete user workspace data on DELETE /me', async () => {

--- a/api/tests/api/models.test.ts
+++ b/api/tests/api/models.test.ts
@@ -45,7 +45,7 @@ describe('Models API', () => {
         .sort();
 
     expect(modelsByProvider('openai')).toEqual(['gpt-4.1-nano', 'gpt-5.4-nano', 'gpt-5.5']);
-    expect(modelsByProvider('gemini')).toEqual(['gemini-3.1-flash-lite-preview', 'gemini-3.1-pro-preview-customtools']);
+    expect(modelsByProvider('gemini')).toEqual(['gemini-3.1-flash-lite-preview', 'gemini-3.5-flash']);
     expect(modelsByProvider('anthropic')).toEqual(['claude-opus-4-7', 'claude-sonnet-4-6']);
     expect(modelsByProvider('mistral')).toEqual(['magistral-medium-2509', 'mistral-small-2603']);
     expect(modelsByProvider('cohere')).toEqual(['command-a-03-2025', 'command-a-reasoning-08-2025']);
@@ -85,6 +85,29 @@ describe('Models API', () => {
     const data = await response.json();
     expect(data.defaults.provider_id).toBe('gemini');
     expect(data.defaults.model_id).toBe('gemini-3.1-flash-lite-preview');
+  });
+
+  it('migrates legacy Gemini Pro defaults to Gemini 3.5 Flash', async () => {
+    const updateResponse = await authenticatedRequest(
+      app,
+      'PUT',
+      '/api/v1/me/ai-settings',
+      user.sessionToken!,
+      { defaultModel: 'gemini-3.1-pro-preview-customtools' }
+    );
+    expect(updateResponse.status).toBe(200);
+
+    const response = await authenticatedRequest(
+      app,
+      'GET',
+      '/api/v1/models/catalog',
+      user.sessionToken!
+    );
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.defaults.provider_id).toBe('gemini');
+    expect(data.defaults.model_id).toBe('gemini-3.5-flash');
   });
 
   it('migrates legacy OpenAI defaults when user overrides with gpt-5.2', async () => {

--- a/api/tests/unit/chat-service-tools.test.ts
+++ b/api/tests/unit/chat-service-tools.test.ts
@@ -506,7 +506,7 @@ it('should evaluate reasoning effort with gemini-3.1-flash-lite-preview when pro
       primaryContextType: 'folder',
       primaryContextId: folderId,
       providerId: 'gemini',
-      model: 'gemini-3.1-pro-preview-customtools'
+      model: 'gemini-3.5-flash'
     });
 
     await chatService.runAssistantGeneration({
@@ -521,7 +521,7 @@ it('should evaluate reasoning effort with gemini-3.1-flash-lite-preview when pro
     expect(calls[0]?.providerId).toBe('gemini');
     expect(calls[0]?.model).toBe('gemini-3.1-flash-lite-preview');
     expect(calls[1]?.providerId).toBe('gemini');
-    expect(calls[1]?.model).toBe('gemini-3.1-pro-preview-customtools');
+    expect(calls[1]?.model).toBe('gemini-3.5-flash');
 
     const events = await db
       .select()

--- a/api/tests/unit/gemini-tool-handoff.test.ts
+++ b/api/tests/unit/gemini-tool-handoff.test.ts
@@ -5,7 +5,7 @@ import { buildGeminiRequestBody } from '../../src/services/llm-runtime';
 describe('buildGeminiRequestBody', () => {
   it('does not request Gemini thoughts when reasoning is not requested', () => {
     const body = buildGeminiRequestBody({
-      model: 'gemini-3.1-pro-preview-customtools',
+      model: 'gemini-3.5-flash',
       messages: [{ role: 'user', content: 'Say OK' }],
     }) as Record<string, unknown>;
 
@@ -14,7 +14,7 @@ describe('buildGeminiRequestBody', () => {
 
   it('requests Gemini thoughts when reasoning is requested', () => {
     const body = buildGeminiRequestBody({
-      model: 'gemini-3.1-pro-preview-customtools',
+      model: 'gemini-3.5-flash',
       messages: [{ role: 'user', content: 'Analyze deeply' }],
       reasoningEffort: 'high',
     }) as {
@@ -34,7 +34,7 @@ describe('buildGeminiRequestBody', () => {
 
   it('preserves assistant history content without provider-specific rewriting', () => {
     const body = buildGeminiRequestBody({
-      model: 'gemini-3.1-pro-preview-customtools',
+      model: 'gemini-3.5-flash',
       messages: [
         {
           role: 'assistant',

--- a/api/tests/unit/llm-runtime-stream.test.ts
+++ b/api/tests/unit/llm-runtime-stream.test.ts
@@ -750,12 +750,12 @@ const STREAM_TEST_MATRIX: StreamTestConfig[] = [
   },
 
   // -----------------------------------------------------------------------
-  // Gemini — Pro Preview (reasoning model)
+  // Gemini — 3.5 Flash (reasoning model)
   // -----------------------------------------------------------------------
   {
     providerId: 'gemini',
-    model: 'gemini-3.1-pro-preview-customtools',
-    label: 'Gemini Pro Preview',
+    model: 'gemini-3.5-flash',
+    label: 'Gemini 3.5 Flash',
     chatEvents: [
       { candidates: [{ content: { parts: [{ text: 'Hello' }] } }] },
       { candidates: [{ content: { parts: [{ text: ' world' }] } }] },
@@ -1040,9 +1040,9 @@ describe('LLM stream event normalization', () => {
   });
 
   // -------------------------------------------------------------------------
-  // Gemini Pro Preview: status + content (original test combined both)
+  // Gemini 3.5 Flash: status + content (original test combined both)
   // -------------------------------------------------------------------------
-  it('should emit status and content for Gemini Pro Preview', async () => {
+  it('should emit status and content for Gemini 3.5 Flash', async () => {
     const { providerRegistry } = await import('../../src/services/provider-registry');
     const provider = providerRegistry.requireProvider('gemini');
     vi.spyOn(provider, 'streamGenerate').mockResolvedValue(
@@ -1062,7 +1062,7 @@ describe('LLM stream event normalization', () => {
       callLLMStream({
         messages: [{ role: 'user', content: 'Think about this' }],
         providerId: 'gemini',
-        model: 'gemini-3.1-pro-preview-customtools',
+        model: 'gemini-3.5-flash',
       }),
     );
 
@@ -1102,7 +1102,7 @@ describe('LLM stream event normalization', () => {
       callLLMStream({
         messages: [{ role: 'user', content: 'Answer' }],
         providerId: 'gemini',
-        model: 'gemini-3.1-pro-preview-customtools',
+        model: 'gemini-3.5-flash',
       }),
     );
 

--- a/api/tests/unit/model-selection-legacy.test.ts
+++ b/api/tests/unit/model-selection-legacy.test.ts
@@ -43,6 +43,25 @@ describe('model selection legacy cutovers', () => {
     });
   });
 
+  it('maps gemini-3.1-pro-preview-customtools to gemini-3.5-flash', () => {
+    expect(findLegacyModelCutoverRule('gemini-3.1-pro-preview-customtools')).toEqual({
+      providerId: 'gemini',
+      fromModelId: 'gemini-3.1-pro-preview-customtools',
+      toModelId: 'gemini-3.5-flash',
+    });
+
+    expect(
+      normalizeLegacyModelSelection({
+        providerId: 'gemini',
+        modelId: 'gemini-3.1-pro-preview-customtools',
+      })
+    ).toEqual({
+      providerId: 'gemini',
+      modelId: 'gemini-3.5-flash',
+      migrated: true,
+    });
+  });
+
   it('leaves non-legacy ids unchanged', () => {
     expect(
       normalizeLegacyModelSelection({

--- a/packages/llm-mesh/src/catalog.ts
+++ b/packages/llm-mesh/src/catalog.ts
@@ -243,8 +243,8 @@ export const modelProfiles = [
   },
   {
     providerId: 'gemini',
-    modelId: 'gemini-3.1-pro-preview-customtools',
-    label: 'Gemini 3.1 Pro',
+    modelId: 'gemini-3.5-flash',
+    label: 'Gemini 3.5 Flash',
     reasoningTier: 'advanced',
     defaultTaskHints: ['chat', 'structured', 'summary'],
     capabilities: modelCapabilities('gemini', 'advanced'),

--- a/packages/llm-mesh/src/providers.ts
+++ b/packages/llm-mesh/src/providers.ts
@@ -14,7 +14,7 @@ export const knownModelIds = [
   'gpt-5.5',
   'gpt-5.4-nano',
   'gpt-4.1-nano',
-  'gemini-3.1-pro-preview-customtools',
+  'gemini-3.5-flash',
   'gemini-3.1-flash-lite-preview',
   'claude-sonnet-4-6',
   'claude-opus-4-7',
@@ -32,7 +32,7 @@ export type QualifiedModelId = `${ProviderId}:${string}`;
 
 export const knownModelIdsByProvider = {
   openai: ['gpt-5.5', 'gpt-5.4-nano', 'gpt-4.1-nano'],
-  gemini: ['gemini-3.1-pro-preview-customtools', 'gemini-3.1-flash-lite-preview'],
+  gemini: ['gemini-3.5-flash', 'gemini-3.1-flash-lite-preview'],
   anthropic: ['claude-sonnet-4-6', 'claude-opus-4-7'],
   mistral: ['mistral-small-2603', 'magistral-medium-2509'],
   cohere: ['command-a-03-2025', 'command-a-reasoning-08-2025'],

--- a/packages/llm-mesh/tests/facade.test.ts
+++ b/packages/llm-mesh/tests/facade.test.ts
@@ -70,8 +70,8 @@ describe('createLlmMesh', () => {
   it('supports explicit provider/model selection pairs', async () => {
     const model = {
       providerId: 'gemini' as const,
-      modelId: 'gemini-3.1-pro-preview-customtools',
-      label: 'Gemini 3.1 Pro',
+      modelId: 'gemini-3.5-flash',
+      label: 'Gemini 3.5 Flash',
       reasoningTier: 'advanced' as const,
       defaultTaskHints: ['chat'] as const,
       capabilities: {
@@ -82,9 +82,9 @@ describe('createLlmMesh', () => {
     const adapter = buildAdapter(model);
     const mesh = createLlmMesh({ registry: createProviderRegistry([adapter]) });
 
-    await mesh.generate({ providerId: 'gemini', modelId: 'gemini-3.1-pro-preview-customtools', messages: userMessage, auth: { type: 'environment-token', envVar: 'GEMINI_API_KEY' } });
+    await mesh.generate({ providerId: 'gemini', modelId: 'gemini-3.5-flash', messages: userMessage, auth: { type: 'environment-token', envVar: 'GEMINI_API_KEY' } });
 
-    expect(adapter.generate).toHaveBeenCalledWith(expect.objectContaining({ providerId: 'gemini', modelId: 'gemini-3.1-pro-preview-customtools' }), expect.anything());
+    expect(adapter.generate).toHaveBeenCalledWith(expect.objectContaining({ providerId: 'gemini', modelId: 'gemini-3.5-flash' }), expect.anything());
   });
 
   it('fails early when the selected model does not support requested tools', async () => {
@@ -117,11 +117,11 @@ describe('createLlmMesh', () => {
 
   it('does not mark reasoning catalog models as unsupported', () => {
     const cohereReasoning = getModelProfile('cohere', 'command-a-reasoning-08-2025');
-    const geminiPro = getModelProfile('gemini', 'gemini-3.1-pro-preview-customtools');
+    const geminiFlash = getModelProfile('gemini', 'gemini-3.5-flash');
 
     expect(cohereReasoning?.reasoningTier).toBe('advanced');
     expect(cohereReasoning?.capabilities.reasoning.support).not.toBe('unsupported');
-    expect(geminiPro?.reasoningTier).toBe('advanced');
-    expect(geminiPro?.capabilities.reasoning.support).not.toBe('unsupported');
+    expect(geminiFlash?.reasoningTier).toBe('advanced');
+    expect(geminiFlash?.capabilities.reasoning.support).not.toBe('unsupported');
   });
 });

--- a/plan/done/HOTFIX-BRANCH_fix-gemini-35-flash.md
+++ b/plan/done/HOTFIX-BRANCH_fix-gemini-35-flash.md
@@ -42,10 +42,10 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
   - Include reason, impact, and rollback strategy.
 
 ## Feedback Loop
-- [ ] No active blocker.
+- [x] No active blocker.
 
 ## AI Flaky tests
-- [ ] No AI flaky test accepted.
+- [x] No AI flaky test accepted.
 
 ## Orchestration Mode (AI-selected)
 - [x] **Mono-branch + cherry-pick** (default for orthogonal tasks; single final test cycle)
@@ -58,11 +58,11 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
 - Execution flow:
   - [x] Develop and run tests in `tmp/fix-gemini-35-flash`.
   - [x] Push branch before UAT.
-  - [ ] Run user UAT from root workspace on the pushed branch or deployment target selected by the user.
-  - [ ] Switch back to `tmp/fix-gemini-35-flash` after UAT.
+  - [x] Run user UAT from root workspace on `uat/gemini-35-flash`.
+  - [x] Switch root back to `main` and continue finalization in `tmp/fix-gemini-35-flash` after UAT.
 
 ## Plan / Todo (lot-based)
-- [ ] **Lot 0 — Baseline & constraints**
+- [x] **Lot 0 — Baseline & constraints**
   - [x] Read `rules/MASTER.md`.
   - [x] Read `rules/workflow.md`.
   - [x] Read `README.md`, `TODO.md`, and `PLAN.md`.
@@ -91,18 +91,19 @@ Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a 
     - [x] `make typecheck-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
     - [x] `make lint-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
 
-- [ ] **Lot N-2 — UAT**
-  - [ ] Web app settings: model selector shows `Gemini 3.5 Flash` under Gemini.
-  - [ ] Web app settings: model selector does not show `Gemini 3.1 Pro`.
-  - [ ] Chat model picker shows `Gemini 3.5 Flash` and can save it as the user default.
-  - [ ] Existing Gemini Flash Lite remains available.
+- [x] **Lot N-2 — UAT**
+  - [x] Web app settings: model selector shows `Gemini 3.5 Flash` under Gemini.
+  - [x] Web app settings: model selector does not show `Gemini 3.1 Pro`.
+  - [x] Chat model picker shows `Gemini 3.5 Flash` and can save it as the user default.
+  - [x] Existing Gemini Flash Lite remains available.
 
 - [x] **Lot N-1 — Docs consolidation**
   - [x] Update existing specs only; no temporary branch spec required.
 
-- [ ] **Lot N — Final validation**
+- [x] **Lot N — Final validation**
   - [x] Review `git diff --stat` and scope boundaries.
   - [x] Run targeted verification commands.
   - [x] Commit runtime/docs alignment with `make commit MSG="test: align gemini flash runtime coverage"`.
   - [x] Push branch before UAT.
   - [x] Hand off UAT instructions to the user.
+  - [x] Move completed branch plan to `plan/done/HOTFIX-BRANCH_fix-gemini-35-flash.md`.

--- a/spec/SPEC_CHATBOT.md
+++ b/spec/SPEC_CHATBOT.md
@@ -164,7 +164,7 @@ BR-14c adds the permanent runtime boundary for model access:
   - `/folder/new` can override model per run without mutating user defaults.
 - **5 active providers** with centralized model catalog (labels served from backend):
   - **OpenAI**: GPT-5.4, GPT-4.1, GPT-4.1 Nano.
-  - **Gemini**: Gemini 3.1 Pro Preview, Gemini 3.1 Flash Lite Preview.
+  - **Gemini**: Gemini 3.5 Flash, Gemini 3.1 Flash Lite Preview.
   - **Anthropic Claude**: Sonnet 4.6, Opus 4.6 — extended thinking (thinking budget_tokens), 1M token context.
   - **Mistral**: Devstral 2, Magistral Medium — Magistral supports reasoning via thinking chunks.
   - **Cohere**: Command A, Command A Reasoning — thinking blocks in `content-delta` stream (field `thinking` vs `text`), `tool-plan-delta` for reasoning with tools.
@@ -176,7 +176,7 @@ BR-14c adds the permanent runtime boundary for model access:
   - provider-specific tool call ID formats are normalized at the adapter layer.
 - Per-model context budgets:
   - Claude (Sonnet/Opus) and GPT-5.4: 1M tokens,
-  - Gemini Pro: 1M tokens,
+  - Gemini 3.5 Flash: 1M tokens,
   - Devstral 2 and Cohere Command A/A R.: 256k tokens,
   - Magistral Medium: 128k tokens,
   - GPT-4.1 / GPT-4.1 Nano and Gemini Flash Lite: default budget.

--- a/spec/SPEC_EVOL_LLM_MESH.md
+++ b/spec/SPEC_EVOL_LLM_MESH.md
@@ -93,7 +93,7 @@ Coverage invariant:
 | OpenAI `gpt-5.4` | Responses output text, reasoning text / reasoning summary events, function-call argument deltas. | `content_delta`, `reasoning_delta`, `tool_call_start`, `tool_call_delta`, `status.response_created`, `done`. | `llm-runtime-stream` matrix content/tool/reasoning row. |
 | OpenAI `gpt-5.4-nano` | Same Responses family as GPT-5.4 with standard reasoning tier. | Same normalized contract as GPT-5.4, with model-specific capability tier. | `llm-runtime-stream` matrix content/tool/reasoning row. |
 | Gemini `gemini-3.1-flash-lite-preview` | Generate Content `parts[].text`, `parts[].thought`, `parts[].functionCall`. | text without `thought` -> `content_delta`; `thought: true` -> `reasoning_delta`; `functionCall` -> `tool_call_start`. | `gemini-tool-handoff` request-body tests; `llm-runtime-stream` matrix content/tool/reasoning row. |
-| Gemini `gemini-3.1-pro-preview-customtools` | Same Generate Content shape; reasoning is requested through `thinkingConfig.includeThoughts: true` when app reasoning is requested. | Same Gemini normalized contract; thoughts are visible only through `reasoning_delta`, not assistant content. | `gemini-tool-handoff` includeThoughts test; `llm-runtime-stream` matrix content/tool/reasoning row and thought-routing test. |
+| Gemini `gemini-3.5-flash` | Same Generate Content shape; reasoning is requested through `thinkingConfig.includeThoughts: true` when app reasoning is requested. | Same Gemini normalized contract; thoughts are visible only through `reasoning_delta`, not assistant content. | `gemini-tool-handoff` includeThoughts test; `llm-runtime-stream` matrix content/tool/reasoning row and thought-routing test. |
 | Anthropic `claude-sonnet-4-6` | Messages stream `text_delta`, `thinking_delta`, `tool_use`, `input_json_delta`. | `content_delta`, `reasoning_delta`, `tool_call_start`, `tool_call_delta`. | `llm-runtime-stream` matrix content/tool/reasoning row. |
 | Anthropic `claude-opus-4-6` | Same Claude stream shape with advanced reasoning tier. | Same normalized contract as Sonnet, with advanced tier. | `llm-runtime-stream` matrix content/tool/reasoning row. |
 | Mistral `mistral-small-2603` | Chat stream text deltas, typed thinking/text content arrays, OpenAI-like tool call deltas. | `content_delta`, `reasoning_delta`, `tool_call_start`, `tool_call_delta`. | `llm-runtime-stream` matrix content/tool/reasoning row. |
@@ -674,9 +674,9 @@ google.supportsReasoning = true;
 Better public contract:
 
 ```ts
-gemini31Pro.capabilities.tools.support = 'supported';
-gemini31Pro.capabilities.tools.parallelCalls = 'supported';
-gemini31Pro.capabilities.tools.streamedArgumentDeltas = 'supported';
+gemini35Flash.capabilities.tools.support = 'supported';
+gemini35Flash.capabilities.tools.parallelCalls = 'supported';
+gemini35Flash.capabilities.tools.streamedArgumentDeltas = 'supported';
 geminiFlashLegacy.capabilities.tools.streamedArgumentDeltas = 'unknown';
 claudeSonnet.capabilities.structuredOutput.jsonSchema = 'partial';
 cohereCommand.capabilities.reasoning = 'unsupported';

--- a/ui/tests/utils/user-ai-settings-events.test.ts
+++ b/ui/tests/utils/user-ai-settings-events.test.ts
@@ -19,14 +19,14 @@ describe('user ai settings events', () => {
 
     emitUserAISettingsUpdated({
       defaultProviderId: 'gemini',
-      defaultModel: 'gemini-3.1-pro-preview-customtools',
+      defaultModel: 'gemini-3.5-flash',
     });
 
     window.removeEventListener(USER_AI_SETTINGS_UPDATED_EVENT, handler);
 
     expect(capturedDetail).toEqual({
       defaultProviderId: 'gemini',
-      defaultModel: 'gemini-3.1-pro-preview-customtools',
+      defaultModel: 'gemini-3.5-flash',
     });
     expect(capturedType).toBe(USER_AI_SETTINGS_UPDATED_EVENT);
     expect(capturedIsCustomEvent).toBe(true);
@@ -49,7 +49,7 @@ describe('user ai settings events', () => {
     });
     emitUserAISettingsUpdated({
       defaultProviderId: 'gemini',
-      defaultModel: 'gemini-3.1-pro-preview-customtools',
+      defaultModel: 'gemini-3.5-flash',
     });
 
     window.removeEventListener(USER_AI_SETTINGS_UPDATED_EVENT, handler);
@@ -58,7 +58,7 @@ describe('user ai settings events', () => {
       { defaultProviderId: 'openai', defaultModel: 'gpt-5.5' },
       {
         defaultProviderId: 'gemini',
-        defaultModel: 'gemini-3.1-pro-preview-customtools',
+        defaultModel: 'gemini-3.5-flash',
       },
     ]);
   });


### PR DESCRIPTION
# Feature: Gemini 3.5 Flash catalog replacement

## Objective
Replace the Gemini 3.1 Pro catalog entry with Gemini 3.5 Flash without adding a global roadmap branch number.

## Scope / Guardrails
- Scope limited to model catalog metadata, model-selection tests, chat context budget metadata, and matching specs.
- No database migration.
- Make-only workflow for build, quality, tests, and commits.
- Root workspace `/home/antoinefa/src/sentropic` is reserved for user dev/UAT and must remain stable.
- Branch development happens in isolated worktree `tmp/fix-gemini-35-flash`.
- Automated test campaigns run on `ENV=test-fix-gemini-35-flash`, never on `ENV=dev`.
- In every `make` command, `ENV=test-fix-gemini-35-flash` must be passed as the last argument when the target accepts an environment.
- All new text in English.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths (implementation scope)**:
  - `BRANCH.md`
  - `packages/llm-mesh/src/catalog.ts`
  - `packages/llm-mesh/src/providers.ts`
  - `packages/llm-mesh/tests/facade.test.ts`
  - `api/src/services/chat-service.ts`
  - `api/src/services/model-selection-legacy.ts`
  - `api/tests/api/*.test.ts`
  - `api/tests/unit/*.test.ts`
  - `ui/tests/**/*.test.ts`
  - `packages/chat-core/tests/**/*.test.ts`
  - `spec/SPEC_CHATBOT.md`
  - `spec/SPEC_EVOL_LLM_MESH.md`
- **Forbidden Paths (must not change in this branch)**:
  - `Makefile`
  - `docker-compose*.yml`
  - `.cursor/rules/**`
  - `PLAN.md`
  - `plan/NN-BRANCH_*.md`
  - `plan/done/**`
- **Conditional Paths (allowed only with explicit exception when not already listed in Allowed Paths)**:
  - `api/drizzle/*.sql`
  - `.github/workflows/**`
- **Exception process**:
  - Declare exception ID `QG35-EXn` in `## Feedback Loop` before touching any conditional or forbidden path.
  - Include reason, impact, and rollback strategy.

## Feedback Loop
- [x] No active blocker.

## AI Flaky tests
- [x] No AI flaky test accepted.

## Orchestration Mode (AI-selected)
- [x] **Mono-branch + cherry-pick** (default for orthogonal tasks; single final test cycle)
- [ ] **Multi-branch** (only if sub-workstreams require independent CI or long-running validation)
- Rationale: Single catalog replacement with tightly scoped tests and no independent sub-workstreams.

## UAT Management (in orchestration context)
- **Mono-branch**: UAT is performed on the integrated branch only.
- UAT checkpoints are listed inside Lot N-2.
- Execution flow:
  - [x] Develop and run tests in `tmp/fix-gemini-35-flash`.
  - [x] Push branch before UAT.
  - [x] Run user UAT from root workspace on `uat/gemini-35-flash`.
  - [x] Switch root back to `main` and continue finalization in `tmp/fix-gemini-35-flash` after UAT.

## Plan / Todo (lot-based)
- [x] **Lot 0 — Baseline & constraints**
  - [x] Read `rules/MASTER.md`.
  - [x] Read `rules/workflow.md`.
  - [x] Read `README.md`, `TODO.md`, and `PLAN.md`.
  - [x] Create isolated worktree `tmp/fix-gemini-35-flash`.
  - [x] Confirm branch is `fix/gemini-35-flash`.
  - [x] Copy root `.env` into the worktree.
  - [x] Capture Makefile targets needed for debug/testing.
  - [x] Define environment mapping: `ENV=test-fix-gemini-35-flash`; UAT ports if needed: API `8795`, UI `5185`, Maildev UI `1085`.
  - [x] Confirm command style: `make ... ENV=test-fix-gemini-35-flash` with `ENV` last.
  - [x] Confirm scope boundaries.

- [x] **Lot 1 — Replace Gemini Pro catalog entry**
  - [x] Add failing tests that expect Gemini catalog to expose `gemini-3.5-flash` and no longer expose `gemini-3.1-pro-preview-customtools`.
  - [x] Replace the llm-mesh Gemini Pro profile with Gemini 3.5 Flash.
  - [x] Update chat-service context budget metadata for the new model id.
  - [x] Add a legacy cutover from `gemini-3.1-pro-preview-customtools` to `gemini-3.5-flash`.
  - [x] Update API/UI/package tests that reference the replaced Gemini model.
  - [x] Update specs that document the active Gemini catalog.
  - [x] Lot gate:
    - [x] Red test observed before implementation: `make test-llm-mesh ENV=test-fix-gemini-35-flash` failed on missing `gemini-3.5-flash` catalog profile.
    - [x] `make test-llm-mesh ENV=test-fix-gemini-35-flash`
    - [x] `make test-api-unit SCOPE="tests/unit/model-selection-legacy.test.ts tests/unit/gemini-tool-handoff.test.ts tests/unit/llm-runtime-stream.test.ts tests/unit/chat-service-tools.test.ts" API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
    - [x] `make test-api-endpoints SCOPE="tests/api/models.test.ts tests/api/me.test.ts" API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
    - [x] `make test-ui SCOPE=tests/utils/user-ai-settings-events.test.ts API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
    - [x] `make typecheck-llm-mesh ENV=test-fix-gemini-35-flash`
    - [x] `make typecheck-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`
    - [x] `make lint-api API_PORT=8795 UI_PORT=5185 MAILDEV_UI_PORT=1085 ENV=test-fix-gemini-35-flash`

- [x] **Lot N-2 — UAT**
  - [x] Web app settings: model selector shows `Gemini 3.5 Flash` under Gemini.
  - [x] Web app settings: model selector does not show `Gemini 3.1 Pro`.
  - [x] Chat model picker shows `Gemini 3.5 Flash` and can save it as the user default.
  - [x] Existing Gemini Flash Lite remains available.

- [x] **Lot N-1 — Docs consolidation**
  - [x] Update existing specs only; no temporary branch spec required.

- [x] **Lot N — Final validation**
  - [x] Review `git diff --stat` and scope boundaries.
  - [x] Run targeted verification commands.
  - [x] Commit runtime/docs alignment with `make commit MSG="test: align gemini flash runtime coverage"`.
  - [x] Push branch before UAT.
  - [x] Hand off UAT instructions to the user.
  - [x] Move completed branch plan to `plan/done/HOTFIX-BRANCH_fix-gemini-35-flash.md`.
