### PR TITLE
feat(chat-ui): MessageActions P2 — additive message-action row lib export

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,24 +1,25 @@
-# Feature: chat-ui ModelSelector P1 (additive lib export)
+# Feature: chat-ui MessageActions P2 (additive lib export)
 
 ## Objective
-Add a reusable `ModelSelector` Svelte component and `model-selection` pure-logic util to `@sentropic/chat-ui` as new additive exports. Librarizes the provider/model selector inline in `AppChatPanel.svelte` (lines 4159-4243, 5827-5849 on main). No app changes, no headless-core, no Makefile changes.
+Add a reusable `MessageActions` Svelte component and `message-actions` pure-logic util to `@sentropic/chat-ui` as new additive exports. Librarizes the message-action row (copy/edit/regenerate/retry/feedback) currently inline in `AppChatPanel.svelte` (handlers at lines 2884-2911, 2975-3000, 3081-3099, 3101-3108, 4409-4423; markup at lines 5095-5138 [user row] and 5181-5244 [assistant row] on main). Comment copy/edit (`startEditComment`, `editingCommentId`) and checkpoint-restore logic stay app-owned. No app changes, no headless-core, no Makefile changes.
 
 ## Scope / Guardrails
 - Scope limited to `packages/chat-ui/` new files and manifest/package.json additions.
 - Make-only workflow, no direct Docker commands.
 - Root workspace reserved for user dev/UAT (`ENV=dev`) — must remain stable.
-- Branch development in isolated worktree `tmp/feat-chatui-model-selector-p1`.
+- Branch development in isolated worktree `tmp/feat-chatui-message-actions-p2`.
 - Automated test campaigns on dedicated environments, never root `dev`.
 - `ENV=<env>` as last argument in all `make` commands.
 - All new text in English.
 
 ## Branch Scope Boundaries (MANDATORY)
 - **Allowed Paths (implementation scope)**:
-  - `packages/chat-ui/src/components/ModelSelector.svelte` (new)
-  - `packages/chat-ui/src/utils/model-selection.ts` (new)
+  - `packages/chat-ui/src/components/MessageActions.svelte` (new)
+  - `packages/chat-ui/src/components/MessageActions.svelte.d.ts` (new)
+  - `packages/chat-ui/src/utils/message-actions.ts` (new)
   - `packages/chat-ui/package.json` (ADD two new exports subpaths + bump version minor)
   - `packages/chat-ui/export-manifest.json` (ADD two new subpaths — additive only)
-  - `packages/chat-ui/tests/model-selection.spec.ts` (new)
+  - `packages/chat-ui/tests/message-actions.spec.ts` (new)
   - `BRANCH.md`
 - **Forbidden Paths (must not change in this branch)**:
   - `Makefile`
@@ -30,7 +31,7 @@ Add a reusable `ModelSelector` Svelte component and `model-selection` pure-logic
 - **Exception process**: none needed (no conditional paths touched)
 
 ## Feedback Loop
-- `deferred` (A0b-DOM): DOM/render tests for ModelSelector.svelte deferred to `feat/chatui-a0b-dom-visual-harness` (A0b jsdom harness). Component covered by typecheck for now. Owner: Wave A plan.
+- `deferred` (A0b-DOM): DOM/render tests for MessageActions.svelte deferred to `feat/chatui-a0b-dom-visual-harness` (A0b jsdom harness). Component covered by typecheck for now. Owner: Wave A plan.
 
 ## AI Flaky tests
 - N/A (no AI tests in this branch)
@@ -46,25 +47,26 @@ Add a reusable `ModelSelector` Svelte component and `model-selection` pure-logic
 ## Plan / Todo (lot-based)
 
 - [x] **Lot 0 — Baseline & constraints**
-  - [x] Read mandatory rules files and spec (workflow, MASTER, subagents, testing, SPEC_EVOL_CHATUI_WAVE_A §4 P1).
-  - [x] Confirm worktree on `feat/chatui-model-selector-p1` (verified: `git -C tmp/feat-chatui-model-selector-p1 branch --show-current` = feat/chatui-model-selector-p1).
+  - [x] Read mandatory rules files and spec (workflow, MASTER, subagents, testing, SPEC_EVOL_CHATUI_WAVE_A §4 P2).
+  - [x] Confirm worktree on `feat/chatui-message-actions-p2`.
   - [x] Confirm export manifest + existing tests (A0a gates must stay green).
-  - [x] Re-validate AppChatPanel.svelte line ranges on main: parse/handler/fallback/width at lines 4159-4243; markup `<select id="chat-model-selection">` at lines 5827-5849.
+  - [x] Re-derive AppChatPanel.svelte message-action sub-ranges on main: handlers at lines 2884-2911 (startEditMessage/cancelEditMessage/saveEditMessage), 2975-3000 (retryMessage), 3081-3099 (retryFromAssistant), 3101-3108 (markCopied/isCopied), 4409-4423 (setFeedback); markup at lines 5095-5138 (user row) and 5181-5244 (assistant row).
+  - [x] Confirmed excluded: startEditComment/editingCommentId (line 2384+), checkpoint/pendingCheckpoint logic (lines 3002-3079).
   - [x] Define scope: no dev stack needed (pure lib, node tests only).
 
 - [x] **Lot 1 — Pure logic util + component + exports + tests**
-  - [x] Write `packages/chat-ui/src/utils/model-selection.ts`: types + parse/format/group/fallback/width helpers.
-  - [x] Write `packages/chat-ui/src/components/ModelSelector.svelte`: native `<select>`, grouped `<optgroup>`, fallback, auto-width, i18n resolver, change event.
-  - [x] Write `packages/chat-ui/src/components/ModelSelector.svelte.d.ts`: props type + default export.
-  - [x] Bump `packages/chat-ui/package.json` version to `0.2.0` (minor — new feature).
+  - [x] Write `packages/chat-ui/src/utils/message-actions.ts`: types + available-actions resolver, feedback-vote toggle logic, copy-payload helpers.
+  - [x] Write `packages/chat-ui/src/components/MessageActions.svelte`: presentational action row for user/assistant messages, i18n resolver, injected callbacks.
+  - [x] Write `packages/chat-ui/src/components/MessageActions.svelte.d.ts`: props type + default export.
+  - [x] Bump `packages/chat-ui/package.json` version to `0.3.0` (minor — new feature).
   - [x] Add two export subpaths to `packages/chat-ui/package.json` exports map.
   - [x] Add two subpath entries to `packages/chat-ui/export-manifest.json` (additive, no existing entries touched).
-  - [x] Write `packages/chat-ui/tests/model-selection.spec.ts`: parse, group, fallback, width — node env.
+  - [x] Write `packages/chat-ui/tests/message-actions.spec.ts`: resolveAvailableActions, toggleFeedbackVote, formatCopyPayload, buildFeedbackNextVote — node env.
   - [x] Lot gate:
     - [x] `make typecheck-chat-ui` — PASS
     - [x] `make build-chat-ui` — PASS
     - [x] `make pack-chat-ui` — PASS
-    - [x] `make test-chat-ui` — PASS (A0a export-surface + projection-golden + new model-selection tests)
+    - [x] `make test-chat-ui` — PASS (A0a export-surface + projection-golden + model-selection + new message-actions tests)
 
 - [ ] **Lot N-1 — Docs consolidation**
   - [ ] No spec EVOL file to integrate (SPEC_EVOL_CHATUI_WAVE_A.md lives in spec/ and is the Wave A master spec — do not delete).
@@ -74,7 +76,7 @@ Add a reusable `ModelSelector` Svelte component and `model-selection` pure-logic
   - [ ] Build: `make build-chat-ui`
   - [ ] Pack: `make pack-chat-ui`
   - [ ] Test: `make test-chat-ui`
-  - [ ] Version bumped: `packages/chat-ui/package.json` → `0.2.0` (minor, new exports added).
+  - [ ] Version bumped: `packages/chat-ui/package.json` → `0.3.0` (minor, new exports added).
   - [ ] Final gate step 1: create/update PR using `BRANCH.md` text as PR body.
   - [ ] Final gate step 2: verify branch CI on that PR.
   - [ ] Final gate step 3: once CI OK, commit removal of `BRANCH.md`, push, merge.

--- a/packages/chat-ui/export-manifest.json
+++ b/packages/chat-ui/export-manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Committed baseline snapshot of @sentropic/chat-ui export surface. Generated manually from package.json exports + source grep. Prop-name snapshot for Svelte components is DEFERRED to A0b (requires svelte-check / compile step — noted below). Regenerate by reading src/** exports and updating this file on any export change.",
   "_generated": "2026-06-02",
-  "_version": "0.2.0",
+  "_version": "0.3.0",
   "subpaths": {
     ".": {
       "kind": "ts",
@@ -431,6 +431,12 @@
       "exists": true,
       "_propSnapshot": "DEFERRED to A0b — requires svelte-check/compile step to extract prop types from .svelte files; not available in node-only vitest environment"
     },
+    "./components/MessageActions.svelte": {
+      "kind": "svelte",
+      "file": "src/components/MessageActions.svelte",
+      "exists": true,
+      "_propSnapshot": "DEFERRED to A0b — requires svelte-check/compile step to extract prop types from .svelte files; not available in node-only vitest environment"
+    },
     "./utils/model-selection": {
       "kind": "ts",
       "file": "src/utils/model-selection.ts",
@@ -448,6 +454,25 @@
         "getSelectedModelLabel",
         "computeModelSelectorWidthCh",
         "providerGroupLabel"
+      ]
+    },
+    "./utils/message-actions": {
+      "kind": "ts",
+      "file": "src/utils/message-actions.ts",
+      "exports": [
+        "MessageActionRole",
+        "MessageActionStreamStatus",
+        "MessageActionAvailability",
+        "ResolveAvailableActionsInput",
+        "MessageFeedbackVote",
+        "FeedbackDirection",
+        "FeedbackNextAction",
+        "FeedbackDisplayState",
+        "resolveAvailableActions",
+        "resolveFeedbackDisplayState",
+        "buildFeedbackNextVote",
+        "applyFeedbackAction",
+        "formatCopyPayload"
       ]
     }
   }

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/chat-ui",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Svelte reference UI package for @sentropic/* chat sessions: stream rendering, optimistic client state, local-tool handoff, renderer registry, and host adapter contracts. Consumes @sentropic/chat-core wire contracts over HTTP/SSE only.",
   "type": "module",
   "license": "MIT",
@@ -147,10 +147,20 @@
       "svelte": "./src/components/ModelSelector.svelte",
       "import": "./src/components/ModelSelector.svelte"
     },
+    "./components/MessageActions.svelte": {
+      "types": "./src/components/MessageActions.svelte.d.ts",
+      "svelte": "./src/components/MessageActions.svelte",
+      "import": "./src/components/MessageActions.svelte"
+    },
     "./utils/model-selection": {
       "types": "./src/utils/model-selection.ts",
       "svelte": "./src/utils/model-selection.ts",
       "import": "./src/utils/model-selection.ts"
+    },
+    "./utils/message-actions": {
+      "types": "./src/utils/message-actions.ts",
+      "svelte": "./src/utils/message-actions.ts",
+      "import": "./src/utils/message-actions.ts"
     }
   },
   "files": [

--- a/packages/chat-ui/src/components/MessageActions.svelte
+++ b/packages/chat-ui/src/components/MessageActions.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+  /**
+   * MessageActions — a presentational action row for a single chat message.
+   *
+   * Renders copy / edit / regenerate (retry) / feedback buttons for user and
+   * assistant messages.  All transport (API calls, clipboard writes) is delegated
+   * to injected callbacks — this component only renders and emits.
+   *
+   * Extracted from AppChatPanel.svelte markup (lines 5095-5138 [user row],
+   * 5181-5244 [assistant row] on main).
+   *
+   * EXCLUDED (app-owned): checkpoint-restore button, comment copy/edit.
+   *
+   * Contract:
+   * - `role`          — 'user' | 'assistant'; drives which buttons are shown.
+   * - `streamStatus`  — 'processing' | 'completed'; disables actions while streaming.
+   * - `isLastAssistantSegment` — show assistant actions only on last terminal segment.
+   * - `isCopied`      — caller tracks copy-flash state per message/segment key.
+   * - `feedbackVote`  — current numeric vote (1 | -1 | null | undefined).
+   * - `labels`        — injected resolver (key: string) => string; NO hardcoded strings.
+   * - `onCopy`        — called when the user clicks copy; caller handles clipboard write.
+   * - `onEdit`        — called when the user clicks edit (user messages only).
+   * - `onRegenerate`  — called when the user clicks regenerate/retry (assistant only).
+   * - `onFeedback`    — called with 'up' | 'down' | 'clear' when feedback clicked.
+   */
+
+  import Check from '@lucide/svelte/icons/check';
+  import Copy from '@lucide/svelte/icons/copy';
+  import Pencil from '@lucide/svelte/icons/pencil';
+  import RotateCcw from '@lucide/svelte/icons/rotate-ccw';
+  import ThumbsDown from '@lucide/svelte/icons/thumbs-down';
+  import ThumbsUp from '@lucide/svelte/icons/thumbs-up';
+
+  import type { ChatUiLabelResolver } from '../hosts/createWebHost.js';
+  import {
+    buildFeedbackNextVote,
+    resolveAvailableActions,
+    resolveFeedbackDisplayState,
+    type MessageActionRole,
+    type MessageActionStreamStatus,
+    type MessageFeedbackVote,
+  } from '../utils/message-actions.js';
+
+  // ---------------------------------------------------------------------------
+  // Props
+  // ---------------------------------------------------------------------------
+
+  /** Role of the message this row belongs to. */
+  export let role: MessageActionRole;
+
+  /** Stream status — 'processing' while streaming, 'completed' when done. */
+  export let streamStatus: MessageActionStreamStatus = 'completed';
+
+  /**
+   * True when this is both a terminal segment AND the last assistant segment.
+   * Only meaningful for assistant messages.  Controls whether assistant actions
+   * (regenerate, feedback) are displayed.
+   */
+  export let isLastAssistantSegment: boolean = false;
+
+  /**
+   * Whether the copy-flash indicator is active for this message.
+   * The host manages the flash timer and passes the boolean here.
+   */
+  export let isCopied: boolean = false;
+
+  /**
+   * Current feedback vote stored on the message (1 = up, -1 = down, null = none).
+   */
+  export let feedbackVote: MessageFeedbackVote = null;
+
+  /**
+   * i18n / label resolver injected by the host.
+   * Receives a key string; returns the display string.
+   * No user-facing string is hardcoded in this component.
+   */
+  export let labels: ChatUiLabelResolver | undefined = undefined;
+
+  // ---------------------------------------------------------------------------
+  // Callbacks — transport is the host's responsibility
+  // ---------------------------------------------------------------------------
+
+  /** Called when the user clicks the copy button. */
+  export let onCopy: (() => void) | undefined = undefined;
+
+  /** Called when the user clicks the edit button (user messages only). */
+  export let onEdit: (() => void) | undefined = undefined;
+
+  /**
+   * Called when the user clicks regenerate / retry (assistant messages only).
+   * The host is responsible for handling checkpoint prompts if needed.
+   */
+  export let onRegenerate: (() => void) | undefined = undefined;
+
+  /**
+   * Called with the next feedback action when the user clicks a feedback button.
+   * Payload: 'up' | 'down' | 'clear'.
+   */
+  export let onFeedback: ((action: 'up' | 'down' | 'clear') => void) | undefined =
+    undefined;
+
+  // ---------------------------------------------------------------------------
+  // Derived state
+  // ---------------------------------------------------------------------------
+  $: available = resolveAvailableActions({ role, streamStatus, isLastAssistantSegment });
+  $: feedback = resolveFeedbackDisplayState(feedbackVote);
+
+  // ---------------------------------------------------------------------------
+  // Label resolver — falls back to the key when no resolver is provided
+  // ---------------------------------------------------------------------------
+  const resolveLabel = (key: string): string => labels?.(key) ?? key;
+</script>
+
+<!--
+  User message action row — aligns right, visible on group-hover.
+  Mirrors AppChatPanel markup lines 5095-5138 on main.
+-->
+{#if role === 'user' && (available.copy || available.edit)}
+  <div
+    class="mt-1 flex items-center justify-end gap-1 text-[11px] text-slate-400 opacity-0 group-hover:opacity-100 transition-opacity"
+  >
+    {#if available.copy}
+      <button
+        class="chat-message-action-button inline-flex items-center rounded px-1.5 py-0.5 hover:bg-slate-100"
+        type="button"
+        aria-label={resolveLabel('common.copy')}
+        title={resolveLabel('common.copy')}
+        on:click={() => onCopy?.()}
+      >
+        {#if isCopied}
+          <Check class="w-3.5 h-3.5 text-slate-900" />
+        {:else}
+          <Copy class="w-3.5 h-3.5" />
+        {/if}
+      </button>
+    {/if}
+    {#if available.edit}
+      <button
+        class="chat-message-action-button inline-flex items-center rounded px-1.5 py-0.5 hover:bg-slate-100"
+        type="button"
+        aria-label={resolveLabel('chat.message.edit')}
+        title={resolveLabel('chat.message.edit')}
+        on:click={() => onEdit?.()}
+      >
+        <Pencil class="w-3.5 h-3.5" />
+      </button>
+    {/if}
+  </div>
+{/if}
+
+<!--
+  Assistant message action row — visible always (not on hover).
+  Mirrors AppChatPanel markup lines 5181-5244 on main.
+-->
+{#if role === 'assistant' && (available.copy || available.regenerate || available.feedbackUp)}
+  <div
+    class="mt-1 flex items-center justify-end gap-1 text-[11px] text-slate-500"
+  >
+    {#if available.copy}
+      <button
+        class="chat-message-action-button inline-flex items-center rounded px-1.5 py-0.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+        type="button"
+        aria-label={resolveLabel('common.copy')}
+        title={resolveLabel('common.copy')}
+        on:click={() => onCopy?.()}
+      >
+        {#if isCopied}
+          <Check class="w-3.5 h-3.5 text-slate-900" />
+        {:else}
+          <Copy class="w-3.5 h-3.5" />
+        {/if}
+      </button>
+    {/if}
+    {#if available.regenerate}
+      <button
+        class="chat-message-action-button inline-flex items-center rounded px-1.5 py-0.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+        type="button"
+        aria-label={resolveLabel('common.retry')}
+        title={resolveLabel('common.retry')}
+        on:click={() => onRegenerate?.()}
+      >
+        <RotateCcw class="w-3.5 h-3.5" />
+      </button>
+    {/if}
+    {#if available.feedbackUp}
+      <button
+        class="chat-message-action-button inline-flex items-center rounded px-1.5 py-0.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+        class:text-slate-900={feedback.isUp}
+        class:chat-message-action-button-active={feedback.isUp}
+        type="button"
+        aria-label={resolveLabel('chat.feedback.useful')}
+        title={resolveLabel('chat.feedback.useful')}
+        on:click={() => onFeedback?.(buildFeedbackNextVote(feedbackVote, 'up'))}
+      >
+        <ThumbsUp
+          class="w-3.5 h-3.5"
+          fill={feedback.isUp ? 'currentColor' : 'none'}
+        />
+      </button>
+    {/if}
+    {#if available.feedbackDown}
+      <button
+        class="chat-message-action-button inline-flex items-center rounded px-1.5 py-0.5 text-slate-400 hover:text-slate-600 hover:bg-slate-100"
+        class:text-slate-900={feedback.isDown}
+        class:chat-message-action-button-active={feedback.isDown}
+        type="button"
+        aria-label={resolveLabel('chat.feedback.notUseful')}
+        title={resolveLabel('chat.feedback.notUseful')}
+        on:click={() => onFeedback?.(buildFeedbackNextVote(feedbackVote, 'down'))}
+      >
+        <ThumbsDown
+          class="w-3.5 h-3.5"
+          fill={feedback.isDown ? 'currentColor' : 'none'}
+        />
+      </button>
+    {/if}
+  </div>
+{/if}

--- a/packages/chat-ui/src/components/MessageActions.svelte.d.ts
+++ b/packages/chat-ui/src/components/MessageActions.svelte.d.ts
@@ -1,0 +1,46 @@
+import type { Component } from 'svelte';
+import type { ChatUiLabelResolver } from '../hosts/createWebHost.js';
+import type {
+  MessageActionRole,
+  MessageActionStreamStatus,
+  MessageFeedbackVote,
+} from '../utils/message-actions.js';
+
+export type MessageActionsProps = {
+  /** Role of the message this row belongs to. */
+  role: MessageActionRole;
+  /** Stream status — 'processing' while streaming, 'completed' when done. */
+  streamStatus?: MessageActionStreamStatus;
+  /**
+   * True when this is both a terminal segment AND the last assistant segment.
+   * Only meaningful for assistant messages.
+   */
+  isLastAssistantSegment?: boolean;
+  /**
+   * Whether the copy-flash indicator is active for this message.
+   * The host manages the flash timer.
+   */
+  isCopied?: boolean;
+  /** Current feedback vote stored on the message (1 = up, -1 = down, null = none). */
+  feedbackVote?: MessageFeedbackVote;
+  /** i18n / label resolver injected by the host. */
+  labels?: ChatUiLabelResolver;
+  /** Called when the user clicks the copy button. */
+  onCopy?: () => void;
+  /** Called when the user clicks the edit button (user messages only). */
+  onEdit?: () => void;
+  /**
+   * Called when the user clicks regenerate / retry (assistant messages only).
+   * The host is responsible for handling checkpoint prompts if needed.
+   */
+  onRegenerate?: () => void;
+  /**
+   * Called with the next feedback action when the user clicks a feedback button.
+   * Payload: 'up' | 'down' | 'clear'.
+   */
+  onFeedback?: (action: 'up' | 'down' | 'clear') => void;
+};
+
+declare const MessageActions: Component<MessageActionsProps>;
+
+export default MessageActions;

--- a/packages/chat-ui/src/utils/message-actions.ts
+++ b/packages/chat-ui/src/utils/message-actions.ts
@@ -1,0 +1,174 @@
+/**
+ * message-actions.ts — pure, framework-agnostic utilities for the message action row.
+ *
+ * Extracted from AppChatPanel.svelte handlers (lines 2884-2911, 2975-3000,
+ * 3081-3099, 3101-3108, 4409-4423 on main) and markup (lines 5095-5138 [user],
+ * 5181-5244 [assistant]).
+ *
+ * EXCLUDED (app-owned): startEditComment, editingCommentId, checkpoint-restore logic.
+ * No Svelte imports, no browser runtime — safe for node-only vitest.
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** The role of the message this action row is attached to. */
+export type MessageActionRole = 'user' | 'assistant';
+
+/** Current streaming / terminal state of the message. */
+export type MessageActionStreamStatus = 'processing' | 'completed';
+
+/**
+ * Which actions are available for a message given its role and state.
+ *
+ * - `copy`       — always available on terminal messages; user-message copy is in-row.
+ * - `edit`       — user messages only, never while streaming.
+ * - `regenerate` — assistant messages only, terminal and last-assistant-segment only.
+ * - `retry`      — synonym for regenerate; exposed as a separate flag so the host
+ *                  can show a distinct button when appropriate.
+ * - `feedbackUp` — assistant messages only, terminal.
+ * - `feedbackDown` — assistant messages only, terminal.
+ */
+export type MessageActionAvailability = {
+  copy: boolean;
+  edit: boolean;
+  regenerate: boolean;
+  retry: boolean;
+  feedbackUp: boolean;
+  feedbackDown: boolean;
+};
+
+/** Input for resolving available message actions. */
+export type ResolveAvailableActionsInput = {
+  role: MessageActionRole;
+  streamStatus: MessageActionStreamStatus;
+  /** True only when this segment is both terminal and the last assistant segment. */
+  isLastAssistantSegment?: boolean;
+};
+
+/**
+ * Numeric feedback vote stored on a message.
+ * 1 = thumbs-up, -1 = thumbs-down, null/undefined = no vote.
+ */
+export type MessageFeedbackVote = 1 | -1 | null | undefined;
+
+/** Directions a feedback toggle can take. */
+export type FeedbackDirection = 'up' | 'down';
+
+/**
+ * The next feedback action to send to the API given the current vote state
+ * and the button the user clicked.
+ *
+ * Mirrors `setFeedback` logic in AppChatPanel (lines 4409-4423 on main).
+ */
+export type FeedbackNextAction = 'up' | 'down' | 'clear';
+
+/**
+ * Resolved display state of the feedback buttons for a given message.
+ */
+export type FeedbackDisplayState = {
+  isUp: boolean;
+  isDown: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Available-actions resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve which action buttons should be rendered for a message.
+ *
+ * Rules mirror AppChatPanel behaviour:
+ * - User message: copy + edit available when not streaming.
+ * - Assistant message: copy + regenerate/retry + feedback available when terminal
+ *   and this is the last assistant segment.
+ */
+export function resolveAvailableActions(
+  input: ResolveAvailableActionsInput,
+): MessageActionAvailability {
+  const isTerminal = input.streamStatus === 'completed';
+
+  if (input.role === 'user') {
+    return {
+      copy: isTerminal,
+      edit: isTerminal,
+      regenerate: false,
+      retry: false,
+      feedbackUp: false,
+      feedbackDown: false,
+    };
+  }
+
+  // assistant
+  const showAll = isTerminal && (input.isLastAssistantSegment ?? false);
+  return {
+    copy: showAll,
+    edit: false,
+    regenerate: showAll,
+    retry: showAll,
+    feedbackUp: showAll,
+    feedbackDown: showAll,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Feedback vote helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Derive the current display state (isUp / isDown) from a stored feedback vote.
+ */
+export function resolveFeedbackDisplayState(
+  vote: MessageFeedbackVote,
+): FeedbackDisplayState {
+  return {
+    isUp: vote === 1,
+    isDown: vote === -1,
+  };
+}
+
+/**
+ * Compute the next feedback action to send to the API.
+ *
+ * Clicking the already-active direction clears the vote.
+ * Clicking the other direction sets it.
+ *
+ * Mirrors `setFeedback(m.id, isUp ? 'clear' : 'up')` pattern from AppChatPanel.
+ */
+export function buildFeedbackNextVote(
+  currentVote: MessageFeedbackVote,
+  clicked: FeedbackDirection,
+): FeedbackNextAction {
+  if (clicked === 'up') {
+    return currentVote === 1 ? 'clear' : 'up';
+  }
+  return currentVote === -1 ? 'clear' : 'down';
+}
+
+/**
+ * Apply an API response action to the stored numeric vote.
+ *
+ * Converts the string action used by the API (`'up' | 'down' | 'clear'`)
+ * to the numeric value stored locally on the message.
+ */
+export function applyFeedbackAction(action: FeedbackNextAction): MessageFeedbackVote {
+  if (action === 'up') return 1;
+  if (action === 'down') return -1;
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Copy-payload helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the plain-text copy payload for a message.
+ *
+ * This is intentionally trivial: the component is responsible for passing
+ * the correct `content` prop. The helper exists so the host can pre-process
+ * (trim, strip markdown, etc.) in a testable way without touching the component.
+ */
+export function formatCopyPayload(content: string | null | undefined): string {
+  return (content ?? '').trimEnd();
+}

--- a/packages/chat-ui/tests/message-actions.spec.ts
+++ b/packages/chat-ui/tests/message-actions.spec.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyFeedbackAction,
+  buildFeedbackNextVote,
+  formatCopyPayload,
+  resolveAvailableActions,
+  resolveFeedbackDisplayState,
+} from '../src/utils/message-actions.js';
+
+// ---------------------------------------------------------------------------
+// resolveAvailableActions — user messages
+// ---------------------------------------------------------------------------
+
+describe('resolveAvailableActions (user)', () => {
+  it('should show copy and edit when user message is completed', () => {
+    const result = resolveAvailableActions({ role: 'user', streamStatus: 'completed' });
+    expect(result.copy).toBe(true);
+    expect(result.edit).toBe(true);
+    expect(result.regenerate).toBe(false);
+    expect(result.retry).toBe(false);
+    expect(result.feedbackUp).toBe(false);
+    expect(result.feedbackDown).toBe(false);
+  });
+
+  it('should hide copy and edit when user message is processing (streaming)', () => {
+    const result = resolveAvailableActions({ role: 'user', streamStatus: 'processing' });
+    expect(result.copy).toBe(false);
+    expect(result.edit).toBe(false);
+  });
+
+  it('should never show regenerate/retry/feedback for user messages', () => {
+    const completed = resolveAvailableActions({ role: 'user', streamStatus: 'completed' });
+    expect(completed.regenerate).toBe(false);
+    expect(completed.retry).toBe(false);
+    expect(completed.feedbackUp).toBe(false);
+    expect(completed.feedbackDown).toBe(false);
+
+    const processing = resolveAvailableActions({ role: 'user', streamStatus: 'processing' });
+    expect(processing.regenerate).toBe(false);
+    expect(processing.retry).toBe(false);
+    expect(processing.feedbackUp).toBe(false);
+    expect(processing.feedbackDown).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAvailableActions — assistant messages
+// ---------------------------------------------------------------------------
+
+describe('resolveAvailableActions (assistant)', () => {
+  it('should show all assistant actions when terminal and last assistant segment', () => {
+    const result = resolveAvailableActions({
+      role: 'assistant',
+      streamStatus: 'completed',
+      isLastAssistantSegment: true,
+    });
+    expect(result.copy).toBe(true);
+    expect(result.regenerate).toBe(true);
+    expect(result.retry).toBe(true);
+    expect(result.feedbackUp).toBe(true);
+    expect(result.feedbackDown).toBe(true);
+    expect(result.edit).toBe(false);
+  });
+
+  it('should hide all assistant actions when streaming (not terminal)', () => {
+    const result = resolveAvailableActions({
+      role: 'assistant',
+      streamStatus: 'processing',
+      isLastAssistantSegment: true,
+    });
+    expect(result.copy).toBe(false);
+    expect(result.regenerate).toBe(false);
+    expect(result.retry).toBe(false);
+    expect(result.feedbackUp).toBe(false);
+    expect(result.feedbackDown).toBe(false);
+  });
+
+  it('should hide all assistant actions when terminal but NOT last assistant segment', () => {
+    const result = resolveAvailableActions({
+      role: 'assistant',
+      streamStatus: 'completed',
+      isLastAssistantSegment: false,
+    });
+    expect(result.copy).toBe(false);
+    expect(result.regenerate).toBe(false);
+    expect(result.feedbackUp).toBe(false);
+  });
+
+  it('should default isLastAssistantSegment to false when not provided', () => {
+    const result = resolveAvailableActions({
+      role: 'assistant',
+      streamStatus: 'completed',
+    });
+    expect(result.copy).toBe(false);
+    expect(result.regenerate).toBe(false);
+  });
+
+  it('should never show edit for assistant messages', () => {
+    const result = resolveAvailableActions({
+      role: 'assistant',
+      streamStatus: 'completed',
+      isLastAssistantSegment: true,
+    });
+    expect(result.edit).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveFeedbackDisplayState
+// ---------------------------------------------------------------------------
+
+describe('resolveFeedbackDisplayState', () => {
+  it('should set isUp=true when vote is 1', () => {
+    const state = resolveFeedbackDisplayState(1);
+    expect(state.isUp).toBe(true);
+    expect(state.isDown).toBe(false);
+  });
+
+  it('should set isDown=true when vote is -1', () => {
+    const state = resolveFeedbackDisplayState(-1);
+    expect(state.isUp).toBe(false);
+    expect(state.isDown).toBe(true);
+  });
+
+  it('should set both false when vote is null', () => {
+    const state = resolveFeedbackDisplayState(null);
+    expect(state.isUp).toBe(false);
+    expect(state.isDown).toBe(false);
+  });
+
+  it('should set both false when vote is undefined', () => {
+    const state = resolveFeedbackDisplayState(undefined);
+    expect(state.isUp).toBe(false);
+    expect(state.isDown).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildFeedbackNextVote
+// ---------------------------------------------------------------------------
+
+describe('buildFeedbackNextVote', () => {
+  it('should return "up" when clicking up and current vote is null (no vote)', () => {
+    expect(buildFeedbackNextVote(null, 'up')).toBe('up');
+  });
+
+  it('should return "clear" when clicking up and current vote is already up (1)', () => {
+    expect(buildFeedbackNextVote(1, 'up')).toBe('clear');
+  });
+
+  it('should return "up" when clicking up and current vote is down (-1)', () => {
+    expect(buildFeedbackNextVote(-1, 'up')).toBe('up');
+  });
+
+  it('should return "down" when clicking down and current vote is null (no vote)', () => {
+    expect(buildFeedbackNextVote(null, 'down')).toBe('down');
+  });
+
+  it('should return "clear" when clicking down and current vote is already down (-1)', () => {
+    expect(buildFeedbackNextVote(-1, 'down')).toBe('clear');
+  });
+
+  it('should return "down" when clicking down and current vote is up (1)', () => {
+    expect(buildFeedbackNextVote(1, 'down')).toBe('down');
+  });
+
+  it('should return "up" when vote is undefined and clicking up', () => {
+    expect(buildFeedbackNextVote(undefined, 'up')).toBe('up');
+  });
+
+  it('should return "down" when vote is undefined and clicking down', () => {
+    expect(buildFeedbackNextVote(undefined, 'down')).toBe('down');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyFeedbackAction
+// ---------------------------------------------------------------------------
+
+describe('applyFeedbackAction', () => {
+  it('should return 1 for "up"', () => {
+    expect(applyFeedbackAction('up')).toBe(1);
+  });
+
+  it('should return -1 for "down"', () => {
+    expect(applyFeedbackAction('down')).toBe(-1);
+  });
+
+  it('should return null for "clear"', () => {
+    expect(applyFeedbackAction('clear')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCopyPayload
+// ---------------------------------------------------------------------------
+
+describe('formatCopyPayload', () => {
+  it('should return the content string trimmed at the end', () => {
+    expect(formatCopyPayload('hello world   ')).toBe('hello world');
+  });
+
+  it('should preserve leading whitespace', () => {
+    expect(formatCopyPayload('  indented')).toBe('  indented');
+  });
+
+  it('should return empty string for null', () => {
+    expect(formatCopyPayload(null)).toBe('');
+  });
+
+  it('should return empty string for undefined', () => {
+    expect(formatCopyPayload(undefined)).toBe('');
+  });
+
+  it('should return empty string for an empty string', () => {
+    expect(formatCopyPayload('')).toBe('');
+  });
+
+  it('should preserve multiline content', () => {
+    const content = 'line 1\nline 2\nline 3';
+    expect(formatCopyPayload(content)).toBe('line 1\nline 2\nline 3');
+  });
+});


### PR DESCRIPTION
# Feature: chat-ui MessageActions P2 (additive lib export)

## Objective
Add a reusable `MessageActions` Svelte component and `message-actions` pure-logic util to `@sentropic/chat-ui` as new additive exports. Librarizes the message-action row (copy/edit/regenerate/retry/feedback) currently inline in `AppChatPanel.svelte` (handlers at lines 2884-2911, 2975-3000, 3081-3099, 3101-3108, 4409-4423; markup at lines 5095-5138 [user row] and 5181-5244 [assistant row] on main). Comment copy/edit (`startEditComment`, `editingCommentId`) and checkpoint-restore logic stay app-owned. No app changes, no headless-core, no Makefile changes.

## Scope / Guardrails
- Scope limited to `packages/chat-ui/` new files and manifest/package.json additions.
- Make-only workflow, no direct Docker commands.
- Root workspace reserved for user dev/UAT (`ENV=dev`) — must remain stable.
- Branch development in isolated worktree `tmp/feat-chatui-message-actions-p2`.
- Automated test campaigns on dedicated environments, never root `dev`.
- `ENV=<env>` as last argument in all `make` commands.
- All new text in English.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths (implementation scope)**:
  - `packages/chat-ui/src/components/MessageActions.svelte` (new)
  - `packages/chat-ui/src/components/MessageActions.svelte.d.ts` (new)
  - `packages/chat-ui/src/utils/message-actions.ts` (new)
  - `packages/chat-ui/package.json` (ADD two new exports subpaths + bump version minor)
  - `packages/chat-ui/export-manifest.json` (ADD two new subpaths — additive only)
  - `packages/chat-ui/tests/message-actions.spec.ts` (new)
  - `BRANCH.md`
- **Forbidden Paths (must not change in this branch)**:
  - `Makefile`
  - `docker-compose*.yml`
  - `.cursor/rules/**`
  - `ui/src/**` (app retrofit is a separate later branch)
  - All other packages
- **Conditional Paths**: none required
- **Exception process**: none needed (no conditional paths touched)

## Feedback Loop
- `deferred` (A0b-DOM): DOM/render tests for MessageActions.svelte deferred to `feat/chatui-a0b-dom-visual-harness` (A0b jsdom harness). Component covered by typecheck for now. Owner: Wave A plan.

## AI Flaky tests
- N/A (no AI tests in this branch)

## Orchestration Mode (AI-selected)
- [x] **Mono-branch + cherry-pick** (additive lib-only; single gate cycle)
- Rationale: single orthogonal additive task, no service stack needed.

## UAT Management (in orchestration context)
- Mono-branch: no UI UAT (lib-only additive; no app changes in this branch).
- Gates are local `make` commands only (typecheck + build + pack + test).

## Plan / Todo (lot-based)

- [x] **Lot 0 — Baseline & constraints**
  - [x] Read mandatory rules files and spec (workflow, MASTER, subagents, testing, SPEC_EVOL_CHATUI_WAVE_A §4 P2).
  - [x] Confirm worktree on `feat/chatui-message-actions-p2`.
  - [x] Confirm export manifest + existing tests (A0a gates must stay green).
  - [x] Re-derive AppChatPanel.svelte message-action sub-ranges on main: handlers at lines 2884-2911 (startEditMessage/cancelEditMessage/saveEditMessage), 2975-3000 (retryMessage), 3081-3099 (retryFromAssistant), 3101-3108 (markCopied/isCopied), 4409-4423 (setFeedback); markup at lines 5095-5138 (user row) and 5181-5244 (assistant row).
  - [x] Confirmed excluded: startEditComment/editingCommentId (line 2384+), checkpoint/pendingCheckpoint logic (lines 3002-3079).
  - [x] Define scope: no dev stack needed (pure lib, node tests only).

- [x] **Lot 1 — Pure logic util + component + exports + tests**
  - [x] Write `packages/chat-ui/src/utils/message-actions.ts`: types + available-actions resolver, feedback-vote toggle logic, copy-payload helpers.
  - [x] Write `packages/chat-ui/src/components/MessageActions.svelte`: presentational action row for user/assistant messages, i18n resolver, injected callbacks.
  - [x] Write `packages/chat-ui/src/components/MessageActions.svelte.d.ts`: props type + default export.
  - [x] Bump `packages/chat-ui/package.json` version to `0.3.0` (minor — new feature).
  - [x] Add two export subpaths to `packages/chat-ui/package.json` exports map.
  - [x] Add two subpath entries to `packages/chat-ui/export-manifest.json` (additive, no existing entries touched).
  - [x] Write `packages/chat-ui/tests/message-actions.spec.ts`: resolveAvailableActions, toggleFeedbackVote, formatCopyPayload, buildFeedbackNextVote — node env.
  - [x] Lot gate:
    - [x] `make typecheck-chat-ui` — PASS
    - [x] `make build-chat-ui` — PASS
    - [x] `make pack-chat-ui` — PASS
    - [x] `make test-chat-ui ENV=test-chatui-p2` — PASS (A0a export-surface + projection-golden + model-selection + new message-actions tests; 241 tests total, 24 files)

- [ ] **Lot N-1 — Docs consolidation**
  - [ ] No spec EVOL file to integrate (SPEC_EVOL_CHATUI_WAVE_A.md lives in spec/ and is the Wave A master spec — do not delete).

- [ ] **Lot N — Final validation**
  - [ ] Typecheck: `make typecheck-chat-ui`
  - [ ] Build: `make build-chat-ui`
  - [ ] Pack: `make pack-chat-ui`
  - [ ] Test: `make test-chat-ui ENV=test-chatui-p2`
  - [ ] Version bumped: `packages/chat-ui/package.json` → `0.3.0` (minor, new exports added).
  - [ ] Final gate step 1: create/update PR using `BRANCH.md` text as PR body.
  - [ ] Final gate step 2: verify branch CI on that PR.
  - [ ] Final gate step 3: once CI OK, commit removal of `BRANCH.md`, push, merge.