### PR TITLE
[needs full-CI verify] A0b: jsdom DOM/ARIA harness + ModelSelector/MessageActions DOM coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1280,7 +1280,20 @@ test-llm-mesh: ## Run @sentropic/llm-mesh tests
 .PHONY: test-chat-ui
 test-chat-ui: ## Run @sentropic/chat-ui tests
 	@docker run --rm -v "$(CURDIR):/workspace" -w /workspace/packages/chat-ui $(LLM_MESH_NODE_IMAGE) sh -lc 'rm -rf node_modules'
-	@docker run --rm -u "$$(id -u):$$(id -g)" -e HOME=/tmp -v "$(CURDIR):/workspace" -w /workspace/packages/chat-ui $(LLM_MESH_NODE_IMAGE) sh -lc 'set -eu; tool_dir="$$(mktemp -d)"; npm_config_cache=/tmp/npm-cache npm install --prefix "$$tool_dir" --no-save --no-audit --no-fund vitest@4.0.18 typescript@5.4.5 @types/node svelte@5.55.7 >/dev/null; mkdir -p node_modules; ln -sfn "$$tool_dir/node_modules/vitest" node_modules/vitest; ln -sfn "$$tool_dir/node_modules/svelte" node_modules/svelte; trap "rm -rf node_modules" EXIT; "$$tool_dir/node_modules/.bin/vitest" run tests --environment node'
+	@docker run --rm -u "$$(id -u):$$(id -g)" -e HOME=/tmp -v "$(CURDIR):/workspace" -w /workspace/packages/chat-ui $(LLM_MESH_NODE_IMAGE) sh -lc 'set -eu; tool_dir="$$(mktemp -d)"; npm_config_cache=/tmp/npm-cache npm install --prefix "$$tool_dir" --no-save --no-audit --no-fund vitest@4.0.18 typescript@5.4.5 @types/node svelte@5.55.7 >/dev/null; mkdir -p node_modules; ln -sfn "$$tool_dir/node_modules/vitest" node_modules/vitest; ln -sfn "$$tool_dir/node_modules/svelte" node_modules/svelte; trap "rm -rf node_modules" EXIT; "$$tool_dir/node_modules/.bin/vitest" run tests --environment node --exclude "tests/**/*.dom.spec.ts"'
+
+# BR-A0b-EX1 — additive jsdom DOM/ARIA test target for @sentropic/chat-ui Svelte 5 components.
+# Rationale: DOM/ARIA harness requires @sveltejs/vite-plugin-svelte + vite + jsdom +
+#   @testing-library/svelte@5 (Svelte-5-era), none of which are in the existing node-env target.
+#   Scope: additive only — does NOT modify the existing test-chat-ui target.
+# Impact: adds ~8 new npm packages installed at test time in an ephemeral docker container;
+#   no package.json devDependency changes; no version bump required (test-only infra).
+# Rollback: delete this target + tests/spike.dom.spec.ts + tests/model-selector.dom.spec.ts
+#   + tests/message-actions.dom.spec.ts + packages/chat-ui/vitest.config.ts.
+.PHONY: test-chat-ui-dom
+test-chat-ui-dom: ## Run @sentropic/chat-ui DOM/ARIA tests (jsdom, Svelte 5, BR-A0b-EX1)
+	@docker run --rm -v "$(CURDIR):/workspace" -w /workspace/packages/chat-ui $(LLM_MESH_NODE_IMAGE) sh -lc 'rm -rf node_modules'
+	@docker run --rm -u "$$(id -u):$$(id -g)" -e HOME=/tmp -v "$(CURDIR):/workspace" -w /workspace/packages/chat-ui $(LLM_MESH_NODE_IMAGE) sh -lc 'set -eu; tool_dir="$$(mktemp -d)"; npm_config_cache=/tmp/npm-cache npm install --prefix "$$tool_dir" --no-save --no-audit --no-fund vitest@4.0.18 typescript@5.4.5 @types/node svelte@5.55.7 vite@8.0.16 @sveltejs/vite-plugin-svelte@7.1.2 @testing-library/svelte@5.3.1 jsdom@29.1.1 "@lucide/svelte@0.562.0" >/dev/null; mkdir -p node_modules/@sveltejs node_modules/@testing-library node_modules/@lucide; ln -sfn "$$tool_dir/node_modules/vitest" node_modules/vitest; ln -sfn "$$tool_dir/node_modules/svelte" node_modules/svelte; ln -sfn "$$tool_dir/node_modules/vite" node_modules/vite; ln -sfn "$$tool_dir/node_modules/jsdom" node_modules/jsdom; ln -sfn "$$tool_dir/node_modules/@sveltejs/vite-plugin-svelte" node_modules/@sveltejs/vite-plugin-svelte; ln -sfn "$$tool_dir/node_modules/@sveltejs/acorn-typescript" node_modules/@sveltejs/acorn-typescript; ln -sfn "$$tool_dir/node_modules/@testing-library/svelte" node_modules/@testing-library/svelte; ln -sfn "$$tool_dir/node_modules/@testing-library/dom" node_modules/@testing-library/dom; ln -sfn "$$tool_dir/node_modules/@testing-library/svelte-core" node_modules/@testing-library/svelte-core; ln -sfn "$$tool_dir/node_modules/@lucide/svelte" node_modules/@lucide/svelte; trap "rm -rf node_modules" EXIT; "$$tool_dir/node_modules/.bin/vitest" run --config vitest.dom.config.ts'
 
 .PHONY: test-chat-server
 test-chat-server: ## Run @sentropic/chat-server tests

--- a/packages/chat-ui/tests/message-actions.dom.spec.ts
+++ b/packages/chat-ui/tests/message-actions.dom.spec.ts
@@ -1,0 +1,326 @@
+/**
+ * message-actions.dom.spec.ts — DOM/ARIA tests for @sentropic/chat-ui MessageActions.
+ *
+ * Tests: action buttons present per message role/state, ARIA labels, events fire on
+ * click, feedback toggle state.
+ *
+ * Environment: jsdom via vitest.config.ts (BR-A0b-EX1 target: test-chat-ui-dom).
+ * Does NOT affect the existing node-env test-chat-ui target.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import MessageActions from '../src/components/MessageActions.svelte';
+
+afterEach(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// User message — buttons present per role/state
+// ---------------------------------------------------------------------------
+
+describe('MessageActions — user message buttons', () => {
+  it('should render copy and edit buttons for a completed user message', () => {
+    render(MessageActions, {
+      props: {
+        role: 'user',
+        streamStatus: 'completed',
+        labels: (key: string) => key,
+      },
+    });
+    // Both action buttons have aria-labels matching the label keys
+    expect(screen.getByRole('button', { name: 'common.copy' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'chat.message.edit' })).not.toBeNull();
+  });
+
+  it('should NOT render any buttons for a user message that is still processing', () => {
+    const { container } = render(MessageActions, {
+      props: {
+        role: 'user',
+        streamStatus: 'processing',
+        labels: (key: string) => key,
+      },
+    });
+    const buttons = container.querySelectorAll('button');
+    expect(buttons.length).toBe(0);
+  });
+
+  it('should NOT render regenerate or feedback buttons for a user message', () => {
+    render(MessageActions, {
+      props: {
+        role: 'user',
+        streamStatus: 'completed',
+        labels: (key: string) => key,
+      },
+    });
+    expect(screen.queryByRole('button', { name: 'common.retry' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'chat.feedback.useful' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'chat.feedback.notUseful' })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Assistant message — buttons present per role/state
+// ---------------------------------------------------------------------------
+
+describe('MessageActions — assistant message buttons', () => {
+  it('should render copy, regenerate, and feedback buttons for the last assistant segment', () => {
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        labels: (key: string) => key,
+      },
+    });
+    expect(screen.getByRole('button', { name: 'common.copy' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'common.retry' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'chat.feedback.useful' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'chat.feedback.notUseful' })).not.toBeNull();
+  });
+
+  it('should NOT render any buttons when isLastAssistantSegment is false', () => {
+    const { container } = render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: false,
+        labels: (key: string) => key,
+      },
+    });
+    expect(container.querySelectorAll('button').length).toBe(0);
+  });
+
+  it('should NOT render any buttons while the assistant message is processing', () => {
+    const { container } = render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'processing',
+        isLastAssistantSegment: true,
+        labels: (key: string) => key,
+      },
+    });
+    expect(container.querySelectorAll('button').length).toBe(0);
+  });
+
+  it('should NOT render edit button for assistant messages', () => {
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        labels: (key: string) => key,
+      },
+    });
+    expect(screen.queryByRole('button', { name: 'chat.message.edit' })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ARIA labels
+// ---------------------------------------------------------------------------
+
+describe('MessageActions — ARIA labels', () => {
+  it('should apply labels from the injected resolver to button aria-label attributes', () => {
+    const labels = (key: string): string => {
+      const map: Record<string, string> = {
+        'common.copy': 'Copy message',
+        'common.retry': 'Retry',
+        'chat.feedback.useful': 'Helpful',
+        'chat.feedback.notUseful': 'Not helpful',
+      };
+      return map[key] ?? key;
+    };
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        labels,
+      },
+    });
+    expect(screen.getByRole('button', { name: 'Copy message' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Retry' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Helpful' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Not helpful' })).not.toBeNull();
+  });
+
+  it('should fall back to the key as aria-label when no labels resolver is provided', () => {
+    render(MessageActions, {
+      props: {
+        role: 'user',
+        streamStatus: 'completed',
+      },
+    });
+    // Without labels resolver, resolveLabel returns the key itself
+    expect(screen.getByRole('button', { name: 'common.copy' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'chat.message.edit' })).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Events fire on click
+// ---------------------------------------------------------------------------
+
+describe('MessageActions — events fire on click', () => {
+  it('should call onCopy when the copy button is clicked (user message)', async () => {
+    const onCopy = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'user',
+        streamStatus: 'completed',
+        onCopy,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'common.copy' }));
+    expect(onCopy).toHaveBeenCalledOnce();
+  });
+
+  it('should call onEdit when the edit button is clicked (user message)', async () => {
+    const onEdit = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'user',
+        streamStatus: 'completed',
+        onEdit,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'chat.message.edit' }));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+
+  it('should call onCopy when the copy button is clicked (assistant message)', async () => {
+    const onCopy = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        onCopy,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'common.copy' }));
+    expect(onCopy).toHaveBeenCalledOnce();
+  });
+
+  it('should call onRegenerate when the retry button is clicked', async () => {
+    const onRegenerate = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        onRegenerate,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'common.retry' }));
+    expect(onRegenerate).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feedback toggle
+// ---------------------------------------------------------------------------
+
+describe('MessageActions — feedback toggle', () => {
+  it('should call onFeedback("up") when thumbs-up is clicked with no current vote', async () => {
+    const onFeedback = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        feedbackVote: null,
+        onFeedback,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'chat.feedback.useful' }));
+    expect(onFeedback).toHaveBeenCalledWith('up');
+  });
+
+  it('should call onFeedback("clear") when thumbs-up is clicked again (toggle off)', async () => {
+    const onFeedback = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        feedbackVote: 1, // already voted up
+        onFeedback,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'chat.feedback.useful' }));
+    expect(onFeedback).toHaveBeenCalledWith('clear');
+  });
+
+  it('should call onFeedback("down") when thumbs-down is clicked with no current vote', async () => {
+    const onFeedback = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        feedbackVote: null,
+        onFeedback,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'chat.feedback.notUseful' }));
+    expect(onFeedback).toHaveBeenCalledWith('down');
+  });
+
+  it('should call onFeedback("clear") when thumbs-down is clicked again (toggle off)', async () => {
+    const onFeedback = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        feedbackVote: -1, // already voted down
+        onFeedback,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'chat.feedback.notUseful' }));
+    expect(onFeedback).toHaveBeenCalledWith('clear');
+  });
+
+  it('should call onFeedback("up") when thumbs-up is clicked and current vote is down', async () => {
+    const onFeedback = vi.fn();
+    render(MessageActions, {
+      props: {
+        role: 'assistant',
+        streamStatus: 'completed',
+        isLastAssistantSegment: true,
+        feedbackVote: -1, // currently voted down
+        onFeedback,
+        labels: (key: string) => key,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'chat.feedback.useful' }));
+    expect(onFeedback).toHaveBeenCalledWith('up');
+  });
+
+  it('should show copy-flash check icon when isCopied is true (user message)', () => {
+    const { container } = render(MessageActions, {
+      props: {
+        role: 'user',
+        streamStatus: 'completed',
+        isCopied: true,
+        labels: (key: string) => key,
+      },
+    });
+    // When isCopied is true, the copy button shows a Check icon (not Copy icon)
+    // We verify it via the button's aria-label still being present (same button)
+    const copyBtn = screen.getByRole('button', { name: 'common.copy' });
+    expect(copyBtn).not.toBeNull();
+    // The button should exist — Check icon shown instead of Copy icon (SVG swap)
+    // We can't query SVG icons directly, but can verify the button wrapper is there
+    expect(container.querySelectorAll('.chat-message-action-button').length).toBeGreaterThan(0);
+  });
+});

--- a/packages/chat-ui/tests/model-selector.dom.spec.ts
+++ b/packages/chat-ui/tests/model-selector.dom.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * model-selector.dom.spec.ts — DOM/ARIA tests for @sentropic/chat-ui ModelSelector.
+ *
+ * Tests the native <select> semantics: optgroups, provider::model composite value
+ * binding, change event, and a11y (aria-label, keyboard).
+ *
+ * Environment: jsdom via vitest.config.ts (BR-A0b-EX1 target: test-chat-ui-dom).
+ * Does NOT affect the existing node-env test-chat-ui target.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ModelSelector from '../src/components/ModelSelector.svelte';
+import type { ModelCatalogGroup, ModelCatalogModel } from '../src/utils/model-selection.js';
+import { groupModelsByProvider } from '../src/utils/model-selection.js';
+
+afterEach(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROVIDERS = [
+  { provider_id: 'openai' as const, label: 'OpenAI', status: 'ready' as const },
+  { provider_id: 'anthropic' as const, label: 'Anthropic', status: 'ready' as const },
+  { provider_id: 'gemini' as const, label: 'Gemini', status: 'planned' as const },
+];
+
+const MODELS: ModelCatalogModel[] = [
+  { provider_id: 'openai', model_id: 'gpt-4o', label: 'GPT-4o', default_contexts: [] },
+  { provider_id: 'openai', model_id: 'gpt-4.1-nano', label: 'GPT-4.1 Nano', default_contexts: [] },
+  { provider_id: 'anthropic', model_id: 'claude-opus-4', label: 'Claude Opus 4', default_contexts: [] },
+  { provider_id: 'gemini', model_id: 'gemini-2.0-flash', label: 'Gemini 2.0 Flash', default_contexts: [] },
+];
+
+const GROUPS: ModelCatalogGroup[] = groupModelsByProvider(PROVIDERS, MODELS);
+
+// ---------------------------------------------------------------------------
+// Native <select> semantics
+// ---------------------------------------------------------------------------
+
+describe('ModelSelector — native <select> semantics', () => {
+  it('should render a native <select> element (not a custom listbox)', () => {
+    render(ModelSelector, { props: { value: '', groups: [], models: [], widthCh: 18 } });
+    const select = screen.getByRole('combobox');
+    expect(select.tagName.toLowerCase()).toBe('select');
+  });
+
+  it('should have id="chat-model-selection"', () => {
+    const { container } = render(ModelSelector, {
+      props: { value: 'openai::gpt-4o', groups: GROUPS, models: MODELS, widthCh: 18 },
+    });
+    const select = container.querySelector('#chat-model-selection');
+    expect(select).not.toBeNull();
+  });
+
+  it('should render <optgroup> elements for each provider', () => {
+    const { container } = render(ModelSelector, {
+      props: { value: 'openai::gpt-4o', groups: GROUPS, models: MODELS, widthCh: 18 },
+    });
+    const optgroups = container.querySelectorAll('optgroup');
+    expect(optgroups.length).toBe(3);
+    expect(optgroups[0].getAttribute('label')).toBe('OpenAI');
+    expect(optgroups[1].getAttribute('label')).toBe('Anthropic');
+    // Gemini is 'planned' — providerGroupLabel appends status
+    expect(optgroups[2].getAttribute('label')).toBe('Gemini (planned)');
+  });
+
+  it('should render <option> elements for each model inside the correct optgroup', () => {
+    const { container } = render(ModelSelector, {
+      props: { value: 'openai::gpt-4o', groups: GROUPS, models: MODELS, widthCh: 18 },
+    });
+    const openaiGroup = container.querySelector('optgroup[label="OpenAI"]');
+    const options = openaiGroup?.querySelectorAll('option');
+    expect(options?.length).toBe(2);
+
+    // Option values must be 'provider::model' composite keys
+    const values = Array.from(options ?? []).map((o) => (o as HTMLOptionElement).value);
+    expect(values).toContain('openai::gpt-4o');
+    expect(values).toContain('openai::gpt-4.1-nano');
+  });
+
+  it('should apply min-width style from widthCh prop', () => {
+    const { container } = render(ModelSelector, {
+      props: { value: '', groups: GROUPS, models: MODELS, widthCh: 24 },
+    });
+    const select = container.querySelector('#chat-model-selection') as HTMLSelectElement;
+    expect(select?.style.minWidth).toBe('24ch');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider::model composite value binding
+// ---------------------------------------------------------------------------
+
+describe('ModelSelector — provider::model value binding', () => {
+  it('should reflect the passed value prop as selected option value', () => {
+    const { container } = render(ModelSelector, {
+      props: { value: 'anthropic::claude-opus-4', groups: GROUPS, models: MODELS, widthCh: 18 },
+    });
+    const select = container.querySelector('#chat-model-selection') as HTMLSelectElement;
+    expect(select?.value).toBe('anthropic::claude-opus-4');
+  });
+
+  it('should show fallback option when groups is empty and models has matching entry', () => {
+    const { container } = render(ModelSelector, {
+      props: { value: 'openai::gpt-4o', groups: [], models: MODELS, widthCh: 18 },
+    });
+    const options = container.querySelectorAll('option');
+    // Only one fallback option rendered when groups is empty
+    expect(options.length).toBe(1);
+    expect((options[0] as HTMLOptionElement).value).toBe('openai::gpt-4o');
+    expect(options[0].textContent).toBe('GPT-4o');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Change event
+// ---------------------------------------------------------------------------
+
+describe('ModelSelector — change event', () => {
+  it('should call onChange with parsed { providerId, modelId } when selection changes', async () => {
+    const onChange = vi.fn();
+    const { container } = render(ModelSelector, {
+      props: {
+        value: 'openai::gpt-4o',
+        groups: GROUPS,
+        models: MODELS,
+        widthCh: 18,
+        onChange,
+      },
+    });
+    const select = container.querySelector('#chat-model-selection') as HTMLSelectElement;
+    // Simulate user picking anthropic::claude-opus-4
+    await fireEvent.change(select, { target: { value: 'anthropic::claude-opus-4' } });
+    expect(onChange).toHaveBeenCalledOnce();
+    expect(onChange).toHaveBeenCalledWith({ providerId: 'anthropic', modelId: 'claude-opus-4' });
+  });
+
+  it('should NOT call onChange when the new value does not parse to a valid pair', async () => {
+    const onChange = vi.fn();
+    const { container } = render(ModelSelector, {
+      props: {
+        value: 'openai::gpt-4o',
+        groups: GROUPS,
+        models: MODELS,
+        widthCh: 18,
+        onChange,
+      },
+    });
+    const select = container.querySelector('#chat-model-selection') as HTMLSelectElement;
+    // Simulate an invalid selection (missing separator)
+    await fireEvent.change(select, { target: { value: 'invalid-value' } });
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ARIA / a11y
+// ---------------------------------------------------------------------------
+
+describe('ModelSelector — ARIA', () => {
+  it('should expose the native select as role="combobox" (a11y tree)', () => {
+    render(ModelSelector, { props: { value: '', groups: GROUPS, models: MODELS, widthCh: 18 } });
+    // screen.getByRole throws if element not found — acts as assertion
+    const el = screen.getByRole('combobox');
+    expect(el).not.toBeNull();
+  });
+
+  it('should have aria-label set via the labels resolver', () => {
+    render(ModelSelector, {
+      props: {
+        value: '',
+        groups: [],
+        models: [],
+        widthCh: 18,
+        labels: (_key: string) => 'Choose a model',
+      },
+    });
+    // Named combobox should be accessible by its label
+    const el = screen.getByRole('combobox', { name: 'Choose a model' });
+    expect(el).not.toBeNull();
+  });
+
+  it('should fall back to the label key as aria-label when no resolver provided', () => {
+    render(ModelSelector, { props: { value: '', groups: [], models: [], widthCh: 18 } });
+    const el = screen.getByRole('combobox', { name: 'chat.model.selector.label' });
+    expect(el).not.toBeNull();
+  });
+
+  it('should be keyboard-accessible as a native select (focus + aria-label)', () => {
+    render(ModelSelector, {
+      props: {
+        value: 'openai::gpt-4o',
+        groups: GROUPS,
+        models: MODELS,
+        widthCh: 18,
+        labels: (_key: string) => 'Model',
+      },
+    });
+    const select = screen.getByRole('combobox', { name: 'Model' }) as HTMLSelectElement;
+    select.focus();
+    expect(document.activeElement).toBe(select);
+    // Verify the element is a native select — keyboard navigation provided by browser
+    expect(select.tagName.toLowerCase()).toBe('select');
+  });
+});

--- a/packages/chat-ui/tests/spike.dom.spec.ts
+++ b/packages/chat-ui/tests/spike.dom.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * spike.dom.spec.ts — Minimal jsdom spike for @sentropic/chat-ui Svelte 5 components.
+ *
+ * Proves that a Svelte 5 component renders in vitest+jsdom via @testing-library/svelte@5.
+ * This is the A0b feasibility spike; if GREEN, the full harness is viable.
+ */
+import { render, screen, cleanup } from '@testing-library/svelte';
+import { flushSync } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Import the simplest component that has no icon peer-deps.
+import ModelSelector from '../src/components/ModelSelector.svelte';
+
+afterEach(() => cleanup());
+
+describe('jsdom spike — ModelSelector renders', () => {
+  it('should render a <select> element with id="chat-model-selection"', () => {
+    const { container } = render(ModelSelector, {
+      props: {
+        value: '',
+        groups: [],
+        models: [],
+        widthCh: 18,
+      },
+    });
+    const select = container.querySelector('#chat-model-selection');
+    expect(select).not.toBeNull();
+    expect(select?.tagName.toLowerCase()).toBe('select');
+  });
+
+  it('should expose the select via ARIA role combobox', () => {
+    render(ModelSelector, {
+      props: { value: '', groups: [], models: [], widthCh: 18 },
+    });
+    // Native <select> is a combobox in ARIA
+    const select = screen.getByRole('combobox');
+    expect(select).not.toBeNull();
+    expect(select.tagName.toLowerCase()).toBe('select');
+  });
+
+  it('should set aria-label on the <select> (fallback: key when no resolver)', () => {
+    render(ModelSelector, {
+      props: { value: '', groups: [], models: [], widthCh: 18 },
+    });
+    // Native <select> with aria-label renders as a named combobox
+    const select = screen.getByRole('combobox', { name: 'chat.model.selector.label' });
+    expect(select).not.toBeNull();
+    expect(select.tagName.toLowerCase()).toBe('select');
+  });
+});

--- a/packages/chat-ui/vitest.dom.config.ts
+++ b/packages/chat-ui/vitest.dom.config.ts
@@ -1,0 +1,61 @@
+/**
+ * vitest.dom.config.ts — jsdom harness for @sentropic/chat-ui DOM/ARIA tests.
+ *
+ * This config is ONLY active for *.dom.spec.ts files (jsdom environment).
+ * The existing node-environment tests run via `vitest run tests --environment node`
+ * (no config file — vitest's default inline env override) and are NOT affected.
+ *
+ * BR-A0b-EX1: requires @sveltejs/vite-plugin-svelte + vite + jsdom +
+ * @testing-library/svelte@5 + @lucide/svelte (added as dev-deps
+ * in the test-chat-ui-dom Makefile target, NOT in package.json devDependencies).
+ *
+ * Spike findings (iterative):
+ * 1. "rune_outside_svelte": @testing-library/svelte-core/props.svelte.js was not
+ *    transformed. Fix: server.deps.inline + ssr.noExternal.
+ * 2. "lifecycle_function_unavailable - mount not available on server": Svelte resolved
+ *    the SSR build. Fix: resolve.conditions = ['browser', ...].
+ * 3. "@lucide/svelte icons resolve to .svelte files": @lucide/svelte has an "Icon.svelte"
+ *    component at its root + icons in dist/icons/*.svelte. The vite-plugin-svelte
+ *    (exclude: []) handles these; alias forces .js resolution for dist icons.
+ */
+import { svelte } from '@sveltejs/vite-plugin-svelte';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [
+    svelte({
+      // Remove the default node_modules exclusion so that
+      // @testing-library/svelte-core/src/props.svelte.js is Svelte-compiled.
+      exclude: [],
+    }),
+  ],
+  resolve: {
+    // Force the browser/module conditions so Svelte's client build is used
+    // (not index-server.js) even when ssr.noExternal is set.
+    // IMPORTANT: do NOT include "svelte" condition here to avoid @lucide/svelte
+    // resolving to .svelte source files that require additional compilation.
+    conditions: ['browser', 'module', 'import', 'default'],
+  },
+  ssr: {
+    // Force these packages to be bundled through vite (not treated as external),
+    // so the Svelte plugin can transform props.svelte.js at test time.
+    noExternal: [
+      '@testing-library/svelte',
+      '@testing-library/svelte-core',
+      '@lucide/svelte',
+    ],
+  },
+  test: {
+    // jsdom environment for DOM/ARIA tests
+    environment: 'jsdom',
+    // Only run *.dom.spec.ts files through this config
+    include: ['tests/**/*.dom.spec.ts'],
+    server: {
+      deps: {
+        // Inline these packages so vitest processes them through vite transforms
+        // (the Svelte plugin must compile .svelte and .svelte.js files from these).
+        inline: [/@testing-library\/svelte/, /@lucide\/svelte/],
+      },
+    },
+  },
+});


### PR DESCRIPTION
WP-CHAT Wave-A lot A0b (rung-2 parity harness).

**Salvaged**: a Sonnet subagent solved the Svelte-5 + jsdom render spike (server.deps.inline for testing-library runes; resolve.conditions=['browser'] for `mount`; @lucide/svelte handling) but hit a stream-idle timeout before committing. Orchestrator verified both gates green and committed.

- New `test-chat-ui-dom` make target (jsdom, Svelte 5, @testing-library/svelte@5) — **BR-A0b-EX1** (additive Makefile target; rationale/impact/rollback documented in the target comment).
- `vitest.dom.config.ts` (jsdom env, `*.dom.spec.ts` only; the existing node target gets a `--exclude` so it is unaffected).
- DOM/ARIA tests: spike (3) + ModelSelector (13) + MessageActions (19) = **35 DOM tests green**.
- Node target still **241 tests green** (unchanged).

**Tier-1**: touches the Makefile (broad CI trigger) — verify full CI before merge (validate-contracts/events/chat-core may need a re-run if they flake on the Makefile-change trigger).

rung-3 (visual screenshot tooling: Storybook vs Playwright-CT vs static route) is **DEFERRED to an owner decision** — not in this PR.
