### PR TITLE
fix(ci): bump Playwright to ^1.60.0 to fix recurring build-e2e hang

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,65 @@
+# Fix: bump Playwright to ^1.60.0 to fix recurring `build-e2e` hang
+
+## Objective
+Unblock CI by bumping `@playwright/test` from `^1.55.1` (resolved 1.58.1) to `^1.60.0`
+so the e2e Docker image build no longer hangs on the Playwright browser/CDN step
+that has started failing intermittently against the older client.
+
+## Scope / Guardrails
+- Scope limited to `e2e/package.json`, `e2e/package-lock.json`, and `Makefile` (new `lock-e2e` target).
+- Make-only workflow, no direct Docker commands on host.
+- Root workspace is reserved for user dev/UAT (`ENV=dev`) and must remain stable.
+- Branch development happens in worktree `tmp/fix-playwright-bump`.
+- No service stack started by this branch (lock regen + CI only).
+
+## Branch Scope Boundaries (MANDATORY)
+- **Allowed Paths (implementation scope)**:
+  - `e2e/package.json`
+  - `e2e/package-lock.json`
+  - `BRANCH.md`
+- **Forbidden Paths (must not change in this branch)**:
+  - `docker-compose*.yml`
+  - `.cursor/rules/**`
+  - `api/**`, `ui/**`, `packages/**`
+  - `plan/NN-BRANCH_*.md` (except this branch file)
+- **Conditional Paths (allowed only with explicit `FIX-PWB-EXn` exception)**:
+  - `Makefile`
+  - `.github/workflows/**`
+- **Exception process**:
+  - `FIX-PWB-EX1` — `Makefile`: add `lock-e2e` target (mirror of `lock-root`) so e2e lock can be regenerated through `make` without bypassing the make-only rule. Risk: minimal (new target, no change to existing); rollback: revert the added block.
+
+## Feedback Loop
+- `FIX-PWB-EX1` `acknowledge` — `Makefile` `lock-e2e` target added, rationale above.
+
+## AI Flaky tests
+- Not applicable: no AI tests modified.
+
+## Orchestration Mode (AI-selected)
+- [x] **Mono-branch + cherry-pick** (single-file capability fix).
+- [ ] Multi-branch
+- Rationale: 3-file orthogonal fix.
+
+## UAT Management
+- Not applicable: no user-facing change.
+
+## Plan / Todo (lot-based)
+- [x] **Lot 0 — Baseline & constraints**
+  - [x] Read `rules/MASTER.md`, `rules/workflow.md`, `rules/testing.md`.
+  - [x] Worktree `tmp/fix-playwright-bump` created from `origin/main` (HEAD `a817aed8`).
+  - [x] Confirm scope and `FIX-PWB-EX1` exception for `Makefile`.
+
+- [x] **Lot 1 — Add `make lock-e2e` target**
+  - [x] Add `.PHONY: lock-e2e` target in `Makefile` after `lock-root`, mirroring its pattern.
+  - [x] Uses `node:24-slim` (matches `e2e/Dockerfile` base) with `--legacy-peer-deps --package-lock-only --ignore-scripts`.
+
+- [x] **Lot 2 — Bump Playwright to `^1.60.0`**
+  - [x] Edit `e2e/package.json` `devDependencies."@playwright/test"`: `^1.55.1` -> `^1.60.0`.
+  - [x] Run `make lock-e2e` to regenerate `e2e/package-lock.json`.
+  - [x] Verify lock: `@playwright/test 1.60.0` and `playwright-core 1.60.0`.
+
+- [ ] **Lot N-2 — CI gate**
+  - [ ] Push branch, open PR, wait for full CI green (especially `build-e2e` no longer hangs).
+- [ ] **Lot N-1 — Docs consolidation**
+  - [ ] N/A (self-documenting Makefile target + this BRANCH.md).
+- [ ] **Lot N — Final validation & merge**
+  - [ ] Remove `BRANCH.md`, merge via merge commit (repo policy §0).

--- a/Makefile
+++ b/Makefile
@@ -431,6 +431,16 @@ lock-root: ## Update root package-lock.json using Node container (workspace root
 		node:24-alpine \
 		sh -lc "npm install --package-lock-only --workspaces --include-workspace-root"
 
+.PHONY: lock-e2e
+lock-e2e: ## Update e2e package-lock.json using Node container (no compose service)
+	@echo "🔒 Updating e2e package-lock.json..."
+	docker run --rm \
+		-u "$$(id -u):$$(id -g)" \
+		-v "$$(pwd):/workspace" \
+		-w /workspace/e2e \
+		node:24-slim \
+		sh -lc "npm install --legacy-peer-deps --package-lock-only --ignore-scripts --no-audit --no-fund"
+
 .PHONY: save-ui
 save-ui: ## Save UI Docker image as tar artifact
 	@echo "💾 Saving UI image as artifact..."

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,16 +9,17 @@
       "version": "1.55.1",
       "hasInstallScript": true,
       "devDependencies": {
-        "@playwright/test": "^1.55.1"
+        "@playwright/test": "^1.60.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
-      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -33,6 +34,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -42,12 +44,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
-      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -60,10 +63,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
-      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -10,7 +10,7 @@
     "install": "playwright install"
   },
   "devDependencies": {
-    "@playwright/test": "^1.55.1"
+    "@playwright/test": "^1.60.0"
   }
 }
 


### PR DESCRIPTION
# Fix: bump Playwright to ^1.60.0 to fix recurring `build-e2e` hang

## Objective
Unblock CI by bumping `@playwright/test` from `^1.55.1` (resolved 1.58.1) to `^1.60.0`
so the e2e Docker image build no longer hangs on the Playwright browser/CDN step
that has started failing intermittently against the older client.

## Scope / Guardrails
- Scope limited to `e2e/package.json`, `e2e/package-lock.json`, and `Makefile` (new `lock-e2e` target).
- Make-only workflow, no direct Docker commands on host.
- Root workspace is reserved for user dev/UAT (`ENV=dev`) and must remain stable.
- Branch development happens in worktree `tmp/fix-playwright-bump`.
- No service stack started by this branch (lock regen + CI only).

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths (implementation scope)**:
  - `e2e/package.json`
  - `e2e/package-lock.json`
  - `BRANCH.md`
- **Forbidden Paths (must not change in this branch)**:
  - `docker-compose*.yml`
  - `.cursor/rules/**`
  - `api/**`, `ui/**`, `packages/**`
  - `plan/NN-BRANCH_*.md` (except this branch file)
- **Conditional Paths (allowed only with explicit `FIX-PWB-EXn` exception)**:
  - `Makefile`
  - `.github/workflows/**`
- **Exception process**:
  - `FIX-PWB-EX1` — `Makefile`: add `lock-e2e` target (mirror of `lock-root`) so e2e lock can be regenerated through `make` without bypassing the make-only rule. Risk: minimal (new target, no change to existing); rollback: revert the added block.

## Feedback Loop
- `FIX-PWB-EX1` `acknowledge` — `Makefile` `lock-e2e` target added, rationale above.

## AI Flaky tests
- Not applicable: no AI tests modified.

## Orchestration Mode (AI-selected)
- [x] **Mono-branch + cherry-pick** (single-file capability fix).
- [ ] Multi-branch
- Rationale: 3-file orthogonal fix.

## UAT Management
- Not applicable: no user-facing change.

## Plan / Todo (lot-based)
- [x] **Lot 0 — Baseline & constraints**
  - [x] Read `rules/MASTER.md`, `rules/workflow.md`, `rules/testing.md`.
  - [x] Worktree `tmp/fix-playwright-bump` created from `origin/main` (HEAD `a817aed8`).
  - [x] Confirm scope and `FIX-PWB-EX1` exception for `Makefile`.

- [x] **Lot 1 — Add `make lock-e2e` target**
  - [x] Add `.PHONY: lock-e2e` target in `Makefile` after `lock-root`, mirroring its pattern.
  - [x] Uses `node:24-slim` (matches `e2e/Dockerfile` base) with `--legacy-peer-deps --package-lock-only --ignore-scripts`.

- [x] **Lot 2 — Bump Playwright to `^1.60.0`**
  - [x] Edit `e2e/package.json` `devDependencies."@playwright/test"`: `^1.55.1` -> `^1.60.0`.
  - [x] Run `make lock-e2e` to regenerate `e2e/package-lock.json`.
  - [x] Verify lock: `@playwright/test 1.60.0` and `playwright-core 1.60.0`.

- [ ] **Lot N-2 — CI gate**
  - [ ] Push branch, open PR, wait for full CI green (especially `build-e2e` no longer hangs).
- [ ] **Lot N-1 — Docs consolidation**
  - [ ] N/A (self-documenting Makefile target + this BRANCH.md).
- [ ] **Lot N — Final validation & merge**
  - [ ] Remove `BRANCH.md`, merge via merge commit (repo policy §0).