### PR TITLE
feat: xlsx/gsheet multi-sheet indexing (rebased on main)

### DIFF
--- a/api/src/services/document-text.ts
+++ b/api/src/services/document-text.ts
@@ -1,7 +1,10 @@
 /**
  * Text extraction helpers for document summarization.
- * MVP requirement: support pdf, docx, pptx, md.
+ * MVP requirement: support pdf, docx, pptx, xlsx, md.
  */
+import JSZip from 'jszip';
+import { DOMParser } from '@xmldom/xmldom';
+
 type ExtractedDocumentMetadata = {
   title?: string;
   author?: string;
@@ -41,6 +44,194 @@ function countWords(text: string): number {
   const t = (text || '').trim();
   if (!t) return 0;
   return t.split(/\s+/g).filter(Boolean).length;
+}
+
+const XLSX_MIME_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+
+function isXlsxDocument(mimeType: string, fileName: string): boolean {
+  return mimeType === XLSX_MIME_TYPE || fileName.endsWith('.xlsx');
+}
+
+type XmlNodeListLike = {
+  length: number;
+  item(index: number): XmlElementLike | null;
+};
+
+type XmlElementLike = {
+  getAttribute?(name: string): string | null;
+  getElementsByTagName?(tagName: string): XmlNodeListLike;
+  textContent?: string | null;
+};
+
+function parseXml(xml: string): XmlElementLike {
+  return new DOMParser().parseFromString(xml, 'application/xml') as unknown as XmlElementLike;
+}
+
+function xmlElements(parent: XmlElementLike | null | undefined, tagName: string): XmlElementLike[] {
+  const nodes = parent?.getElementsByTagName?.(tagName);
+  if (!nodes || typeof nodes.length !== 'number') return [];
+  const out: XmlElementLike[] = [];
+  for (let i = 0; i < nodes.length; i += 1) {
+    const node = nodes.item(i);
+    if (node) out.push(node);
+  }
+  return out;
+}
+
+function xmlAttribute(node: XmlElementLike | null | undefined, name: string): string | null {
+  const value = node?.getAttribute?.(name);
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function xmlText(node: XmlElementLike | null | undefined): string {
+  const value = node?.textContent;
+  return typeof value === 'string' ? value : '';
+}
+
+function normalizeCellText(value: string): string {
+  return value.replace(/[\t\r\n]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeZipPath(input: string): string {
+  const parts: string[] = [];
+  for (const part of input.replace(/^\/+/, '').split('/')) {
+    if (!part || part === '.') continue;
+    if (part === '..') parts.pop();
+    else parts.push(part);
+  }
+  return parts.join('/');
+}
+
+function resolveWorkbookTarget(target: string): string {
+  if (target.startsWith('/')) return normalizeZipPath(target);
+  if (target.startsWith('xl/')) return normalizeZipPath(target);
+  return normalizeZipPath(`xl/${target}`);
+}
+
+function columnIndexFromReference(reference: string | null): number | null {
+  if (!reference) return null;
+  const letters = reference.match(/^[A-Z]+/i)?.[0]?.toUpperCase();
+  if (!letters) return null;
+  let index = 0;
+  for (const ch of letters) {
+    index = index * 26 + (ch.charCodeAt(0) - 64);
+  }
+  return index > 0 ? index - 1 : null;
+}
+
+async function readZipText(zip: JSZip, path: string): Promise<string | null> {
+  const file = zip.file(path);
+  return file ? file.async('text') : null;
+}
+
+function readSharedStrings(xml: string | null): string[] {
+  if (!xml) return [];
+  const doc = parseXml(xml);
+  return xmlElements(doc, 'si').map((si) =>
+    xmlElements(si, 't')
+      .map((node) => xmlText(node))
+      .join(''),
+  );
+}
+
+function readWorkbookSheets(workbookXml: string | null, relationshipsXml: string | null): Array<{
+  name: string;
+  path: string;
+}> {
+  if (!workbookXml) return [];
+  const rels = new Map<string, string>();
+  if (relationshipsXml) {
+    for (const rel of xmlElements(parseXml(relationshipsXml), 'Relationship')) {
+      const id = xmlAttribute(rel, 'Id');
+      const target = xmlAttribute(rel, 'Target');
+      if (id && target) rels.set(id, resolveWorkbookTarget(target));
+    }
+  }
+
+  return xmlElements(parseXml(workbookXml), 'sheet')
+    .map((sheet) => {
+      const name = xmlAttribute(sheet, 'name') ?? 'Sheet';
+      const relationshipId = xmlAttribute(sheet, 'r:id');
+      const path = relationshipId ? rels.get(relationshipId) : null;
+      return path ? { name, path } : null;
+    })
+    .filter((sheet): sheet is { name: string; path: string } => Boolean(sheet));
+}
+
+function readCellValue(cell: XmlElementLike, sharedStrings: string[]): string {
+  const type = xmlAttribute(cell, 't');
+
+  if (type === 'inlineStr') {
+    return normalizeCellText(
+      xmlElements(cell, 't')
+        .map((node) => xmlText(node))
+        .join(''),
+    );
+  }
+
+  const raw = normalizeCellText(xmlText(xmlElements(cell, 'v')[0]));
+  if (!raw) return '';
+  if (type === 's') {
+    const index = Number.parseInt(raw, 10);
+    return Number.isFinite(index) ? normalizeCellText(sharedStrings[index] ?? raw) : raw;
+  }
+  if (type === 'b') return raw === '1' ? 'TRUE' : 'FALSE';
+  return raw;
+}
+
+function extractWorksheetRows(xml: string, sharedStrings: string[]): string[][] {
+  const rows: string[][] = [];
+  for (const row of xmlElements(parseXml(xml), 'row')) {
+    const values: string[] = [];
+    let nextColumnIndex = 0;
+    for (const cell of xmlElements(row, 'c')) {
+      const explicitColumnIndex = columnIndexFromReference(xmlAttribute(cell, 'r'));
+      const columnIndex = explicitColumnIndex ?? nextColumnIndex;
+      while (values.length < columnIndex) values.push('');
+      values[columnIndex] = readCellValue(cell, sharedStrings);
+      nextColumnIndex = columnIndex + 1;
+    }
+    while (values.length > 0 && !values[values.length - 1]) values.pop();
+    if (values.some((value) => value.trim().length > 0)) rows.push(values);
+  }
+  return rows;
+}
+
+async function extractXlsxDocumentInfo(params: {
+  bytes: Uint8Array;
+  filename?: string | null;
+}): Promise<ExtractedDocumentInfo> {
+  const zip = await JSZip.loadAsync(Buffer.from(params.bytes));
+  const workbookXml = await readZipText(zip, 'xl/workbook.xml');
+  const relationshipsXml = await readZipText(zip, 'xl/_rels/workbook.xml.rels');
+  const sharedStrings = readSharedStrings(await readZipText(zip, 'xl/sharedStrings.xml'));
+  const workbookSheets = readWorkbookSheets(workbookXml, relationshipsXml);
+  const sheets =
+    workbookSheets.length > 0
+      ? workbookSheets
+      : Object.keys(zip.files)
+          .filter((path) => /^xl\/worksheets\/[^/]+\.xml$/i.test(path))
+          .sort()
+          .map((path, index) => ({ name: `Sheet ${index + 1}`, path }));
+
+  const sections: string[] = [];
+  const headingsH1: string[] = [];
+  for (const sheet of sheets) {
+    const worksheetXml = await readZipText(zip, sheet.path);
+    if (!worksheetXml) continue;
+    const rows = extractWorksheetRows(worksheetXml, sharedStrings);
+    if (rows.length === 0) continue;
+    headingsH1.push(sheet.name);
+    sections.push([`Sheet: ${sheet.name}`, ...rows.map((row) => row.join('\t'))].join('\n'));
+  }
+
+  const text = sections.join('\n\n').trim();
+  const metadata: ExtractedDocumentMetadata = {};
+  const title = params.filename?.trim();
+  if (title) metadata.title = title;
+  const words = countWords(text);
+  if (words > 0) metadata.words = words;
+  return { text, metadata, headingsH1 };
 }
 
 function extractHeadingsH1FromAst(ast: unknown): string[] {
@@ -117,6 +308,10 @@ export async function extractDocumentInfoFromDocument(params: {
   const isMarkdown = mime === 'text/markdown' || name.endsWith('.md') || name.endsWith('.markdown');
   const isTextLike = mime.startsWith('text/') || mime.includes('json') || isMarkdown;
 
+  if (isXlsxDocument(mime, name)) {
+    return extractXlsxDocumentInfo(params);
+  }
+
   if (isTextLike) {
     const text = new TextDecoder('utf-8', { fatal: false }).decode(params.bytes);
     const metadata: ExtractedDocumentMetadata = {};
@@ -189,5 +384,3 @@ export async function extractTextFromDocument(params: {
   const { text } = await extractDocumentInfoFromDocument(params);
   return text;
 }
-
-

--- a/api/src/services/google-drive-client.ts
+++ b/api/src/services/google-drive-client.ts
@@ -87,7 +87,8 @@ const extensionByExportMimeType: Record<string, string> = {
 
 const ingestExportMimeTypeBySourceMimeType: Record<GoogleWorkspaceMimeType, string> = {
   [GOOGLE_WORKSPACE_MIME_TYPES.document]: 'text/markdown',
-  [GOOGLE_WORKSPACE_MIME_TYPES.spreadsheet]: 'text/csv',
+  [GOOGLE_WORKSPACE_MIME_TYPES.spreadsheet]:
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   [GOOGLE_WORKSPACE_MIME_TYPES.presentation]: 'text/plain',
 };
 

--- a/api/tests/unit/document-text.test.ts
+++ b/api/tests/unit/document-text.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+import JSZip from 'jszip';
+import { extractDocumentInfoFromDocument } from '../../src/services/document-text';
+
+async function createWorkbookBytes(): Promise<Uint8Array> {
+  const zip = new JSZip();
+  zip.file(
+    '[Content_Types].xml',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/worksheets/sheet2.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+</Types>`,
+  );
+  zip.file(
+    '_rels/.rels',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    'xl/workbook.xml',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+    <sheet name="Budget" sheetId="1" r:id="rId1"/>
+    <sheet name="Roadmap" sheetId="2" r:id="rId2"/>
+  </sheets>
+</workbook>`,
+  );
+  zip.file(
+    'xl/_rels/workbook.xml.rels',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet2.xml"/>
+</Relationships>`,
+  );
+  zip.file(
+    'xl/sharedStrings.xml',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <si><t>Department</t></si>
+  <si><t>Q1</t></si>
+  <si><t>Q2</t></si>
+  <si><t>Support</t></si>
+  <si><t>Sales</t></si>
+  <si><t>Milestone</t></si>
+  <si><t>Owner</t></si>
+  <si><t>Launch</t></si>
+  <si><t>Alice</t></si>
+</sst>`,
+  );
+  zip.file(
+    'xl/worksheets/sheet1.xml',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c></row>
+    <row r="2"><c r="A2" t="s"><v>3</v></c><c r="B2"><v>120</v></c><c r="C2"><v>150</v></c></row>
+    <row r="3"><c r="A3" t="s"><v>4</v></c><c r="B3"><v>200</v></c><c r="C3"><v>225</v></c></row>
+  </sheetData>
+</worksheet>`,
+  );
+  zip.file(
+    'xl/worksheets/sheet2.xml',
+    `<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>5</v></c><c r="B1" t="s"><v>6</v></c></row>
+    <row r="2"><c r="A2" t="s"><v>7</v></c><c r="B2" t="s"><v>8</v></c></row>
+  </sheetData>
+</worksheet>`,
+  );
+  return new Uint8Array(await zip.generateAsync({ type: 'uint8array' }));
+}
+
+describe('document text extraction', () => {
+  it('extracts readable text from every XLSX worksheet', async () => {
+    const extracted = await extractDocumentInfoFromDocument({
+      bytes: await createWorkbookBytes(),
+      filename: 'planning.xlsx',
+      mimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    });
+
+    expect(extracted.text).toContain('Sheet: Budget');
+    expect(extracted.text).toContain('Department\tQ1\tQ2');
+    expect(extracted.text).toContain('Support\t120\t150');
+    expect(extracted.text).toContain('Sheet: Roadmap');
+    expect(extracted.text).toContain('Milestone\tOwner');
+    expect(extracted.text).toContain('Launch\tAlice');
+    expect(extracted.metadata.title).toBe('planning.xlsx');
+    expect(extracted.metadata.words).toBeGreaterThan(5);
+  });
+});

--- a/api/tests/unit/google-drive-client.test.ts
+++ b/api/tests/unit/google-drive-client.test.ts
@@ -51,12 +51,12 @@ describe('google drive client', () => {
     expect((init?.headers as Record<string, string>).Authorization).toBe('Bearer access-token');
   });
 
-  it('maps Google Workspace MIME types to text export formats', () => {
+  it('maps Google Workspace MIME types to ingest and download export formats', () => {
     expect(pickGoogleDriveExportMimeType(GOOGLE_WORKSPACE_MIME_TYPES.document)).toBe(
       'text/markdown',
     );
     expect(pickGoogleDriveExportMimeType(GOOGLE_WORKSPACE_MIME_TYPES.spreadsheet)).toBe(
-      'text/csv',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
     );
     expect(pickGoogleDriveExportMimeType(GOOGLE_WORKSPACE_MIME_TYPES.presentation)).toBe(
       'text/plain',
@@ -114,6 +114,49 @@ describe('google drive client', () => {
     expect(content.mimeType).toBe('text/markdown');
     expect(content.exportMimeType).toBe('text/markdown');
     expect(new TextDecoder().decode(content.bytes)).toContain('Milestone');
+  });
+
+  it('exports Google Sheets to XLSX for ingestion so all worksheets can be indexed', async () => {
+    const fetchImpl = vi.fn(async () =>
+      new Response(new Uint8Array([80, 75, 3, 4]), {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        },
+      }),
+    );
+
+    const content = await loadGoogleDriveFileContent({
+      accessToken: 'access-token',
+      file: {
+        id: 'sheet_1',
+        name: 'Pipeline',
+        mimeType: GOOGLE_WORKSPACE_MIME_TYPES.spreadsheet,
+        webViewLink: null,
+        webContentLink: null,
+        iconLink: null,
+        modifiedTime: null,
+        version: null,
+        size: null,
+        md5Checksum: null,
+        trashed: false,
+        driveId: null,
+      },
+      fetchImpl,
+    });
+
+    const [url] = fetchImpl.mock.calls[0];
+    expect(String(url)).toContain('/drive/v3/files/sheet_1/export?');
+    expect(String(url)).toContain(
+      'mimeType=application%2Fvnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    expect(content.fileName).toBe('Pipeline.xlsx');
+    expect(content.mimeType).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    expect(content.exportMimeType).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
   });
 
   it('exports native Google Workspace files to Office formats for user downloads', async () => {

--- a/ui/src/lib/utils/documents.ts
+++ b/ui/src/lib/utils/documents.ts
@@ -3,7 +3,7 @@ import { getApiAuthToken, getApiBaseUrl } from '$lib/core/api-client';
 
 export type DocumentContextType = 'organization' | 'folder' | 'initiative' | 'chat_session';
 export const DOCUMENT_UPLOAD_ACCEPT =
-  'application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/markdown,text/plain,application/json,.zip,.tar.gz,.tgz,application/zip,application/x-zip-compressed,application/gzip,application/x-gzip,application/x-tar,application/tar';
+  'application/pdf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/markdown,text/plain,application/json,.xlsx,.zip,.tar.gz,.tgz,application/zip,application/x-zip-compressed,application/gzip,application/x-gzip,application/x-tar,application/tar';
 
 function getUrlBaseForBrowser(): string {
   // In production Docker UI build, API_BASE_URL is typically "/api/v1" (relative)
@@ -51,6 +51,7 @@ const GOOGLE_WORKSPACE_MIME_LABELS: Record<string, string> = {
   'application/vnd.google-apps.document': 'Google Docs',
   'application/vnd.google-apps.spreadsheet': 'Google Sheets',
   'application/vnd.google-apps.presentation': 'Google Slides',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'Excel workbook',
 };
 
 export function getDocumentMimeLabel(mimeType: string): string {

--- a/ui/tests/utils/documents.test.ts
+++ b/ui/tests/utils/documents.test.ts
@@ -17,6 +17,10 @@ describe('documents utils', () => {
   });
 
   it('includes archive formats in upload accept list', () => {
+    expect(DOCUMENT_UPLOAD_ACCEPT).toContain(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    );
+    expect(DOCUMENT_UPLOAD_ACCEPT).toContain('.xlsx');
     expect(DOCUMENT_UPLOAD_ACCEPT).toContain('.zip');
     expect(DOCUMENT_UPLOAD_ACCEPT).toContain('.tar.gz');
     expect(DOCUMENT_UPLOAD_ACCEPT).toContain('.tgz');
@@ -26,6 +30,7 @@ describe('documents utils', () => {
     expect(getDocumentMimeLabel('application/vnd.google-apps.document')).toBe('Google Docs');
     expect(getDocumentMimeLabel('application/vnd.google-apps.spreadsheet')).toBe('Google Sheets');
     expect(getDocumentMimeLabel('application/vnd.google-apps.presentation')).toBe('Google Slides');
+    expect(getDocumentMimeLabel('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet')).toBe('Excel workbook');
     expect(getDocumentMimeLabel('application/pdf')).toBe('application/pdf');
   });
 


### PR DESCRIPTION
## Summary
Rebases the multi-sheet (multi-tab) spreadsheet indexing change from the stale `feat/xlsx-gsheet-indexing` branch (which was 310 commits behind `main`) onto current `main`. Only the indexing change is brought over — no unrelated drift.

This is the prerequisite for BR-40b (query-tool sheet awareness), which stacks on top once this lands on `main`.

## What changed (6 files, +350/-7)
- `api/src/services/document-text.ts` — multi-sheet XLSX text extraction (JSZip + @xmldom/xmldom): each worksheet preserved and labelled `Sheet: <name>`, tab-separated rows, sheet names added to `headingsH1[]`. Wired into `extractDocumentInfoFromDocument` via mime/extension detection (`spreadsheetml.sheet` / `.xlsx`).
- `api/src/services/google-drive-client.ts` — Google Sheets ingest export switched from `text/csv` to `xlsx` so all worksheets are preserved during ingestion (download export was already xlsx).
- `ui/src/lib/utils/documents.ts` — added xlsx mime + `.xlsx` to the upload accept list and an "Excel workbook" mime label.
- Tests: `api/tests/unit/document-text.test.ts` (new, multi-sheet extraction), `api/tests/unit/google-drive-client.test.ts` (gsheet→xlsx export), `ui/tests/utils/documents.test.ts` (accept list + label).

`jszip` and `@xmldom/xmldom` are already dependencies on `main`; no package.json changes needed.

## Rebase / conflict notes
- Cherry-picked the single feature commit `ae01ee18`; the source branch's other two commits only touched its own `BRANCH.md`.
- The only cherry-pick conflict was `BRANCH.md` (deleted on `main`, modified in the commit) — intentionally dropped. All 6 code/test files applied cleanly with no semantic conflicts.

## Gate results (ENV=test-feat-xlsx-indexing-rebased, slot 3 ports 9203/5403/1303)
- `make typecheck-api` — PASS (0 errors)
- `make lint-api` — PASS (0 errors; 178 pre-existing `no-console` warnings, none in touched files)
- `make typecheck-ui` — PASS (0 errors, 6 unrelated warnings)
- `make lint-ui` — PASS (clean)
- `document-text.test.ts` — 1/1 PASS
- `google-drive-client.test.ts` — 8/8 PASS
- `documents.test.ts` (UI) — 11/11 PASS

## Do NOT
This PR is opened for the conductor to merge. Sub-agent does not merge.