### PR TITLE
fix(ci): build api-image on ui-only PRs (unblock e2e green)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -550,18 +550,18 @@ jobs:
     needs: [changes]
     steps:
       - uses: actions/checkout@v6
-        if: needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
       - name: Setup Docker
-        if: needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         uses: docker/setup-buildx-action@v4
       - name: Build API image
-        if: needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         run: make build-api
       - name: Save API image as artifact
-        if: needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         run: make save-api
       - name: Upload API image artifact
-        if: needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
+        if: needs.changes.outputs.ui == 'true' || needs.changes.outputs.api == 'true' || needs.changes.outputs.global == 'true'
         uses: actions/upload-artifact@v7
         with:
           name: api-image


### PR DESCRIPTION
## Bug
For **ui-only PRs**, the `build-api-image` job's steps were all gated on `api || global`, so they were SKIPPED → no `api-image` artifact produced. But the e2e jobs run whenever `ui` changes and need that artifact → they failed with `Artifact not found: api-image` / `pull-api-image Error 1` → **red CI on every ui-only PR** (e.g. the chat-ui app retrofit #219).

## Fix
Add `ui == 'true'` to the `build-api-image` step conditions so the api-image artifact is built + uploaded whenever the e2e jobs run (ui OR api OR global). Minimal, additive — mirrors the existing `build-ui`/`build-e2e` conditions which already include `ui`.

## Validation
This PR changes only `ci.yml` (global) → `build-api-image` builds + e2e runs against unmodified app code → a GREEN run proves the artifact plumbing is fixed end-to-end. Unblocks #219 (and all future ui-only PRs) so they can go green before merge.
