### PR TITLE
feat(chat-ui): additive ModelSelector P1 — native select + model-selection utils (v0.2.0)

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,80 @@
+# Feature: chat-ui ModelSelector P1 (additive lib export)
+
+## Objective
+Add a reusable `ModelSelector` Svelte component and `model-selection` pure-logic util to `@sentropic/chat-ui` as new additive exports. Librarizes the provider/model selector inline in `AppChatPanel.svelte` (lines 4159-4243, 5827-5849 on main). No app changes, no headless-core, no Makefile changes.
+
+## Scope / Guardrails
+- Scope limited to `packages/chat-ui/` new files and manifest/package.json additions.
+- Make-only workflow, no direct Docker commands.
+- Root workspace reserved for user dev/UAT (`ENV=dev`) — must remain stable.
+- Branch development in isolated worktree `tmp/feat-chatui-model-selector-p1`.
+- Automated test campaigns on dedicated environments, never root `dev`.
+- `ENV=<env>` as last argument in all `make` commands.
+- All new text in English.
+
+## Branch Scope Boundaries (MANDATORY)
+- **Allowed Paths (implementation scope)**:
+  - `packages/chat-ui/src/components/ModelSelector.svelte` (new)
+  - `packages/chat-ui/src/utils/model-selection.ts` (new)
+  - `packages/chat-ui/package.json` (ADD two new exports subpaths + bump version minor)
+  - `packages/chat-ui/export-manifest.json` (ADD two new subpaths — additive only)
+  - `packages/chat-ui/tests/model-selection.spec.ts` (new)
+  - `BRANCH.md`
+- **Forbidden Paths (must not change in this branch)**:
+  - `Makefile`
+  - `docker-compose*.yml`
+  - `.cursor/rules/**`
+  - `ui/src/**` (app retrofit is a separate later branch)
+  - All other packages
+- **Conditional Paths**: none required
+- **Exception process**: none needed (no conditional paths touched)
+
+## Feedback Loop
+- `deferred` (A0b-DOM): DOM/render tests for ModelSelector.svelte deferred to `feat/chatui-a0b-dom-visual-harness` (A0b jsdom harness). Component covered by typecheck for now. Owner: Wave A plan.
+
+## AI Flaky tests
+- N/A (no AI tests in this branch)
+
+## Orchestration Mode (AI-selected)
+- [x] **Mono-branch + cherry-pick** (additive lib-only; single gate cycle)
+- Rationale: single orthogonal additive task, no service stack needed.
+
+## UAT Management (in orchestration context)
+- Mono-branch: no UI UAT (lib-only additive; no app changes in this branch).
+- Gates are local `make` commands only (typecheck + build + pack + test).
+
+## Plan / Todo (lot-based)
+
+- [x] **Lot 0 — Baseline & constraints**
+  - [x] Read mandatory rules files and spec (workflow, MASTER, subagents, testing, SPEC_EVOL_CHATUI_WAVE_A §4 P1).
+  - [x] Confirm worktree on `feat/chatui-model-selector-p1` (verified: `git -C tmp/feat-chatui-model-selector-p1 branch --show-current` = feat/chatui-model-selector-p1).
+  - [x] Confirm export manifest + existing tests (A0a gates must stay green).
+  - [x] Re-validate AppChatPanel.svelte line ranges on main: parse/handler/fallback/width at lines 4159-4243; markup `<select id="chat-model-selection">` at lines 5827-5849.
+  - [x] Define scope: no dev stack needed (pure lib, node tests only).
+
+- [x] **Lot 1 — Pure logic util + component + exports + tests**
+  - [x] Write `packages/chat-ui/src/utils/model-selection.ts`: types + parse/format/group/fallback/width helpers.
+  - [x] Write `packages/chat-ui/src/components/ModelSelector.svelte`: native `<select>`, grouped `<optgroup>`, fallback, auto-width, i18n resolver, change event.
+  - [x] Write `packages/chat-ui/src/components/ModelSelector.svelte.d.ts`: props type + default export.
+  - [x] Bump `packages/chat-ui/package.json` version to `0.2.0` (minor — new feature).
+  - [x] Add two export subpaths to `packages/chat-ui/package.json` exports map.
+  - [x] Add two subpath entries to `packages/chat-ui/export-manifest.json` (additive, no existing entries touched).
+  - [x] Write `packages/chat-ui/tests/model-selection.spec.ts`: parse, group, fallback, width — node env.
+  - [x] Lot gate:
+    - [x] `make typecheck-chat-ui` — PASS
+    - [x] `make build-chat-ui` — PASS
+    - [x] `make pack-chat-ui` — PASS
+    - [x] `make test-chat-ui` — PASS (A0a export-surface + projection-golden + new model-selection tests)
+
+- [ ] **Lot N-1 — Docs consolidation**
+  - [ ] No spec EVOL file to integrate (SPEC_EVOL_CHATUI_WAVE_A.md lives in spec/ and is the Wave A master spec — do not delete).
+
+- [ ] **Lot N — Final validation**
+  - [ ] Typecheck: `make typecheck-chat-ui`
+  - [ ] Build: `make build-chat-ui`
+  - [ ] Pack: `make pack-chat-ui`
+  - [ ] Test: `make test-chat-ui`
+  - [ ] Version bumped: `packages/chat-ui/package.json` → `0.2.0` (minor, new exports added).
+  - [ ] Final gate step 1: create/update PR using `BRANCH.md` text as PR body.
+  - [ ] Final gate step 2: verify branch CI on that PR.
+  - [ ] Final gate step 3: once CI OK, commit removal of `BRANCH.md`, push, merge.

--- a/packages/chat-ui/export-manifest.json
+++ b/packages/chat-ui/export-manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Committed baseline snapshot of @sentropic/chat-ui export surface. Generated manually from package.json exports + source grep. Prop-name snapshot for Svelte components is DEFERRED to A0b (requires svelte-check / compile step — noted below). Regenerate by reading src/** exports and updating this file on any export change.",
   "_generated": "2026-06-02",
-  "_version": "0.1.1",
+  "_version": "0.2.0",
   "subpaths": {
     ".": {
       "kind": "ts",
@@ -424,6 +424,31 @@
       "file": "src/components/ChatComposer.svelte",
       "exists": true,
       "_propSnapshot": "DEFERRED to A0b — requires svelte-check/compile step to extract prop types from .svelte files; not available in node-only vitest environment"
+    },
+    "./components/ModelSelector.svelte": {
+      "kind": "svelte",
+      "file": "src/components/ModelSelector.svelte",
+      "exists": true,
+      "_propSnapshot": "DEFERRED to A0b — requires svelte-check/compile step to extract prop types from .svelte files; not available in node-only vitest environment"
+    },
+    "./utils/model-selection": {
+      "kind": "ts",
+      "file": "src/utils/model-selection.ts",
+      "exports": [
+        "ModelProviderId",
+        "ModelCatalogProvider",
+        "ModelCatalogModel",
+        "ModelCatalogGroup",
+        "ParsedModelKey",
+        "parseModelSelectionKey",
+        "formatModelSelectionKey",
+        "groupModelsByProvider",
+        "resolveFallbackModelOption",
+        "coerceSelectionToValidEntry",
+        "getSelectedModelLabel",
+        "computeModelSelectorWidthCh",
+        "providerGroupLabel"
+      ]
     }
   }
 }

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/chat-ui",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Svelte reference UI package for @sentropic/* chat sessions: stream rendering, optimistic client state, local-tool handoff, renderer registry, and host adapter contracts. Consumes @sentropic/chat-core wire contracts over HTTP/SSE only.",
   "type": "module",
   "license": "MIT",
@@ -141,6 +141,16 @@
       "types": "./src/components/ChatComposer.svelte.d.ts",
       "svelte": "./src/components/ChatComposer.svelte",
       "import": "./src/components/ChatComposer.svelte"
+    },
+    "./components/ModelSelector.svelte": {
+      "types": "./src/components/ModelSelector.svelte.d.ts",
+      "svelte": "./src/components/ModelSelector.svelte",
+      "import": "./src/components/ModelSelector.svelte"
+    },
+    "./utils/model-selection": {
+      "types": "./src/utils/model-selection.ts",
+      "svelte": "./src/utils/model-selection.ts",
+      "import": "./src/utils/model-selection.ts"
     }
   },
   "files": [

--- a/packages/chat-ui/src/components/ModelSelector.svelte
+++ b/packages/chat-ui/src/components/ModelSelector.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+  /**
+   * ModelSelector — a native <select> component for provider/model selection.
+   *
+   * Preserves native <select> semantics as specified in radar neg:chat-librarization-radar P1.
+   * Extracted from AppChatPanel.svelte (lines 4159-4243, 5827-5849 on main).
+   *
+   * Contract:
+   * - value is a 'provider::model' composite key (two-way bindable via bind:value).
+   * - groups is the pre-computed ModelCatalogGroup[] (use groupModelsByProvider()).
+   * - models is the flat ModelCatalogModel[] for fallback resolution.
+   * - widthCh is the min-width in ch units (use computeModelSelectorWidthCh()).
+   * - labels is an injected resolver (key: string) => string for all user-visible strings.
+   *   No hardcoded user-facing string is emitted — all go through labels().
+   * - onChange fires after a valid selection change with the new parsed pair.
+   */
+
+  import type { ChatUiLabelResolver } from '../hosts/createWebHost.js';
+  import type {
+    ModelCatalogGroup,
+    ModelCatalogModel,
+    ModelProviderId,
+  } from '../utils/model-selection.js';
+  import {
+    formatModelSelectionKey,
+    parseModelSelectionKey,
+    providerGroupLabel,
+    resolveFallbackModelOption,
+  } from '../utils/model-selection.js';
+
+  /** The currently-selected 'provider::model' composite key (bindable). */
+  export let value: string = '';
+
+  /** Provider-grouped model list (use groupModelsByProvider()). */
+  export let groups: ModelCatalogGroup[] = [];
+
+  /** Flat model list — used only for fallback rendering when groups is empty. */
+  export let models: ModelCatalogModel[] = [];
+
+  /** Width of the <select> element in `ch` units (use computeModelSelectorWidthCh()). */
+  export let widthCh: number = 18;
+
+  /**
+   * i18n / label resolver injected by the host.
+   * Receives a key string; returns the display string.
+   * No user-facing string is hardcoded in this component.
+   */
+  export let labels: ChatUiLabelResolver | undefined = undefined;
+
+  /**
+   * Fires after the user picks a new selection that parses successfully.
+   * Payload: { providerId, modelId }.
+   */
+  export let onChange:
+    | ((payload: { providerId: ModelProviderId; modelId: string }) => void)
+    | undefined = undefined;
+
+  // ---------------------------------------------------------------------------
+  // Derived: the currently-selected provider/model parsed from the composite key
+  // ---------------------------------------------------------------------------
+  $: parsed = parseModelSelectionKey(value);
+  $: selectedProviderId = (parsed?.providerId ?? 'openai') as ModelProviderId;
+  $: selectedModelId = parsed?.modelId ?? '';
+
+  // ---------------------------------------------------------------------------
+  // Fallback option (shown when groups is empty — catalog not yet loaded)
+  // ---------------------------------------------------------------------------
+  $: fallbackOption =
+    groups.length === 0
+      ? resolveFallbackModelOption(models, selectedProviderId, selectedModelId)
+      : null;
+
+  $: fallbackValue = fallbackOption
+    ? formatModelSelectionKey(fallbackOption.provider_id, fallbackOption.model_id)
+    : value;
+
+  $: fallbackLabel = fallbackOption?.label ?? selectedModelId;
+
+  // ---------------------------------------------------------------------------
+  // Resolved labels — all user-visible strings go through the resolver
+  // ---------------------------------------------------------------------------
+  const resolveLabel = (key: string): string => labels?.(key) ?? key;
+
+  // ---------------------------------------------------------------------------
+  // Event handler
+  // ---------------------------------------------------------------------------
+  const handleChange = (event: Event) => {
+    const target = event.currentTarget as HTMLSelectElement | null;
+    if (!target) return;
+    const next = parseModelSelectionKey(target.value);
+    if (!next) return;
+    value = target.value;
+    onChange?.(next);
+  };
+</script>
+
+<!--
+  Native <select> — preserves browser a11y (keyboard navigation, screen-reader
+  role="combobox", OS-native touch pickers). Do not replace with a custom listbox.
+-->
+<select
+  id="chat-model-selection"
+  {value}
+  on:change={handleChange}
+  class="w-auto px-2 py-0.5 text-[11px] text-slate-700 focus:outline-none"
+  style={`width:${widthCh}ch;min-width:${widthCh}ch;`}
+  aria-label={resolveLabel('chat.model.selector.label')}
+>
+  {#if groups.length === 0 && fallbackOption}
+    <!-- Catalog not yet loaded: render a single option so the select is not empty -->
+    <option value={fallbackValue}>{fallbackLabel}</option>
+  {:else}
+    {#each groups as group}
+      <optgroup label={providerGroupLabel(group.provider)}>
+        {#each group.models as modelOption}
+          <option value={formatModelSelectionKey(modelOption.provider_id, modelOption.model_id)}>
+            {modelOption.label}
+          </option>
+        {/each}
+      </optgroup>
+    {/each}
+  {/if}
+</select>

--- a/packages/chat-ui/src/components/ModelSelector.svelte.d.ts
+++ b/packages/chat-ui/src/components/ModelSelector.svelte.d.ts
@@ -1,0 +1,25 @@
+import type { Component } from 'svelte';
+import type { ChatUiLabelResolver } from '../hosts/createWebHost.js';
+import type { ModelCatalogGroup, ModelCatalogModel, ModelProviderId } from '../utils/model-selection.js';
+
+export type ModelSelectorProps = {
+  /** The currently-selected 'provider::model' composite key (two-way bindable). */
+  value?: string;
+  /** Provider-grouped model list (use groupModelsByProvider()). */
+  groups?: ModelCatalogGroup[];
+  /** Flat model list — used only for fallback rendering when groups is empty. */
+  models?: ModelCatalogModel[];
+  /** Width of the <select> element in `ch` units (use computeModelSelectorWidthCh()). */
+  widthCh?: number;
+  /** i18n / label resolver injected by the host. */
+  labels?: ChatUiLabelResolver;
+  /**
+   * Fires after the user picks a new selection that parses successfully.
+   * Payload: { providerId, modelId }.
+   */
+  onChange?: (payload: { providerId: ModelProviderId; modelId: string }) => void;
+};
+
+declare const ModelSelector: Component<ModelSelectorProps>;
+
+export default ModelSelector;

--- a/packages/chat-ui/src/utils/model-selection.ts
+++ b/packages/chat-ui/src/utils/model-selection.ts
@@ -1,0 +1,225 @@
+/**
+ * model-selection.ts — pure, framework-agnostic utilities for the model/provider selector.
+ *
+ * Extracted from AppChatPanel.svelte (lines 4159-4243, 5827-5849 on main).
+ * No Svelte imports, no browser runtime — safe for node-only vitest.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Known provider IDs. Kept as a union so callers can switch exhaustively. */
+export type ModelProviderId = 'openai' | 'gemini' | 'anthropic' | 'mistral' | 'cohere';
+
+/** Thin catalog entry for a provider (mirrors API payload shape). */
+export type ModelCatalogProvider = {
+  provider_id: ModelProviderId;
+  label: string;
+  /** 'ready' = available; 'planned' = not yet available. */
+  status: 'ready' | 'planned';
+};
+
+/** Thin catalog entry for a model (mirrors API payload shape). */
+export type ModelCatalogModel = {
+  provider_id: ModelProviderId;
+  model_id: string;
+  label: string;
+  default_contexts: string[];
+};
+
+/** Grouped view: one provider + its models, used to render `<optgroup>`. */
+export type ModelCatalogGroup = {
+  provider: ModelCatalogProvider;
+  models: ModelCatalogModel[];
+};
+
+/** Parsed result of a `'provider::model'` selection key. */
+export type ParsedModelKey = {
+  providerId: ModelProviderId;
+  modelId: string;
+};
+
+// ---------------------------------------------------------------------------
+// Known provider IDs (for parse validation)
+// ---------------------------------------------------------------------------
+
+const KNOWN_PROVIDER_IDS: ReadonlySet<string> = new Set<ModelProviderId>([
+  'openai',
+  'gemini',
+  'anthropic',
+  'mistral',
+  'cohere',
+]);
+
+// ---------------------------------------------------------------------------
+// Parse / format
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a `'provider::model'` composite key into its components.
+ *
+ * Returns `null` if the value is missing the separator, has an empty model
+ * segment, or contains an unrecognised provider id.
+ */
+export function parseModelSelectionKey(rawValue: string): ParsedModelKey | null {
+  const separatorIndex = rawValue.indexOf('::');
+  if (separatorIndex <= 0) return null;
+  const providerId = rawValue.slice(0, separatorIndex);
+  const modelId = rawValue.slice(separatorIndex + 2);
+  if (!modelId) return null;
+  if (!KNOWN_PROVIDER_IDS.has(providerId)) return null;
+  return { providerId: providerId as ModelProviderId, modelId };
+}
+
+/**
+ * Format a provider + model pair into the composite selection key used as
+ * the `<option value>` and `bind:value` target.
+ */
+export function formatModelSelectionKey(
+  providerId: ModelProviderId,
+  modelId: string,
+): string {
+  return `${providerId}::${modelId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Group a flat models list by provider, preserving the provider order from
+ * `providers`.  Groups with no models are omitted.
+ */
+export function groupModelsByProvider(
+  providers: ModelCatalogProvider[],
+  models: ModelCatalogModel[],
+): ModelCatalogGroup[] {
+  return providers
+    .map((provider) => ({
+      provider,
+      models: models.filter((m) => m.provider_id === provider.provider_id),
+    }))
+    .filter((group) => group.models.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Fallback selection
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the catalog entry that corresponds to the current
+ * `(selectedProviderId, selectedModelId)` pair.
+ *
+ * Falls back in priority order:
+ * 1. Exact provider + model match.
+ * 2. Any entry with the same model_id (provider moved / renamed).
+ * 3. `null` — caller renders a fallback `<option>`.
+ */
+export function resolveFallbackModelOption(
+  models: ModelCatalogModel[],
+  selectedProviderId: ModelProviderId,
+  selectedModelId: string,
+): ModelCatalogModel | null {
+  return (
+    models.find(
+      (m) => m.provider_id === selectedProviderId && m.model_id === selectedModelId,
+    ) ??
+    models.find((m) => m.model_id === selectedModelId) ??
+    null
+  );
+}
+
+/**
+ * Coerce `(selectedProviderId, selectedModelId)` to a valid catalog entry
+ * when the catalog has loaded and the current selection is no longer present.
+ *
+ * Priority order:
+ * 1. Exact match — no change.
+ * 2. Match on `modelId` only (provider migrated).
+ * 3. First model for the same `providerId`.
+ * 4. First model in the catalog.
+ *
+ * Returns the original pair unchanged if the catalog is empty or the exact
+ * match already exists.
+ */
+export function coerceSelectionToValidEntry(
+  models: ModelCatalogModel[],
+  selectedProviderId: ModelProviderId,
+  selectedModelId: string,
+): { providerId: ModelProviderId; modelId: string } {
+  if (models.length === 0) {
+    return { providerId: selectedProviderId, modelId: selectedModelId };
+  }
+
+  const exactMatch = models.find(
+    (m) => m.provider_id === selectedProviderId && m.model_id === selectedModelId,
+  );
+  if (exactMatch) {
+    return { providerId: selectedProviderId, modelId: selectedModelId };
+  }
+
+  const modelMatch = models.find((m) => m.model_id === selectedModelId);
+  if (modelMatch) {
+    return { providerId: modelMatch.provider_id, modelId: modelMatch.model_id };
+  }
+
+  const providerFallback =
+    models.find((m) => m.provider_id === selectedProviderId) ?? models[0];
+  return {
+    providerId: providerFallback.provider_id,
+    modelId: providerFallback.model_id,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the display label for the currently-selected model, falling back
+ * to the raw `modelId` string when the catalog is not yet loaded.
+ */
+export function getSelectedModelLabel(
+  models: ModelCatalogModel[],
+  selectedProviderId: ModelProviderId,
+  selectedModelId: string,
+): string {
+  return (
+    resolveFallbackModelOption(models, selectedProviderId, selectedModelId)?.label ??
+    selectedModelId
+  );
+}
+
+/**
+ * Compute the minimum `ch` width required so the `<select>` element is wide
+ * enough for the longest label in the catalog.
+ *
+ * Mirrors the app logic: `Math.max(longestLabelLength + 4, 18)`.
+ * The `+4` accounts for browser-rendered dropdown arrow padding.
+ */
+export function computeModelSelectorWidthCh(
+  groups: ModelCatalogGroup[],
+  models: ModelCatalogModel[],
+  selectedProviderId: ModelProviderId,
+  selectedModelId: string,
+): number {
+  const labels = groups.flatMap((g) => g.models.map((m) => m.label));
+  if (labels.length === 0) {
+    labels.push(getSelectedModelLabel(models, selectedProviderId, selectedModelId));
+  }
+  const longest = labels.reduce((max, l) => Math.max(max, l.length), 0);
+  return Math.max(longest + 4, 18);
+}
+
+/**
+ * Build the `<optgroup>` label for a provider entry.
+ *
+ * 'ready' providers show the bare label; non-ready providers append the
+ * status in parentheses.
+ */
+export function providerGroupLabel(provider: ModelCatalogProvider): string {
+  return provider.status === 'ready'
+    ? provider.label
+    : `${provider.label} (${provider.status})`;
+}

--- a/packages/chat-ui/tests/model-selection.spec.ts
+++ b/packages/chat-ui/tests/model-selection.spec.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it } from 'vitest';
+import {
+  coerceSelectionToValidEntry,
+  computeModelSelectorWidthCh,
+  formatModelSelectionKey,
+  getSelectedModelLabel,
+  groupModelsByProvider,
+  parseModelSelectionKey,
+  providerGroupLabel,
+  resolveFallbackModelOption,
+  type ModelCatalogModel,
+  type ModelCatalogProvider,
+} from '../src/utils/model-selection.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROVIDERS: ModelCatalogProvider[] = [
+  { provider_id: 'openai', label: 'OpenAI', status: 'ready' },
+  { provider_id: 'anthropic', label: 'Anthropic', status: 'ready' },
+  { provider_id: 'gemini', label: 'Gemini', status: 'planned' },
+];
+
+const MODELS: ModelCatalogModel[] = [
+  { provider_id: 'openai', model_id: 'gpt-4.1-nano', label: 'GPT-4.1 Nano', default_contexts: [] },
+  { provider_id: 'openai', model_id: 'gpt-4o', label: 'GPT-4o', default_contexts: [] },
+  { provider_id: 'anthropic', model_id: 'claude-opus-4', label: 'Claude Opus 4', default_contexts: [] },
+  { provider_id: 'gemini', model_id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', default_contexts: [] },
+];
+
+// ---------------------------------------------------------------------------
+// parseModelSelectionKey
+// ---------------------------------------------------------------------------
+
+describe('parseModelSelectionKey', () => {
+  it('should parse a valid provider::model key', () => {
+    expect(parseModelSelectionKey('openai::gpt-4o')).toEqual({
+      providerId: 'openai',
+      modelId: 'gpt-4o',
+    });
+  });
+
+  it('should parse all known providers', () => {
+    const providers = ['openai', 'gemini', 'anthropic', 'mistral', 'cohere'] as const;
+    for (const p of providers) {
+      expect(parseModelSelectionKey(`${p}::some-model`)?.providerId).toBe(p);
+    }
+  });
+
+  it('should return null when separator is missing', () => {
+    expect(parseModelSelectionKey('openai:gpt-4o')).toBeNull();
+    expect(parseModelSelectionKey('openaigpt-4o')).toBeNull();
+  });
+
+  it('should return null when provider segment is empty (key starts with ::)', () => {
+    expect(parseModelSelectionKey('::gpt-4o')).toBeNull();
+  });
+
+  it('should return null when model segment is empty', () => {
+    expect(parseModelSelectionKey('openai::')).toBeNull();
+  });
+
+  it('should return null for an unknown provider', () => {
+    expect(parseModelSelectionKey('unknown::gpt-4o')).toBeNull();
+    expect(parseModelSelectionKey('xai::grok-3')).toBeNull();
+  });
+
+  it('should return null for an empty string', () => {
+    expect(parseModelSelectionKey('')).toBeNull();
+  });
+
+  it('should preserve model ids that contain :: correctly', () => {
+    // Only the FIRST :: is the separator; rest is part of modelId
+    const result = parseModelSelectionKey('openai::some::weird::model');
+    // indexOf('::') at position 6, so modelId = 'some::weird::model'
+    expect(result).toEqual({ providerId: 'openai', modelId: 'some::weird::model' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatModelSelectionKey
+// ---------------------------------------------------------------------------
+
+describe('formatModelSelectionKey', () => {
+  it('should format provider and model into a composite key', () => {
+    expect(formatModelSelectionKey('openai', 'gpt-4o')).toBe('openai::gpt-4o');
+    expect(formatModelSelectionKey('anthropic', 'claude-opus-4')).toBe('anthropic::claude-opus-4');
+  });
+
+  it('should be round-trippable with parseModelSelectionKey', () => {
+    const key = formatModelSelectionKey('gemini', 'gemini-2.0-flash');
+    expect(parseModelSelectionKey(key)).toEqual({
+      providerId: 'gemini',
+      modelId: 'gemini-2.0-flash',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// groupModelsByProvider
+// ---------------------------------------------------------------------------
+
+describe('groupModelsByProvider', () => {
+  it('should group models by provider in provider order', () => {
+    const groups = groupModelsByProvider(PROVIDERS, MODELS);
+    expect(groups).toHaveLength(3);
+    expect(groups[0].provider.provider_id).toBe('openai');
+    expect(groups[0].models).toHaveLength(2);
+    expect(groups[1].provider.provider_id).toBe('anthropic');
+    expect(groups[1].models).toHaveLength(1);
+    expect(groups[2].provider.provider_id).toBe('gemini');
+    expect(groups[2].models).toHaveLength(1);
+  });
+
+  it('should omit providers with no models', () => {
+    const provs: ModelCatalogProvider[] = [
+      { provider_id: 'cohere', label: 'Cohere', status: 'planned' },
+      ...PROVIDERS,
+    ];
+    const groups = groupModelsByProvider(provs, MODELS);
+    const ids = groups.map((g) => g.provider.provider_id);
+    expect(ids).not.toContain('cohere');
+  });
+
+  it('should return an empty array when models list is empty', () => {
+    expect(groupModelsByProvider(PROVIDERS, [])).toEqual([]);
+  });
+
+  it('should return an empty array when providers list is empty', () => {
+    expect(groupModelsByProvider([], MODELS)).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFallbackModelOption
+// ---------------------------------------------------------------------------
+
+describe('resolveFallbackModelOption', () => {
+  it('should return exact match when provider and model both match', () => {
+    const result = resolveFallbackModelOption(MODELS, 'openai', 'gpt-4.1-nano');
+    expect(result?.model_id).toBe('gpt-4.1-nano');
+    expect(result?.provider_id).toBe('openai');
+  });
+
+  it('should fall back to model-only match when provider differs', () => {
+    // Simulate a model that moved provider (e.g. openai -> anthropic)
+    const result = resolveFallbackModelOption(MODELS, 'openai', 'claude-opus-4');
+    expect(result?.model_id).toBe('claude-opus-4');
+  });
+
+  it('should return null when neither provider+model nor model-only match exists', () => {
+    const result = resolveFallbackModelOption(MODELS, 'openai', 'nonexistent-model');
+    expect(result).toBeNull();
+  });
+
+  it('should return null when models list is empty', () => {
+    expect(resolveFallbackModelOption([], 'openai', 'gpt-4o')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// coerceSelectionToValidEntry
+// ---------------------------------------------------------------------------
+
+describe('coerceSelectionToValidEntry', () => {
+  it('should return the selection unchanged when an exact match exists', () => {
+    const result = coerceSelectionToValidEntry(MODELS, 'openai', 'gpt-4o');
+    expect(result).toEqual({ providerId: 'openai', modelId: 'gpt-4o' });
+  });
+
+  it('should migrate to correct provider when model moved provider', () => {
+    // claude-opus-4 belongs to anthropic; if selectedProviderId is openai, it should fix
+    const result = coerceSelectionToValidEntry(MODELS, 'openai', 'claude-opus-4');
+    expect(result).toEqual({ providerId: 'anthropic', modelId: 'claude-opus-4' });
+  });
+
+  it('should fall back to first model for provider when model not found', () => {
+    const result = coerceSelectionToValidEntry(MODELS, 'openai', 'nonexistent');
+    // Should fall back to first model for 'openai'
+    expect(result.providerId).toBe('openai');
+    expect(['gpt-4.1-nano', 'gpt-4o']).toContain(result.modelId);
+  });
+
+  it('should fall back to first catalog model when provider has no models', () => {
+    const modelsWithoutAnthropicAndGemini: ModelCatalogModel[] = [
+      { provider_id: 'openai', model_id: 'gpt-4.1-nano', label: 'GPT-4.1 Nano', default_contexts: [] },
+    ];
+    const result = coerceSelectionToValidEntry(modelsWithoutAnthropicAndGemini, 'anthropic', 'nonexistent');
+    expect(result).toEqual({ providerId: 'openai', modelId: 'gpt-4.1-nano' });
+  });
+
+  it('should return the original pair unchanged when catalog is empty', () => {
+    const result = coerceSelectionToValidEntry([], 'openai', 'gpt-4o');
+    expect(result).toEqual({ providerId: 'openai', modelId: 'gpt-4o' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getSelectedModelLabel
+// ---------------------------------------------------------------------------
+
+describe('getSelectedModelLabel', () => {
+  it('should return the label for an exact match', () => {
+    expect(getSelectedModelLabel(MODELS, 'openai', 'gpt-4.1-nano')).toBe('GPT-4.1 Nano');
+  });
+
+  it('should fall back to the raw modelId when catalog is empty', () => {
+    expect(getSelectedModelLabel([], 'openai', 'gpt-4o')).toBe('gpt-4o');
+  });
+
+  it('should fall back to the raw modelId when model is not in catalog', () => {
+    expect(getSelectedModelLabel(MODELS, 'openai', 'unknown-model')).toBe('unknown-model');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeModelSelectorWidthCh
+// ---------------------------------------------------------------------------
+
+describe('computeModelSelectorWidthCh', () => {
+  it('should return at least 18 ch as minimum', () => {
+    expect(computeModelSelectorWidthCh([], [], 'openai', 'x')).toBeGreaterThanOrEqual(18);
+  });
+
+  it('should use longest label + 4 when groups have labels', () => {
+    const groups = groupModelsByProvider(PROVIDERS, MODELS);
+    const result = computeModelSelectorWidthCh(groups, MODELS, 'openai', 'gpt-4.1-nano');
+    // Longest label: 'Claude Opus 4' = 13 chars → 13 + 4 = 17, which is < 18, so minimum = 18
+    // Actually 'Gemini 2.0 Flash' = 16 chars → 16 + 4 = 20 > 18
+    expect(result).toBe(20);
+  });
+
+  it('should fall back to selected model label when groups is empty', () => {
+    // When groups is empty, uses the selectedModel label length
+    const result = computeModelSelectorWidthCh([], MODELS, 'openai', 'gpt-4.1-nano');
+    // 'GPT-4.1 Nano'.length = 12, 12 + 4 = 16, min 18 => 18
+    expect(result).toBe(18);
+  });
+
+  it('should use minimum 18 even when longest label is short', () => {
+    const shortModels: ModelCatalogModel[] = [
+      { provider_id: 'openai', model_id: 'gpt', label: 'GPT', default_contexts: [] },
+    ];
+    const shortProviders: ModelCatalogProvider[] = [
+      { provider_id: 'openai', label: 'OpenAI', status: 'ready' },
+    ];
+    const groups = groupModelsByProvider(shortProviders, shortModels);
+    // 'GPT'.length = 3, 3 + 4 = 7, min 18 => 18
+    expect(computeModelSelectorWidthCh(groups, shortModels, 'openai', 'gpt')).toBe(18);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// providerGroupLabel
+// ---------------------------------------------------------------------------
+
+describe('providerGroupLabel', () => {
+  it('should return the plain label for a ready provider', () => {
+    const p: ModelCatalogProvider = { provider_id: 'openai', label: 'OpenAI', status: 'ready' };
+    expect(providerGroupLabel(p)).toBe('OpenAI');
+  });
+
+  it('should append the status in parentheses for non-ready providers', () => {
+    const p: ModelCatalogProvider = { provider_id: 'gemini', label: 'Gemini', status: 'planned' };
+    expect(providerGroupLabel(p)).toBe('Gemini (planned)');
+  });
+});


### PR DESCRIPTION
# Feature: chat-ui ModelSelector P1 (additive lib export)

## Objective
Add a reusable `ModelSelector` Svelte component and `model-selection` pure-logic util to `@sentropic/chat-ui` as new additive exports. Librarizes the provider/model selector inline in `AppChatPanel.svelte` (lines 4159-4243, 5827-5849 on main). No app changes, no headless-core, no Makefile changes.

## Scope / Guardrails
- Scope limited to `packages/chat-ui/` new files and manifest/package.json additions.
- Make-only workflow, no direct Docker commands.
- Root workspace reserved for user dev/UAT (`ENV=dev`) — must remain stable.
- Branch development in isolated worktree `tmp/feat-chatui-model-selector-p1`.
- Automated test campaigns on dedicated environments, never root `dev`.
- `ENV=<env>` as last argument in all `make` commands.
- All new text in English.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths (implementation scope)**:
  - `packages/chat-ui/src/components/ModelSelector.svelte` (new)
  - `packages/chat-ui/src/utils/model-selection.ts` (new)
  - `packages/chat-ui/package.json` (ADD two new exports subpaths + bump version minor)
  - `packages/chat-ui/export-manifest.json` (ADD two new subpaths — additive only)
  - `packages/chat-ui/tests/model-selection.spec.ts` (new)
  - `BRANCH.md`
- **Forbidden Paths (must not change in this branch)**:
  - `Makefile`
  - `docker-compose*.yml`
  - `.cursor/rules/**`
  - `ui/src/**` (app retrofit is a separate later branch)
  - All other packages
- **Conditional Paths**: none required
- **Exception process**: none needed (no conditional paths touched)

## Feedback Loop
- `deferred` (A0b-DOM): DOM/render tests for ModelSelector.svelte deferred to `feat/chatui-a0b-dom-visual-harness` (A0b jsdom harness). Component covered by typecheck for now. Owner: Wave A plan.

## AI Flaky tests
- N/A (no AI tests in this branch)

## Orchestration Mode (AI-selected)
- [x] **Mono-branch + cherry-pick** (additive lib-only; single gate cycle)
- Rationale: single orthogonal additive task, no service stack needed.

## UAT Management (in orchestration context)
- Mono-branch: no UI UAT (lib-only additive; no app changes in this branch).
- Gates are local `make` commands only (typecheck + build + pack + test).

## Plan / Todo (lot-based)

- [x] **Lot 0 — Baseline & constraints**
  - [x] Read mandatory rules files and spec (workflow, MASTER, subagents, testing, SPEC_EVOL_CHATUI_WAVE_A §4 P1).
  - [x] Confirm worktree on `feat/chatui-model-selector-p1` (verified: `git -C tmp/feat-chatui-model-selector-p1 branch --show-current` = feat/chatui-model-selector-p1).
  - [x] Confirm export manifest + existing tests (A0a gates must stay green).
  - [x] Re-validate AppChatPanel.svelte line ranges on main: parse/handler/fallback/width at lines 4159-4243; markup `<select id="chat-model-selection">` at lines 5827-5849.
  - [x] Define scope: no dev stack needed (pure lib, node tests only).

- [x] **Lot 1 — Pure logic util + component + exports + tests**
  - [x] Write `packages/chat-ui/src/utils/model-selection.ts`: types + parse/format/group/fallback/width helpers.
  - [x] Write `packages/chat-ui/src/components/ModelSelector.svelte`: native `<select>`, grouped `<optgroup>`, fallback, auto-width, i18n resolver, change event.
  - [x] Write `packages/chat-ui/src/components/ModelSelector.svelte.d.ts`: props type + default export.
  - [x] Bump `packages/chat-ui/package.json` version to `0.2.0` (minor — new feature).
  - [x] Add two export subpaths to `packages/chat-ui/package.json` exports map.
  - [x] Add two subpath entries to `packages/chat-ui/export-manifest.json` (additive, no existing entries touched).
  - [x] Write `packages/chat-ui/tests/model-selection.spec.ts`: parse, group, fallback, width — node env.
  - [x] Lot gate:
    - [x] `make typecheck-chat-ui` — PASS
    - [x] `make build-chat-ui` — PASS
    - [x] `make pack-chat-ui` — PASS
    - [x] `make test-chat-ui` — PASS (A0a export-surface + projection-golden + new model-selection tests)

- [ ] **Lot N-1 — Docs consolidation**
  - [ ] No spec EVOL file to integrate (SPEC_EVOL_CHATUI_WAVE_A.md lives in spec/ and is the Wave A master spec — do not delete).

- [ ] **Lot N — Final validation**
  - [ ] Typecheck: `make typecheck-chat-ui`
  - [ ] Build: `make build-chat-ui`
  - [ ] Pack: `make pack-chat-ui`
  - [ ] Test: `make test-chat-ui`
  - [ ] Version bumped: `packages/chat-ui/package.json` → `0.2.0` (minor, new exports added).
  - [ ] Final gate step 1: create/update PR using `BRANCH.md` text as PR body.
  - [ ] Final gate step 2: verify branch CI on that PR.
  - [ ] Final gate step 3: once CI OK, commit removal of `BRANCH.md`, push, merge.