### PR TITLE
Fix: Chat Loop Guard

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -104,17 +104,17 @@ Reapply the repeated-tool-error loop breaker (chat-core dispatch breaker + chat-
     - [x] `make typecheck-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
     - [x] `make test-pkg-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard` (21 files, 248 tests; `runtime-tool-dispatch.test.ts` 22 → 25 tests)
 
-- [ ] **Lot 2 — chat-service outer-loop sync line**
-  - [ ] Read `api/src/services/chat-service.ts` around the post-`consumeToolCalls` "thin invocation + state sync" block (~ L3800-3830 on current main): identify the exact location after `streamSeq`/`contextBudgetReplanAttempts` are synced back.
-  - [ ] Add `continueGenerationLoop = loopState.continueGenerationLoop;` immediately after the existing sync of `streamSeq` and `contextBudgetReplanAttempts` so the outer `while (continueGenerationLoop)` honors the breaker's stop signal.
-  - [ ] Add regression test `should stop repeated identical tool validation errors before the max-iteration fallback` in `api/tests/unit/chat-service-tools.test.ts`:
-    - [ ] Mock `callLLMStream` to always emit a `plan` tool call with invalid `{action:'unknown'}` args when tools are enabled.
-    - [ ] Assert `calls.length === 4` (3 tool-enabled attempts + 1 pass-2 with `toolChoice: 'none'`).
-    - [ ] Confirm the pre-existing `should continue beyond 10 iterations when active TODO can progress without user input` still passes (legitimate progression untouched).
-  - [ ] Lot gate:
-    - [ ] `make typecheck-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
-    - [ ] `make lint-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
-    - [ ] `make test-api-unit SCOPE=tests/unit/chat-service-tools.test.ts API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+- [x] **Lot 2 — chat-service outer-loop sync line**
+  - [x] Read `api/src/services/chat-service.ts` around the post-`consumeToolCalls` "thin invocation + state sync" block (L3887-3893 on current main): identified insertion after `streamSeq`/`contextBudgetReplanAttempts` are synced back.
+  - [x] Add `continueGenerationLoop = loopState.continueGenerationLoop;` immediately after the existing sync of `streamSeq` and `contextBudgetReplanAttempts` so the outer `while (continueGenerationLoop)` honors the breaker's stop signal.
+  - [x] Add regression test `should stop repeated identical tool validation errors before the max-iteration fallback` in `api/tests/unit/chat-service-tools.test.ts`:
+    - [x] Mock `callLLMStream` to always emit a `plan` tool call with invalid `{action:'unknown'}` args when tools are enabled.
+    - [x] Assert `calls.length === 4` (3 tool-enabled attempts + 1 pass-2 with `toolChoice: 'none'`).
+    - [x] Confirm the pre-existing `should continue beyond 10 iterations when active TODO can progress without user input` still passes (legitimate progression untouched).
+  - [x] Lot gate:
+    - [x] `make typecheck-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [x] `make lint-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [x] `make test-api-unit SCOPE=tests/unit/chat-service-tools.test.ts API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard` (17 tests, including the new `should stop repeated identical tool validation errors before the max-iteration fallback`)
 
 - [ ] **Lot 3 — chat-ui stream projection compaction** *(deferred)*
   - On-main analysis: `packages/chat-ui/src/utils/chat-run-projection.ts` (200 LOC) already deduplicates by `sequence` in both `appendLiveProjectionEvent` (line 198) and `mergeProjectionHistoryEvents` (Map by sequence). The original PR #183 compaction targeted the live unbounded delta flood. With the Lot 1 backend breaker capping repeated identical tool errors at **3 attempts + 1 pass-2 = 4 LLM calls** per turn, the flood is structurally bounded upstream — the secondary UI compaction is speculative without direct evidence on current main.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,175 +1,159 @@
-# Feature: BR-39d — Service-to-Service Auth (client_credentials + @sentropic/auth-client)
+# Fix: Chat Loop Guard
 
 ## Objective
-Add OAuth2 `client_credentials` grant to the Sentropic IdP so backend services (paas, immo-api, diag-api) mint scoped, audience-bound, stateless access tokens without a human, expose a `@sentropic/auth-client` Node helper for consumers, and ship a `createRequireServiceAuth` Hono middleware for resource servers — DPoP opt-in, RFC 8707 resource indicators, single migration, no change to the shipped `oauth_tokens` table.
+Reapply the repeated-tool-error loop breaker (chat-core dispatch breaker + chat-service outer-loop sync) plus the chat-ui stream projection compaction on current `main`, after BR-38a/BR-41a refactored the dispatch into `ChatRuntime.consumeToolCalls`. Prevent repeated tool-call/tool-error loops from freezing or saturating the browser tab while preserving legitimate multi-step tool use.
 
 ## Scope / Guardrails
-- Scope limited to S2S auth: `packages/auth-hono`, new `packages/auth-client`, `api` host wiring (schema + adapter + one protected route + one outbound consumer + scripts), tests, CI/Make parity.
-- One migration max in `api/drizzle/*.sql` → `0029_service_clients.sql` (0028 already taken by chat attachments; `0029` confirmed as next free number).
-- Service tokens are **stateless** (`BR39d-D5`): no row in `oauth_tokens`, no change to its `user_id`/FK constraints. Revocation/introspection of service tokens deferred to BR-39h.
-- Make-only workflow, no direct Docker commands. `ENV=<env>` last argument always.
-- Root workspace `~/src/sentropic` reserved for user dev/UAT (`ENV=dev`) — must stay stable; never test on `ENV=dev`.
-- Branch development happens in isolated worktree `tmp/feat-auth-s2s` only.
-- Automated test campaigns run on `ENV=test-feat-auth-s2s` / `ENV=e2e-feat-auth-s2s`, never on root `dev`.
-- No breaking changes to `@sentropic/auth-hono` public surface — extend `OauthStateStorePort` and exports additively/optionally only.
-- All new text in English.
+- Scope limited to chat assistant turn execution, tool-call error handling, chat stream projection, chat rendering, and focused tests.
+- No database migration planned.
+- Make-only workflow, no direct Docker/npm commands.
+- Root workspace `/home/antoinefa/src/sentropic` is reserved for user dev/UAT (`ENV=dev`) and must remain stable.
+- Branch development happens in isolated worktree `tmp/fix-chat-loop-guard`.
+- Automated test campaigns must run on dedicated environments, never on root `dev`.
+- In every `make` command, `ENV=<env>` must be passed as the last argument.
+- All new text in code, docs, tests, commits, and PR body must be English.
+- Start by reading current `ChatRuntime.consumeToolCalls` structure before reimplementing; do not pattern-match the closed PR #183 diff blindly — the post-Lot-21e-2 dispatch lives inside chat-core now.
+- Do not add arbitrary timeouts or hide tool errors from the user.
+- Do not introduce a generic max-iteration cap; the guard must trigger only on signature-repeated errors.
 
 ## Branch Scope Boundaries (MANDATORY)
 - **Allowed Paths (implementation scope)**:
-  - `packages/auth-hono/src/**`
-  - `packages/auth-hono/tests/**`
-  - `packages/auth-hono/README.md`
-  - `packages/auth-hono/package.json`
-  - `packages/auth-client/**` (new package)
-  - `api/src/db/schema.ts`
-  - `api/src/services/auth/**`
-  - `api/src/routes/auth/**`
-  - `api/src/scripts/**`
-  - `api/tests/api/auth/**`
-  - `api/tests/unit/auth/**`
-  - `e2e/tests/02-auth-s2s-*.spec.ts`
-  - `docs/secrets.md` (S2S env vars + rotation runbook)
+  - `BRANCH.md`
+  - `package-lock.json`
+  - `api/src/services/chat-service.ts`
+  - `api/tests/unit/chat-service-tools.test.ts`
+  - `packages/chat-core/src/runtime-tool-dispatch.ts`
+  - `packages/chat-core/src/runtime.ts`
+  - `packages/chat-core/src/runtime-run-prepare.ts`
+  - `packages/chat-core/tests/runtime-tool-dispatch.test.ts`
+  - `packages/chat-core/package.json`
+  - `packages/chat-ui/src/utils/chat-run-projection.ts`
+  - `packages/chat-ui/src/client/streamHistory.ts`
+  - `packages/chat-ui/tests/stream-throughput.test.ts`
+  - `packages/chat-ui/tests/chat-run-projection.test.ts`
+  - `packages/chat-ui/package.json`
+  - `ui/tests/utils/chat-run-projection.test.ts`
 - **Forbidden Paths (must not change in this branch)**:
+  - `Makefile`
   - `docker-compose*.yml`
   - `.cursor/rules/**`
-  - `plan/NN-BRANCH_*.md` (except this branch file)
-  - any `ui/**` (S2S is server-side only, no UI surface in 39d)
-- **Conditional Paths (allowed only with declared `BR39d-EXn` exception)**:
-  - `api/drizzle/0029_service_clients.sql` (max 1 migration file) → `BR39d-EX3`
-  - `.github/workflows/ci.yml` (validate/publish-auth-client lanes, filters, bootstrap enum) → `BR39d-EX2`
-  - `Makefile` (auth-client targets + `oauth-rotate-service-client`) → `BR39d-EX1`
-  - root `package.json` / `package-lock.json` (workspace registration of new package) → `BR39d-EX4`
-  - `api/Dockerfile` (COPY + build wiring so `api` imports `@sentropic/auth-client`) → `BR39d-EX5`
+  - `packages/skills/**`
+  - `plan/NN-BRANCH_*.md` (any branch file)
+- **Conditional Paths (allowed only with explicit exception)**:
+  - `api/drizzle/*.sql`
+  - `.github/workflows/**`
+  - `api/src/services/llm-runtime/**`
+  - `api/src/routes/**`
+  - `e2e/tests/03-chat.spec.ts`
+  - `e2e/tests/06-streams.spec.ts`
+  - `e2e/tests/08-chat-heavy.spec.ts`
+  - `ui/src/lib/components/chat/**`
+  - `ui/src/lib/stores/streamHub.ts`
+  - `spec/**`
 - **Exception process**:
-  - Declare exception ID `BR39d-EXn` in `## Feedback Loop` before touching any conditional/forbidden path.
+  - Declare exception ID `CLG2-EXn` in `## Feedback Loop` before touching any conditional or forbidden path.
   - Include reason, impact, and rollback strategy.
 
 ## Feedback Loop
-Actions with the following status should be included around tasks only if really required.
-
-**Conductor resolutions (2026-06-02, after local gates green):**
-- `BR39d-Q1` — **RESOLVED**: host `docker network prune -f` freed the IPv4 pool; `make typecheck-api` ✅, `make lint-api` ✅ (0 errors), `make test-api ENV=test-feat-auth-s2s` ✅ **493/493** (1 evolution fixed: wellknown `grant_types_supported` assertion).
-- `BR39d-Q2` — **RESOLVED**: `seedServiceClients()` wired into `api/tests/utils/seed-test-data.ts` (1-line micro-exception, conductor-approved; type-safe `SeededServiceClient[]`).
-- `BR39d-Q3` — **RESOLVED via `BR39d-EX6`**: auth-ui peer widened to `^0.3.0 || ^0.4.0` + auth-ui patch-bump `0.3.0→0.3.1`; `make lock-root` clean (ERESOLVE gone).
-- `BR39d-EX6` (packages/auth-ui/package.json) — **acknowledge** (conductor): widen `@sentropic/auth-hono` peer + patch bump, directly necessitated by the auth-hono `0.4.0` minor. Impact: additive/reversible, no auth-ui src change. Rollback: revert peer + version.
-- `BR39d-EX7` (api/src/config/env.ts) — **RATIFIED** (conductor): additive optional S2S env vars; project convention centralizes env validation in `env.ts`.
-- Package gates: `make test-auth-hono` ✅ 101, `make test-auth-client` ✅ 7, builds + packs ✅.
-
-- `BR39d-Q3` (auth-hono 0.4.0 bump breaks auth-ui peer, OPEN, BLOCKING the lockfile/bump gate) — Bumping `@sentropic/auth-hono` 0.3.0 → 0.4.0 (per Lot N + required by the touched `src/**`) breaks the workspace lockfile: `@sentropic/auth-ui@0.3.0` declares `peerDependencies: { "@sentropic/auth-hono": "^0.3.0" }`, and `^0.3.0` excludes `0.4.0`. `make lock-root` fails with ERESOLVE. `packages/auth-ui/**` is a Forbidden Path and BRANCH.md says "auth-ui unchanged", so I did NOT edit it. Options: **(A, recommended)** widen auth-ui peer to `"^0.3.0 || ^0.4.0"` + patch-bump auth-ui 0.3.0→0.3.1 (additive, reversible; needs a Forbidden-path exception `BR39d-EX6`), then `make lock-root`; **(B)** keep auth-hono at a 0.3.x bump (e.g. 0.3.1) — but a new grant + new middleware is a feature and warrants a minor, so this is wrong semver; **(C)** `--legacy-peer-deps` — rejected, masks a real ERESOLVE that npm consumers of auth-ui@0.3.0 + auth-hono@0.4.0 would also hit. The auth-hono `package.json` is left at `0.4.0` (correct per spec). Conductor must pick A (preferred) and run `make lock-root` to finalize the lockfile, OR direct option B. Until resolved, the lockfile is NOT regenerated for the 0.4.0 bump.
-- `BR39d-Q2` (e2e seed wiring, OPEN, needs micro-EX) — The optional E2E spec `e2e/tests/02-auth-s2s-client-credentials.spec.ts` needs the e2e DB to contain the `example-service-rp` service client. Seeding happens in `api/tests/utils/seed-test-data.ts` (calls `seedOAuthClients()`), which is OUTSIDE this branch's Allowed Paths. To run the E2E lane, add one line `await seedServiceClients();` next to the existing `seedOAuthClients()` call (import from `../../src/services/auth/oauth-client-seed`). Recommendation: conductor approves a 1-line micro-exception (or folds it into `api/tests/utils` allowance) since the seed helper is already implemented and exported. Non-blocking for unit/integration gates; only gates the optional E2E lane.
-- `BR39d-Q1` (infra blocker, OPEN) — Host Docker IPv4 network pool exhausted: every compose-network target (`make typecheck-api`, `make test-api`, dev/e2e stacks) fails with `could not find an available, non-overlapping IPv4 address pool`. Remedy is `docker network prune` but raw `docker` is blocked by the agent sandbox and no `make` target prunes networks. Package-only gates (`make typecheck-auth-hono`, `make test-auth-hono`, `make build-auth-hono`, `make pack-auth-hono`, `make typecheck-auth-client`, `make test-auth-client`) use `docker run` (no network) and PASS. Conductor must `docker network prune -f` on the host (non-destructive, preserves volumes), then re-run the api/e2e gates. All source for api/CI/Make/docs lots is written and committed; only the api-runtime test/typecheck execution is pending.
-- `BR39d-EX1` (Makefile) — `acknowledge`: new npm package requires make wiring per make-only rule. Targets added: `typecheck-auth-client`, `test-auth-client`, `build-auth-client`, `pack-auth-client`, `publish-auth-client`, `publish-auth-client-token`, `oauth-rotate-service-client`. Impact: additive targets only, mirrors `*-auth-hono` exactly. Rollback: delete the added targets.
-- `BR39d-EX2` (.github/workflows/ci.yml) — `acknowledge`: new package needs CI parity. Adds `auth_client` + `auth_client_publish` path filters, `validate-auth-client` job (mirror of `validate-auth-hono`), `publish-auth-client` job (mirror of `publish-auth-hono`), `auth-client` to `bootstrap_publish_target` enum + bootstrap step. Impact: additive jobs, no change to existing lanes. Rollback: revert the additions.
-- `BR39d-EX3` (api/drizzle/0029_service_clients.sql) — `acknowledge`: single migration creating `service_clients` only (no `oauth_tokens` ALTER, per `BR39d-D5`). Within template's one-migration-max. Also touches `api/drizzle/meta/_journal.json` (add idx-29 entry) — the drizzle migrator (`drizzle-orm/node-postgres/migrator`) reads `_journal.json`, so the hand-written migration cannot apply without this companion line. Rollback: drop migration + table + journal entry.
-- `BR39d-EX7` (api/src/config/env.ts) — `acknowledge` (NEW, beyond declared EX1-EX5): added S2S env vars `OAUTH_SERVICE_ACCESS_TOKEN_TTL_SEC` (default 900), `OAUTH_SERVICE_RESOURCE_URI`, `OAUTH_SELF_SERVICE_CLIENT_ID`, `OAUTH_SELF_SERVICE_CLIENT_SECRET`. `api/src/config/**` is not in the declared Allowed Paths, but the project's pattern centralizes all env validation in `env.ts` (reading `process.env` directly would violate that convention). Impact: additive zod fields only, all optional/defaulted — no behavior change to existing routes. Rollback: remove the four fields. Conductor: please ratify or relocate.
-- `BR39d-EX4` (root package.json/package-lock.json) — `acknowledge`: register `@sentropic/auth-client` in npm workspace so `api` consumes it. Impact: workspace member add + lockfile. Rollback: remove member.
-- `BR39d-EX5` (api/Dockerfile) — `acknowledge`: `api` imports `@sentropic/auth-client` (dogfood S2S consumer, `BR39d-D10`) → Dockerfile must COPY `packages/auth-client/package.json` + build it in the workspace step, mirroring the existing auth-hono lines. Impact: additive COPY/build lines only. Rollback: remove them.
-
-**Decisions (frozen for 39d, dual-review gated — Opus 4.8 + Codex 5.5-high, 2026-06-01):**
-- `BR39d-D1` — **DPoP for service clients = opt-in** via `service_clients.dpop_bound_access_tokens boolean default false`. Consistent with `BR39c-D2` (mandatory only for `type ∈ {agent,nhi,mcp_connector}` arriving in 39h). README documents a strong recommendation to enable for production S2S. Reversible.
-- `BR39d-D2` — **Secret rotation = make target** `make oauth-rotate-service-client CLIENT_ID=<id> ENV=<env>`: generates a new secret, prints it once, replaces `client_secret_hash`, stamps `secret_rotated_at`. Single-secret immediate cutover (operator coordinates consumer redeploy). Zero-downtime dual-secret grace window + admin UI deferred to BR-39g/39h. Reversible.
-- `BR39d-D3` — **`@sentropic/auth-client` = Node-only** (server-side consumers). Uses `jose` + Node WebCrypto. Browser variant deferred (`39d-bis`). Reversible.
-- `BR39d-D4` — **`aud` = RFC 8707 strict resource indicators**. `service_clients.resource_indicators text[]` lists allowed audiences. Token request carries `resource=<uri>`; issued access-token `aud` = that resource and MUST be in the client's `resource_indicators`. Resolution rule: 1 indicator + no `resource` ⇒ use it; >1 indicator + no `resource` ⇒ `invalid_target`; 0 indicators ⇒ `resource` required else `invalid_target`; requested `resource` not in list ⇒ `invalid_target`. `createRequireServiceAuth({requiredScopes, resource})` validates `aud === its own resource`. Reversible.
-- `BR39d-D5` — **Service tokens are STATELESS** (user decision, 2026-06-01). `client_credentials` issues a signed Ed25519 JWT and does NOT call `saveTokenMeta` → no `oauth_tokens` row, no schema/FK change to the shipped table. Security control = short TTL (`OAUTH_SERVICE_ACCESS_TOKEN_TTL_SEC`, default `900`) + DPoP recommendation. Revocation + introspection of service tokens are **deferred to BR-39h** (which reworks token tables under the unified identities model). Resource servers verify statelessly via JWKS, so no DB dependency. Consequence: no immediate kill-switch before expiry — mitigated by short TTL + secret rotation (stops new tokens). `TokenMeta.userId` is NOT widened (no service rows persisted). Reversible.
-- `BR39d-D6` — **Narrow port for `createRequireServiceAuth`** (Opus M5, co-design lesson `feedback_contract_consumer_codesign`): accept `ServiceAuthPorts = Pick<AuthHonoPorts, 'jwks' | 'clock'> & { dpopReplay?: Pick<OauthStateStorePort, 'recordDpopJti'> }` — NOT the full 15-port `AuthHonoPorts`. RS consumers must not construct users/credentials/sessions/email ports just to verify a bearer token. Reversible.
-- `BR39d-D7` — **DPoP at the resource server enforces `ath`** (B2): the middleware passes the bound access token into `verifyOAuthDpopProof` (RFC 9449 §4.3 `ath` binding) and records `jti` anti-replay via `dpopReplay.recordDpopJti` with a symmetric acceptance window (`iatSkew`, default 60s). Without `ath`, a stolen DPoP proof + token would replay. Reversible.
-- `BR39d-D8` — **`findServiceClient` is OPTIONAL on `OauthStateStorePort`** (Codex MAJOR): declared `findServiceClient?(clientId): Promise<ServiceClientRecord | null>` so existing implementors of the published `0.3.0` contract keep compiling. The handler treats absence as "service grant unsupported" (`unsupported_grant_type`). Additive, non-breaking. Reversible.
-- `BR39d-D9` — **Discovery + error semantics**: `.well-known/openid-configuration` advertises `grant_types_supported: ['authorization_code','client_credentials']` and `token_endpoint_auth_methods_supported: ['client_secret_basic','client_secret_post','none']`. Error codes pinned: missing/invalid client auth ⇒ `invalid_client` (401); requested scope ⊄ allowed ⇒ `invalid_scope`; `resource` unknown/ambiguous/zero ⇒ `invalid_target`. Empty/absent `scope` ⇒ grant the client's full `allowed_scopes` (RFC 6749 §4.4.2). Reversible.
-- `BR39d-D10` — **`auth-client` activation via `api` dogfooding** (Opus M1 + `rules/architecture.md` activation rule): `api` imports `@sentropic/auth-client` and uses it for a real outbound mint→call loop against its own `createRequireServiceAuth`-protected route (self-S2S health/ping). Satisfies "≥1 app root imports through workspace wiring", exercises the full client contract on a real host, and provides the UAT artifact. Requires `BR39d-EX5` (api/Dockerfile). Reversible.
-
-**Deferred to BR-39h:**
-- Service-token revocation + introspection (stateless in 39d per `BR39d-D5`).
-- Zero-downtime dual-secret rotation grace window + admin UI (per `BR39d-D2`, also BR-39g).
-- Fusion of `oauth_clients` + `service_clients` into unified `identities` table.
-
-**Post-merge external action (NOT a pre-UAT blocker):** register `validate-auth-client` as a required status check in GitHub branch protection (repo-admin UI) once the job exists.
+- [ ] Branch context: replaces closed PR #183 (fix/chat-loop-guard-analysis, 397 commits behind main when closed). Old worktree `tmp/fix-chat-loop-guard-analysis` and its branch remain untouched as historical reference.
+- [ ] Before/after measurement carried over from the old branch (live-run on 2026-06-02 in `tmp/fix-chat-loop-guard-analysis` with sync line removed): pre-fix scenario rides to **11 LLM calls** (`BASE_MAX_ITERATIONS=10` + 1 pass-2 fallback); post-fix breaker caps at **4 LLM calls** (3 tentatives + pass-2). Reduction 64 %. Reapply target on current main MUST preserve this signature.
 
 ## AI Flaky tests
-- Acceptance rule per `rules/testing.md`: accept only non-systematic provider/network nondeterminism as `flaky accepted` (≥1 success same commit+command). Never add timeouts. S2S suites are deterministic (no AI) → no flaky tolerance expected.
+- Acceptance rule:
+  - Accept only non-systematic provider/network/model nondeterminism as `flaky accepted`.
+  - Non-systematic means at least one success on the same commit and same command.
+  - Never amend tests with additive timeouts.
+  - If flaky, analyze impact vs `main`: if unrelated, accept and record command + failing test file + signature in `BRANCH.md`; if related, treat as blocking.
+  - Capture explicit user sign-off before merge.
+- Pre-recorded flaky carried from PR #183: `api/tests/ai/chat-sync.test.ts` (`should generate assistant response with AI` 15 s timeout; `should generate response with tool calls` jobCompleted false at 30 s). Signature: provider/network latency under CI parallel load. If it recurs on this branch, re-validate the signature on this commit (same-commit CI rerun + local repro) before reusing the prior sign-off.
 
 ## Orchestration Mode (AI-selected)
-- [x] **Mono-branch + cherry-pick** (single worktree `tmp/feat-auth-s2s`, one final test cycle)
+- [x] **Mono-branch + cherry-pick** (default for orthogonal tasks; single final test cycle)
 - [ ] **Multi-branch**
-- Rationale: One cohesive vertical slice (schema → grant → middleware → package → host wiring). Lots are sequential with a shared contract (`OauthStateStorePort` extension), not orthogonal — multi-branch would fragment it. Implementation delegated to one Codex sub-agent (39c pattern); conductor integrates.
+- Rationale: the loop guard breaker, the api-side sync, and the UI projection bound form one runtime defect class and need one integrated test cycle.
 
 ## UAT Management (in orchestration context)
-- Mono-branch: UAT after lots complete. S2S has **no UI surface** → UAT is a scripted API round-trip run by the user from root `ENV=dev`: (1) mint a token via `client_credentials` (Basic + POST), (2) call the `createRequireServiceAuth`-protected route → 200, (3) negative cases (no token → 401, wrong scope → 403, wrong `resource`/`aud` → 401, wrong secret → 401), (4) DPoP-bound happy path, (5) `npm pack` dry-run inspection of `@sentropic/auth-client`, (6) the `api` self-S2S dogfood loop succeeds.
-- Push branch before UAT; run UAT from root workspace; switch back to `tmp/feat-auth-s2s` after.
+- **Mono-branch**: UAT performed on the integrated branch after push, on the user's root workspace (`ENV=dev`).
+- Branch diagnostics and automated tests run from `tmp/fix-chat-loop-guard`.
 
 ## Plan / Todo (lot-based)
-- [x] **Lot 0 — Baseline & constraints**
-  - [x] Read `rules/MASTER.md`, `rules/workflow.md`, `rules/subagents.md`, `rules/testing.md`, `rules/security.md`, `rules/architecture.md`.
-  - [x] Read `packages/auth-hono/README.md`, `packages/auth-hono/src/oauth/*`, `packages/auth-hono/src/ports.ts`, `api/src/services/auth/oauth-state-adapter.ts`, `api/src/db/schema.ts` (oauth_clients + token tables), `api/drizzle/0027_oauth_clients.sql`.
-  - [x] Confirm worktree `tmp/feat-auth-s2s` on branch `feat/auth-s2s` (`git branch --show-current`).
-  - [x] Env/port mapping (BR-39 slot 3): `API_PORT=9198`, `UI_PORT=5398`, `MAILDEV_UI_PORT=1298`; `ENV=test-feat-auth-s2s` and `ENV=e2e-feat-auth-s2s`. `make ps-all` to confirm no conflict.
-  - [x] Confirm command style `make ... <vars> ENV=<env>` with `ENV` last.
-  - [x] Validate scope boundaries + decisions `BR39d-D1..D10` + exceptions `BR39d-EX1..EX5` (above).
+- [ ] **Lot 0 — Baseline & constraints**
+  - [x] Read `rules/MASTER.md`, `rules/workflow.md`, `rules/conductor.md`, `rules/subagents.md`, `rules/testing.md`.
+  - [x] Confirm isolated worktree `tmp/fix-chat-loop-guard` based on `origin/main` (`90323a6b`).
+  - [x] Copy root `.env` into the worktree.
+  - [x] Define environment mapping: branch dev `ENV=fix-chat-loop-guard`, tests `ENV=test-fix-chat-loop-guard`, e2e `ENV=e2e-fix-chat-loop-guard`.
+  - [x] Define ports: API `9096`, UI `5296`, Maildev UI `1196` (carried over from PR #183 ports; free at branch start).
+  - [x] Confirm command style: `make ... API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=<env>` with `ENV` last.
+  - [x] Confirm scope and guardrails.
 
-- [x] **Lot 1 — Schema & port contract (`service_clients`)**
-  - [x] `api/drizzle/0029_service_clients.sql`: `service_clients` table ONLY — `id text PK`, `client_id text UNIQUE NOT NULL`, `client_secret_hash text NOT NULL`, `display_name text`, `allowed_scopes text[] NOT NULL`, `resource_indicators text[] NOT NULL DEFAULT '{}'`, `dpop_bound_access_tokens boolean NOT NULL DEFAULT false`, `tenant_id text NULL` (hook `BR39c-D18`), `secret_rotated_at timestamp`, `created_at timestamp NOT NULL DEFAULT now()`, `revoked_at timestamp NULL`. No `oauth_tokens` ALTER (`BR39d-D5`). (+ `_journal.json` idx 29 entry so drizzle migrator applies it.)
-  - [x] `api/src/db/schema.ts`: drizzle `serviceClients` table mirroring the migration.
-  - [x] `packages/auth-hono/src/oauth/state-store-types.ts`: add `ServiceClientRecord` interface + **optional** `findServiceClient?(clientId): Promise<ServiceClientRecord | null>` on `OauthStateStorePort` (`BR39d-D8`). Export `ServiceClientRecord` from `ports.ts`/`index.ts`.
-  - [x] `api/src/services/auth/oauth-state-adapter.ts`: implement `findServiceClient` (filter `revoked_at IS NULL`).
-  - [x] Memory state-store fixture extended with service clients for handler tests.
+- [ ] **Lot 1 — chat-core repeated-tool-error breaker (post-Lot-21e refactor)**
+  - [ ] Read `packages/chat-core/src/runtime-tool-dispatch.ts` on current main; locate the per-tool dispatch body and the catch path (`{status:'error'}` envelope returns and thrown errors).
+  - [ ] Add `toolErrorSignatureCounts?: Record<string, number>` to `AssistantRunLoopState` in `packages/chat-core/src/runtime.ts`.
+  - [ ] Initialize `toolErrorSignatureCounts: {}` in `packages/chat-core/src/runtime-run-prepare.ts` next to `continueGenerationLoop`.
+  - [ ] In `runtime-tool-dispatch.ts`:
+    - [ ] Add signature helpers: `normalizeLoopGuardText`, `normalizeLoopGuardArgs` (strip request_id/trace_id/timestamps/UUIDs/numeric IDs), `buildToolLoopSignature(toolName, args, errorMessage)`.
+    - [ ] Add `incrementToolLoopErrorCount(loopState, toolName, args, errorMessage)` and `getReturnedToolErrorMessage(result)` (detects `{status:'error', code?, error?|message?}` returns that do not throw).
+    - [ ] On the 3rd identical normalized signature (threshold = 2 → trip on count > 2), set `loopState.continueGenerationLoop = false`, emit a `tool_call_result` carrying `{status:'error', code:'tool_loop_repeated_error', error:..., repeat_count, tool_name}`, return `shouldBreakLoop: true` and exit the per-tool loop early.
+    - [ ] Refactor success/error accumulator pushes into a single `pushToolAccumulator` helper to avoid double-tracking the signature.
+  - [ ] Add `packages/chat-core/tests/runtime-tool-dispatch.test.ts`:
+    - [ ] `trips a terminal loop breaker after repeated identical returned tool errors in one assistant turn`
+    - [ ] `normalizes noisy thrown tool errors before tripping the loop breaker`
+    - [ ] `does not trip the repeated-error breaker when tool arguments change meaningfully`
+  - [ ] Bump `packages/chat-core/package.json` (minor — new public state field on `AssistantRunLoopState`).
   - [ ] Lot gate:
-    - [x] `make typecheck-auth-hono` PASS. `make typecheck-api` BLOCKED (`BR39d-Q1` docker net pool). `make lint-auth-hono` n/a (no such target; CI validates auth-hono via typecheck+test+build+pack).
-    - [x] **API tests**: `api/tests/unit/auth/oauth-state-adapter.test.ts` — `findServiceClient` cases (found / revoked / missing) WRITTEN. Execution BLOCKED (`BR39d-Q1`).
-    - [x] Sub-lot gate: `make test-auth-hono` PASS (80 tests). `make test-api ENV=test-feat-auth-s2s` BLOCKED (`BR39d-Q1`).
+    - [ ] `make typecheck-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [ ] `make test-pkg-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
 
-- [x] **Lot 2 — `client_credentials` grant on token endpoint (stateless)**
-  - [x] `packages/auth-hono/src/oauth/token-handler.ts`: branch on `grant_type=client_credentials` (keep `authorization_code` path untouched) → authenticate `client_secret_basic`/`client_secret_post` against `findServiceClient` (via `ports.tokens.hashSecret` — host impl is sha256, not Argon2id; the contract is the port); empty/absent `scope` ⇒ full `allowed_scopes`, else subset check (`invalid_scope` on superset); resolve `resource` per `BR39d-D4` (`invalid_target`); DPoP `cnf={jkt}` per `BR39d-D1`; issue a signed **access_token only** (no `id_token`, no `refresh_token`, `aud` = resolved resource, TTL `serviceAccessTokenTtlSeconds` default 900); **do NOT call `saveTokenMeta`** (`BR39d-D5`). Uses resolved resource as `aud`, not the userinfo constant.
-  - [x] `packages/auth-hono/src/oauth/wellknown-handler.ts`: `grant_types_supported` + `token_endpoint_auth_methods_supported` per `BR39d-D9`.
-  - [x] If `findServiceClient` is undefined on the port, `client_credentials` ⇒ `unsupported_grant_type` (`BR39d-D8`).
-  - [x] Lot gate:
-    - [x] `make typecheck-auth-hono` PASS. `make lint-auth-hono` n/a (no such target).
-    - [x] **auth-hono tests**: `packages/auth-hono/tests/oauth-client-credentials.test.ts` (11 tests) — happy (Basic + POST), DPoP-bound happy (`cnf.jkt`, `token_type=DPoP`), no-`scope` ⇒ all allowed, errors: wrong secret (`invalid_client`), scope superset (`invalid_scope`), revoked client, unknown `resource` (`invalid_target`), missing `resource` with >1 indicator (`invalid_target`), 0 indicators + no resource (`invalid_target`), unsupported when port lacks findServiceClient. Updated `oauth-wellknown` test for new metadata. Asserts NO token-meta row written (`store.tokens.size === 0`).
-    - [x] Sub-lot gate: `make test-auth-hono` PASS (91 tests).
-
-- [x] **Lot 3 — `createRequireServiceAuth` middleware (resource server)**
-  - [x] `packages/auth-hono/src/oauth/service-auth-middleware.ts`: `createRequireServiceAuth({issuer, requiredScopes, resource, ports})` where `ports: ServiceAuthPorts` (narrow, `BR39d-D6`) → parse `Authorization: Bearer|DPoP <jwt>`; JWKS verify via `JwksPort` (kid lookup); validate `iss`, `aud === resource`, `exp`, `scope ⊇ requiredScopes`; if `cnf.jkt` present require + verify `DPoP` proof passing the access token for `ath` (`BR39d-D7`) + `recordDpopJti` replay via `dpopReplay`; `c.set('serviceClient', {...})`; 401/403 with `WWW-Authenticate`.
-  - [x] Export `createRequireServiceAuth` + `ServiceAuthPorts` (+ `ServiceAuthContext`) from `packages/auth-hono/src/index.ts` (root export).
-  - [x] Lot gate:
-    - [x] `make typecheck-auth-hono` PASS. `make lint-auth-hono` n/a.
-    - [x] **auth-hono tests**: `packages/auth-hono/tests/service-auth-middleware.test.ts` (10 tests) — pass (Bearer + DPoP), reject: missing token, bad signature, wrong `aud`, expired, missing required scope (403 insufficient_scope), DPoP proof missing / replayed / `ath` mismatch.
-    - [x] Sub-lot gate: `make test-auth-hono` PASS (101 tests).
-
-- [x] **Lot 4 — New package `@sentropic/auth-client` (Node consumer helper)**
-  - [x] `packages/auth-client/` scaffold: `package.json` (`@sentropic/auth-client`, `0.1.0`, ESM, `jose` peer dep, mirrors auth-hono build/test config), `README.md`, `src/index.ts`, `tsconfig.json`, `LICENSE`. (No `vitest.config.ts` — auth-hono pattern runs `vitest run tests` directly.)
-  - [x] `createAuthClient({issuer, clientId, clientSecret, dpop?, resource?, scope?, tokenEndpoint?, refreshSkewSeconds?, fetch?, now?})` → `getToken({scope?, resource?, forceRefresh?}) → Promise<{access_token, token_type, expires_at, scope}>` with in-memory cache (keyed scope+resource) + auto-refresh (skew default 30s); lazy Ed25519 DPoP keypair + `buildDpopProof({htm, htu, accessToken?})` when `dpop:true`; `AuthClientError` carries OAuth code + status.
-  - [x] Workspace registration (`BR39d-EX4`): `packages/*` glob already covers it; `package-lock.json` synced via `make lock-root`; `api/package.json` declares `@sentropic/auth-client`. Dockerfile wiring (`BR39d-EX5`): COPY + `npm --workspace @sentropic/auth-client run build`.
-  - [x] Lot gate:
-    - [x] `make typecheck-auth-client` (`BR39d-EX1`) PASS. (No auth-client lint target; CI parity = typecheck+test+build+pack.)
-    - [x] **auth-client tests**: `packages/auth-client/tests/auth-client.test.ts` (7 tests) — token fetch + cache reuse, refresh on expiry, scope/resource forwarding, DPoP proof shape, **real round-trip** mint→protected-route (Bearer + DPoP w/ ath) against an in-process `@sentropic/auth-hono` IdP, error mapping. Not mocks-only.
-    - [x] Sub-lot gate: `make test-auth-client` PASS (7 tests). `make pack-auth-client` PASS (dist+src+README+LICENSE).
-
-- [x] **Lot 5 — Host wiring in Sentropic API (real consumer co-design + dogfood)**
-  - [x] Per `feedback_contract_consumer_codesign`: exercise BOTH contracts on the real host.
-  - [x] `api`: mount `createRequireServiceAuth({requiredScopes:['service:ping'], resource:<api resource uri>})`-protected internal route `GET /api/v1/auth/s2s/ping` returning minimal JSON (resource-server side). New file `api/src/routes/auth/service-s2s.ts`; mounted in `api/src/routes/auth/index.ts` under `/s2s`.
-  - [x] `api` imports `@sentropic/auth-client` (`BR39d-D10`, `EX4`+`EX5`): `GET /api/v1/auth/s2s/self-check` mints via `createAuthClient` → calls the protected `/ping` route — the activation + UAT artifact (gated behind `OAUTH_SELF_SERVICE_CLIENT_ID/_SECRET`).
-  - [x] `api/src/services/auth/oauth-client-seed.ts` (+ `api/src/scripts/oauth-seed-clients.ts`): `seedServiceClients()` seeds `example-service-rp` + the self-S2S dogfood client for dev/test/e2e. Env: `OAUTH_SERVICE_ACCESS_TOKEN_TTL_SEC`, `OAUTH_SERVICE_RESOURCE_URI`, `OAUTH_SELF_SERVICE_CLIENT_ID/_SECRET`.
+- [ ] **Lot 2 — chat-service outer-loop sync line**
+  - [ ] Read `api/src/services/chat-service.ts` around the post-`consumeToolCalls` "thin invocation + state sync" block (~ L3800-3830 on current main): identify the exact location after `streamSeq`/`contextBudgetReplanAttempts` are synced back.
+  - [ ] Add `continueGenerationLoop = loopState.continueGenerationLoop;` immediately after the existing sync of `streamSeq` and `contextBudgetReplanAttempts` so the outer `while (continueGenerationLoop)` honors the breaker's stop signal.
+  - [ ] Add regression test `should stop repeated identical tool validation errors before the max-iteration fallback` in `api/tests/unit/chat-service-tools.test.ts`:
+    - [ ] Mock `callLLMStream` to always emit a `plan` tool call with invalid `{action:'unknown'}` args when tools are enabled.
+    - [ ] Assert `calls.length === 4` (3 tool-enabled attempts + 1 pass-2 with `toolChoice: 'none'`).
+    - [ ] Confirm the pre-existing `should continue beyond 10 iterations when active TODO can progress without user input` still passes (legitimate progression untouched).
   - [ ] Lot gate:
-    - [x] `make typecheck-api` BLOCKED (`BR39d-Q1` docker net pool). `make lint-api` BLOCKED (same).
-    - [x] **API tests**: `api/tests/api/auth/service-auth-middleware.test.ts` WRITTEN — full host round-trip (mint via `client_credentials` → protected route 200) + negatives (no token 401, wrong scope 403, wrong `aud`/`resource` 401). Execution BLOCKED (`BR39d-Q1`).
-    - [x] Sub-lot gate: `make test-api ENV=test-feat-auth-s2s` BLOCKED (`BR39d-Q1`).
-    - [x] **E2E (optional, API-level)**: `e2e/tests/02-auth-s2s-client-credentials.spec.ts` WRITTEN. Running it requires `seedServiceClients()` to be wired into `api/tests/utils/seed-test-data.ts` (out of Allowed Paths) — see `BR39d-Q2`. Execution BLOCKED (`BR39d-Q1` + e2e build).
+    - [ ] `make typecheck-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [ ] `make lint-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [ ] `make test-api-unit SCOPE=tests/unit/chat-service-tools.test.ts API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
 
-- [x] **Lot 6 — CI / Make / ops parity**
-  - [x] `Makefile` (`BR39d-EX1`): added `typecheck-auth-client`, `test-auth-client`, `build-auth-client`, `pack-auth-client`, `publish-auth-client`, `publish-auth-client-token`, `oauth-rotate-service-client CLIENT_ID=... ENV=...` (mirror `*-auth-hono`; `oauth:rotate-service-client` npm script + `api/src/scripts/oauth-rotate-service-client.ts`).
-  - [x] `.github/workflows/ci.yml` (`BR39d-EX2`): added `auth_client` + `auth_client_publish` filters (`packages/auth-client/**`), `validate-auth-client` job (typecheck+test+build+pack), `publish-auth-client` job (main-gated, OIDC id-token), `auth-client` in `bootstrap_publish_target` enum + bootstrap step. YAML validated.
-  - [x] root `package.json`/`package-lock.json` (`BR39d-EX4`) + `api/Dockerfile` (`BR39d-EX5`): workspace member (glob) + lockfile + COPY/build wiring for auth-client (done in Lot 4).
-  - [x] `docs/secrets.md`: S2S inventory rows (`OAUTH_SERVICE_ACCESS_TOKEN_TTL_SEC`, `OAUTH_SERVICE_RESOURCE_URI`, `OAUTH_SELF_SERVICE_CLIENT_ID/_SECRET`), provisioning + mint/use + DPoP + `oauth-rotate-service-client` runbook + stateless/no-revoke note (defer 39h).
-  - [x] Lot gate: `make typecheck`/`make lint` are `typecheck-ui+typecheck-api` / `lint-ui+lint-api` — BLOCKED by `BR39d-Q1` (compose network). Package gates (typecheck/test/build/pack auth-hono + auth-client) all PASS.
+- [ ] **Lot 3 — chat-ui stream projection compaction**
+  - [ ] Read `packages/chat-ui/src/utils/chat-run-projection.ts` on current main; verify the projection model has not converged with the closed PR #183 approach (BR-38a may have added attachment-related projection paths).
+  - [ ] Compact/bound repeated transient status/tool-call deltas for the same `tool_call_id` within one assistant turn (dedupe consecutive identical `tool_call_args` deltas; clamp per-turn projection length without dropping the final transcript or tool error visibility).
+  - [ ] Update `packages/chat-ui/src/client/streamHistory.ts` if the projection contract changes (otherwise leave untouched).
+  - [ ] Add `packages/chat-ui/tests/stream-throughput.test.ts`:
+    - [ ] Asserts the projection length stays bounded under a synthetic flood of identical status/tool-call deltas.
+  - [ ] Update `packages/chat-ui/tests/chat-run-projection.test.ts` to cover the dedupe-but-preserve-final-error contract.
+  - [ ] Update `ui/tests/utils/chat-run-projection.test.ts` to assert UI-side wrapper behavior remains stable.
+  - [ ] Bump `packages/chat-ui/package.json` (minor — new projection compaction contract).
+  - [ ] Lot gate:
+    - [ ] `make typecheck-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [ ] `make test-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [ ] `make test-ui SCOPE=tests/utils/chat-run-projection.test.ts API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
 
-- [x] **Lot N-1 — Docs consolidation**
-  - [x] `packages/auth-hono/README.md`: `client_credentials` grant, optional `findServiceClient`, `createRequireServiceAuth` + `ServiceAuthPorts`, RFC 8707 resource indicators, DPoP S2S recommendation, stateless service-token note, `0.4.0` version entry + env vars.
-  - [x] `packages/auth-client/README.md`: Node consumer quickstart, `createAuthClient`/`getToken`, DPoP opt-in, config + errors (written in Lot 4).
-  - [x] No `spec/BRANCH_SPEC_EVOL.md` was created for this branch.
+- [ ] **Lot N-2 — UAT (root workspace, `ENV=dev`)**
+  - [ ] Web app: repeated identical tool-error loop terminates cleanly without freezing the browser tab.
+  - [ ] Web app: normal multi-step tool workflow (legitimate progressing plan/todo) still works.
+  - [ ] Web app: DOCX organization generation still completes.
+  - [ ] Web app: PPTX organization generation still completes.
+  - [ ] Web app: breaker-stopped loop shows an actionable user-visible error (`tool_loop_repeated_error` surface).
 
 - [ ] **Lot N — Final validation**
-  - [x] `make typecheck`/`make lint` for auth-hono + auth-client PASS (typecheck). `make typecheck-api`/`make lint-api` BLOCKED (`BR39d-Q1`).
-  - [x] `make test-auth-hono` (101) + `make test-auth-client` (7) PASS. `make test-api ENV=test-feat-auth-s2s` BLOCKED (`BR39d-Q1`).
-  - [ ] Retest E2E (if added): BLOCKED (`BR39d-Q1` + `BR39d-Q2`).
-  - [x] Version bumps: `packages/auth-hono` `0.3.0 → 0.4.0` (minor) DONE; new `packages/auth-client` `0.1.0` DONE. `auth-ui` unchanged — but the 0.4.0 bump breaks auth-ui's `^0.3.0` peer, see `BR39d-Q3` (lockfile NOT regenerated for the 0.4.0 bump pending conductor decision).
-  - [ ] Final gate step 1: create/update PR using `BRANCH.md` as PR body.
-  - [ ] Final gate step 2: run/verify branch CI on PR; resolve blockers (`enforce-package-bump`, `validate-auth-client`).
-  - [ ] Final gate step 3: once UAT + CI green → commit removal of `BRANCH.md`, push, merge. First publish of `@sentropic/auth-client` via `bootstrap_publish_target=auth-client` then attach OIDC trusted publisher (Playwright, `feedback_npm_trusted_publisher_via_playwright`). `auth-hono` 0.4.0 publish may need the bootstrap fallback (trusted publisher still broken — handover §3). Register `validate-auth-client` as required check (admin).
+  - [ ] `make typecheck-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make lint-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make typecheck-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make lint-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make typecheck-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make typecheck-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make test-pkg-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make test-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make test-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make test-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+  - [ ] `make test-api-ai API_TEST_WORKERS=1 API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard` (document any flaky signatures vs the carry-over note above)
+  - [ ] `git diff --check`
+  - [ ] Confirm `packages/chat-core/package.json` version bump if `packages/chat-core/src/**` changed.
+  - [ ] Confirm `packages/chat-ui/package.json` version bump if `packages/chat-ui/src/**` changed.
+  - [ ] Build before e2e: `make build-api build-ui-image API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=e2e-fix-chat-loop-guard`
+  - [ ] E2E chat smoke: `make test-e2e E2E_SPEC=tests/03-chat.spec.ts WORKERS=1 RETRIES=0 API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=e2e-fix-chat-loop-guard`
+  - [ ] Create PR using `BRANCH.md` text as PR body (link the closed PR #183 in the description for context).
+  - [ ] Verify PR CI.
+  - [ ] Once UAT + CI are both OK, commit removal of `BRANCH.md`, push, and merge.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -86,23 +86,23 @@ Reapply the repeated-tool-error loop breaker (chat-core dispatch breaker + chat-
   - [x] Confirm command style: `make ... API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=<env>` with `ENV` last.
   - [x] Confirm scope and guardrails.
 
-- [ ] **Lot 1 — chat-core repeated-tool-error breaker (post-Lot-21e refactor)**
-  - [ ] Read `packages/chat-core/src/runtime-tool-dispatch.ts` on current main; locate the per-tool dispatch body and the catch path (`{status:'error'}` envelope returns and thrown errors).
-  - [ ] Add `toolErrorSignatureCounts?: Record<string, number>` to `AssistantRunLoopState` in `packages/chat-core/src/runtime.ts`.
-  - [ ] Initialize `toolErrorSignatureCounts: {}` in `packages/chat-core/src/runtime-run-prepare.ts` next to `continueGenerationLoop`.
-  - [ ] In `runtime-tool-dispatch.ts`:
-    - [ ] Add signature helpers: `normalizeLoopGuardText`, `normalizeLoopGuardArgs` (strip request_id/trace_id/timestamps/UUIDs/numeric IDs), `buildToolLoopSignature(toolName, args, errorMessage)`.
-    - [ ] Add `incrementToolLoopErrorCount(loopState, toolName, args, errorMessage)` and `getReturnedToolErrorMessage(result)` (detects `{status:'error', code?, error?|message?}` returns that do not throw).
-    - [ ] On the 3rd identical normalized signature (threshold = 2 → trip on count > 2), set `loopState.continueGenerationLoop = false`, emit a `tool_call_result` carrying `{status:'error', code:'tool_loop_repeated_error', error:..., repeat_count, tool_name}`, return `shouldBreakLoop: true` and exit the per-tool loop early.
-    - [ ] Refactor success/error accumulator pushes into a single `pushToolAccumulator` helper to avoid double-tracking the signature.
-  - [ ] Add `packages/chat-core/tests/runtime-tool-dispatch.test.ts`:
-    - [ ] `trips a terminal loop breaker after repeated identical returned tool errors in one assistant turn`
-    - [ ] `normalizes noisy thrown tool errors before tripping the loop breaker`
-    - [ ] `does not trip the repeated-error breaker when tool arguments change meaningfully`
-  - [ ] Bump `packages/chat-core/package.json` (minor — new public state field on `AssistantRunLoopState`).
-  - [ ] Lot gate:
-    - [ ] `make typecheck-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
-    - [ ] `make test-pkg-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+- [x] **Lot 1 — chat-core repeated-tool-error breaker (post-Lot-21e refactor)**
+  - [x] Read `packages/chat-core/src/runtime-tool-dispatch.ts` on current main; locate the per-tool dispatch body and the catch path (`{status:'error'}` envelope returns and thrown errors).
+  - [x] Add `toolErrorSignatureCounts?: Record<string, number>` to `AssistantRunLoopState` in `packages/chat-core/src/runtime.ts`.
+  - [x] Initialize `toolErrorSignatureCounts: {}` in `packages/chat-core/src/runtime-run-prepare.ts` next to `continueGenerationLoop`.
+  - [x] In `runtime-tool-dispatch.ts`:
+    - [x] Add signature helpers: `normalizeLoopGuardText`, `normalizeLoopGuardArgs` (strip request_id/trace_id/timestamps/UUIDs/numeric IDs), `buildToolLoopSignature(toolName, args, errorMessage)`.
+    - [x] Add `incrementToolLoopErrorCount(loopState, toolName, args, errorMessage)` and `getReturnedToolErrorMessage(result)` (detects `{status:'error', code?, error?|message?}` returns that do not throw).
+    - [x] On the 3rd identical normalized signature (threshold = 2 → trip on count > 2), set `loopState.continueGenerationLoop = false`, emit a `tool_call_result` carrying `{status:'error', code:'tool_loop_repeated_error', error:..., repeat_count, tool_name}`, return `shouldBreakLoop: true` and exit the per-tool loop early.
+    - [x] Refactor success/error accumulator pushes into a single `pushToolAccumulator` helper to avoid double-tracking the signature.
+  - [x] Add `packages/chat-core/tests/runtime-tool-dispatch.test.ts`:
+    - [x] `trips a terminal loop breaker after repeated identical returned tool errors in one assistant turn`
+    - [x] `normalizes noisy thrown tool errors before tripping the loop breaker`
+    - [x] `does not trip the repeated-error breaker when tool arguments change meaningfully`
+  - [x] Bump `packages/chat-core/package.json` (patch 0.1.3 → 0.1.4 — new optional state field on `AssistantRunLoopState`, additive, stays within consumers' `^0.1.2` range; aligned `package-lock.json` chat-core entry).
+  - [x] Lot gate:
+    - [x] `make typecheck-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+    - [x] `make test-pkg-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard` (21 files, 248 tests; `runtime-tool-dispatch.test.ts` 22 → 25 tests)
 
 - [ ] **Lot 2 — chat-service outer-loop sync line**
   - [ ] Read `api/src/services/chat-service.ts` around the post-`consumeToolCalls` "thin invocation + state sync" block (~ L3800-3830 on current main): identify the exact location after `streamSeq`/`contextBudgetReplanAttempts` are synced back.
@@ -116,19 +116,9 @@ Reapply the repeated-tool-error loop breaker (chat-core dispatch breaker + chat-
     - [ ] `make lint-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
     - [ ] `make test-api-unit SCOPE=tests/unit/chat-service-tools.test.ts API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
 
-- [ ] **Lot 3 — chat-ui stream projection compaction**
-  - [ ] Read `packages/chat-ui/src/utils/chat-run-projection.ts` on current main; verify the projection model has not converged with the closed PR #183 approach (BR-38a may have added attachment-related projection paths).
-  - [ ] Compact/bound repeated transient status/tool-call deltas for the same `tool_call_id` within one assistant turn (dedupe consecutive identical `tool_call_args` deltas; clamp per-turn projection length without dropping the final transcript or tool error visibility).
-  - [ ] Update `packages/chat-ui/src/client/streamHistory.ts` if the projection contract changes (otherwise leave untouched).
-  - [ ] Add `packages/chat-ui/tests/stream-throughput.test.ts`:
-    - [ ] Asserts the projection length stays bounded under a synthetic flood of identical status/tool-call deltas.
-  - [ ] Update `packages/chat-ui/tests/chat-run-projection.test.ts` to cover the dedupe-but-preserve-final-error contract.
-  - [ ] Update `ui/tests/utils/chat-run-projection.test.ts` to assert UI-side wrapper behavior remains stable.
-  - [ ] Bump `packages/chat-ui/package.json` (minor — new projection compaction contract).
-  - [ ] Lot gate:
-    - [ ] `make typecheck-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
-    - [ ] `make test-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
-    - [ ] `make test-ui SCOPE=tests/utils/chat-run-projection.test.ts API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
+- [ ] **Lot 3 — chat-ui stream projection compaction** *(deferred)*
+  - On-main analysis: `packages/chat-ui/src/utils/chat-run-projection.ts` (200 LOC) already deduplicates by `sequence` in both `appendLiveProjectionEvent` (line 198) and `mergeProjectionHistoryEvents` (Map by sequence). The original PR #183 compaction targeted the live unbounded delta flood. With the Lot 1 backend breaker capping repeated identical tool errors at **3 attempts + 1 pass-2 = 4 LLM calls** per turn, the flood is structurally bounded upstream — the secondary UI compaction is speculative without direct evidence on current main.
+  - Decision: defer chat-ui projection compaction. Reopen only if the UAT in Lot N-2 surfaces residual tab saturation after the backend breaker. If reopened, do so on a dedicated `fix/chat-ui-projection-compaction` branch with concrete reproduction (failing `stream-throughput.test.ts` asserting unbounded growth on a synthetic flood) before code changes.
 
 - [ ] **Lot N-2 — UAT (root workspace, `ENV=dev`)**
   - [ ] Web app: repeated identical tool-error loop terminates cleanly without freezing the browser tab.

--- a/api/src/services/chat-service.ts
+++ b/api/src/services/chat-service.ts
@@ -3891,6 +3891,7 @@ When generating JavaScript \`code\` for DOCX or PPTX, use double-quoted string l
       executedTools.push(...consumed.executedTools);
       streamSeq = consumed.streamSeq;
       contextBudgetReplanAttempts = consumed.contextBudgetReplanAttempts;
+      continueGenerationLoop = loopState.continueGenerationLoop;
 
       // BR14b Lot 21e-3 — post-`consumeToolCalls` per-iteration finalization
       // (Block A trace + todo refresh, Block B `pendingLocalToolCalls`

--- a/api/tests/unit/chat-service-tools.test.ts
+++ b/api/tests/unit/chat-service-tools.test.ts
@@ -931,6 +931,58 @@ it('should evaluate reasoning effort with gemini-3.1-flash-lite when provider is
     expect(calls.length).toBeGreaterThan(10);
   });
 
+  it('should stop repeated identical tool validation errors before the max-iteration fallback', async () => {
+    const mock = callLLMStream as unknown as ReturnType<typeof vi.fn>;
+    const calls: any[] = [];
+
+    mock.mockImplementation((opts: any) => {
+      calls.push(opts);
+      const toolsEnabled = Array.isArray(opts?.tools) && opts.tools.length > 0;
+      if (toolsEnabled) {
+        return stream([
+          {
+            type: 'tool_call_start',
+            data: {
+              tool_call_id: `call_plan_bad_${calls.length}`,
+              name: 'plan',
+              args: JSON.stringify({ action: 'unknown' }),
+            },
+          },
+          { type: 'done', data: {} },
+        ]);
+      }
+      return stream([
+        {
+          type: 'content_delta',
+          data: { delta: 'Je ne peux pas continuer avec cet appel outil.' },
+        },
+        { type: 'done', data: {} },
+      ]);
+    });
+
+    const msg = await chatService.createUserMessageWithAssistantPlaceholder({
+      userId,
+      workspaceId,
+      content: 'Run the plan tool with invalid args repeatedly',
+      model: 'gpt-4.1-nano',
+    });
+
+    await chatService.runAssistantGeneration({
+      userId,
+      sessionId: msg.sessionId,
+      assistantMessageId: msg.assistantMessageId,
+      model: msg.model,
+      tools: ['plan'],
+    });
+
+    expect(calls).toHaveLength(4);
+    expect(calls[0]?.tools?.length).toBeGreaterThan(0);
+    expect(calls[1]?.tools?.length).toBeGreaterThan(0);
+    expect(calls[2]?.tools?.length).toBeGreaterThan(0);
+    expect(calls[3]?.tools).toBeUndefined();
+    expect(calls[3]?.toolChoice).toBe('none');
+  });
+
   it('should inject strict TODO orchestration rules in system prompt when an active session TODO exists', async () => {
     const mock = callLLMStream as unknown as ReturnType<typeof vi.fn>;
     let systemPrompt = '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -14888,7 +14888,7 @@
     },
     "packages/chat-core": {
       "name": "@sentropic/chat-core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@sentropic/contracts": "^0.1.0",

--- a/packages/chat-core/package.json
+++ b/packages/chat-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/chat-core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Chat orchestration core for @sentropic/* — port interfaces (CheckpointStore, MessageStore, SessionStore, StreamBuffer, LiveDocumentStore, ToolRegistry, EventSink, JobQueue, AgentRuntime). Adapters live in persistence-* / flow.",
   "type": "module",
   "license": "MIT",

--- a/packages/chat-core/src/runtime-run-prepare.ts
+++ b/packages/chat-core/src/runtime-run-prepare.ts
@@ -542,6 +542,7 @@ export class ChatRuntimeRunPrepare {
       lastBudgetAnnouncedPct: -1,
       contextBudgetReplanAttempts: 0,
       continueGenerationLoop: true,
+      toolErrorSignatureCounts: {},
       useCodexTransport: input.useCodexTransport ?? false,
     };
   }

--- a/packages/chat-core/src/runtime-tool-dispatch.ts
+++ b/packages/chat-core/src/runtime-tool-dispatch.ts
@@ -70,6 +70,7 @@ import type {
   ApplyContextBudgetGateInput,
   ApplyContextBudgetGateResult,
   AssistantRunLoopExecutedTool,
+  AssistantRunLoopState,
   ChatRuntimeDeps,
   ConsumeAssistantStreamInput,
   ConsumeAssistantStreamResult,
@@ -78,6 +79,115 @@ import type {
   ExecuteServerToolInput,
   ExecuteServerToolResult,
 } from './runtime.js';
+
+const TOOL_LOOP_REPEAT_THRESHOLD = 2;
+
+const LOOP_GUARD_NOISE_KEYS = new Set([
+  'request_id',
+  'requestId',
+  'request-id',
+  'trace_id',
+  'traceId',
+  'trace-id',
+  'timestamp',
+  'time',
+  'nonce',
+  'run_id',
+  'run-id',
+]);
+
+const normalizeLoopGuardText = (text: string): string => {
+  return String(text ?? '')
+    .trim()
+    .toLowerCase()
+    .replace(
+      /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi,
+      '<uuid>',
+    )
+    .replace(
+      /\b(?:req|request|run|trace|call|tool|msg|message|stream|session|job|task)_[a-z0-9_-]+\b/gi,
+      '<id>',
+    )
+    .replace(/\b[0-9a-f]{32,}\b/gi, '<id>')
+    .replace(/\b\d{10,}\b/g, '<number>')
+    .replace(/\s+/g, ' ');
+};
+
+const normalizeLoopGuardArgs = (input: unknown): unknown => {
+  if (input === null || typeof input !== 'object') {
+    return input;
+  }
+  if (input instanceof Date) {
+    return input.toISOString();
+  }
+  if (Array.isArray(input)) {
+    return input.map((item) => normalizeLoopGuardArgs(item));
+  }
+  const record = input as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  const keys = Object.keys(record).sort();
+  for (const key of keys) {
+    if (LOOP_GUARD_NOISE_KEYS.has(key)) continue;
+    out[key] = normalizeLoopGuardArgs(record[key]);
+  }
+  return out;
+};
+
+const buildToolLoopSignature = (
+  toolName: string,
+  args: unknown,
+  errorMessage: string,
+): string => {
+  const normalizedArgs = normalizeLoopGuardArgs(args);
+  const normalizedArgsSig =
+    typeof normalizedArgs === 'string'
+      ? normalizedArgs
+      : JSON.stringify(normalizedArgs) ?? String(normalizedArgs);
+  const normalizedErrorSig = normalizeLoopGuardText(errorMessage);
+  return `${String(toolName || '').trim()}|${normalizedArgsSig}|${normalizedErrorSig}`;
+};
+
+const incrementToolLoopErrorCount = (
+  loopState: AssistantRunLoopState,
+  toolName: string,
+  args: unknown,
+  errorMessage: string,
+): number => {
+  const counts = loopState.toolErrorSignatureCounts ?? {};
+  const key = buildToolLoopSignature(toolName, args, errorMessage);
+  const next = (counts[key] ?? 0) + 1;
+  counts[key] = next;
+  loopState.toolErrorSignatureCounts = counts;
+  return next;
+};
+
+const getReturnedToolErrorMessage = (result: unknown): string | null => {
+  const record = asRecord(result);
+  if (!record) return null;
+  const status = String(record.status ?? '').trim().toLowerCase();
+  if (status !== 'error') return null;
+  const code = typeof record.code === 'string' ? record.code.trim() : '';
+  const error =
+    typeof record.error === 'string'
+      ? record.error.trim()
+      : typeof record.message === 'string'
+        ? record.message.trim()
+        : '';
+  return [code, error].filter(Boolean).join(': ') || 'tool returned status=error';
+};
+
+const buildToolLoopGuardResult = (
+  toolName: string,
+  repeatedCount: number,
+): Record<string, unknown> => ({
+  status: 'error',
+  code: 'tool_loop_repeated_error',
+  error:
+    `Tool '${toolName || 'unknown_tool'}' failed repeatedly with the same arguments and error. ` +
+    'Stop retrying this tool call in this assistant turn. Ask the user to clarify, choose a different approach, or switch to a different tool.',
+  repeat_count: repeatedCount,
+  tool_name: toolName || 'unknown_tool',
+});
 
 export class ChatRuntimeToolDispatch {
   constructor(private readonly deps: ChatRuntimeDeps) {}
@@ -646,6 +756,59 @@ export class ChatRuntimeToolDispatch {
     }> = [];
     const executedTools: AssistantRunLoopExecutedTool[] = [];
     const currentMessages = input.currentMessages;
+    const pushToolAccumulator = (
+      toolCall: { id: string; name: string; args: string },
+      args: unknown,
+      result: unknown,
+    ) => {
+      executedTools.push({
+        toolCallId: toolCall.id,
+        name: toolCall.name || 'unknown_tool',
+        args,
+        result,
+      });
+      toolResults.push({
+        role: 'tool',
+        content: JSON.stringify(result),
+        tool_call_id: toolCall.id,
+      });
+      responseToolOutputs.push({
+        type: 'function_call_output',
+        call_id: toolCall.id,
+        output: JSON.stringify(result),
+      });
+    };
+    const emitAndPushLoopGuard = async (
+      toolCall: { id: string; name: string; args: string },
+      args: unknown,
+      repeatedCount: number,
+    ): Promise<ConsumeToolCallsResult> => {
+      loopState.continueGenerationLoop = false;
+      const guardResult = buildToolLoopGuardResult(
+        String(toolCall.name || '').trim(),
+        repeatedCount,
+      );
+      const seq = await this.deps.streamSequencer.allocate(streamId);
+      await this.deps.streamBuffer.append(
+        streamId,
+        'tool_call_result',
+        { tool_call_id: toolCall.id, result: guardResult },
+        seq,
+        streamId,
+      );
+      streamSeq = seq + 1;
+      loopState.streamSeq = streamSeq;
+      pushToolAccumulator(toolCall, args, guardResult);
+      return {
+        toolResults,
+        responseToolOutputs,
+        pendingLocalToolCalls,
+        executedTools,
+        shouldBreakLoop: true,
+        streamSeq,
+        contextBudgetReplanAttempts,
+      };
+    };
     for (const toolCall of loopState.toolCalls) {
       if (signal?.aborted) throw new Error('AbortError');
       const toolName = String(toolCall.name || '').trim();
@@ -670,8 +833,10 @@ export class ChatRuntimeToolDispatch {
         loopState.streamSeq = streamSeq;
         continue;
       }
+      let argsSignatureSeed: unknown = toolCall.args;
       try {
         const args = JSON.parse(toolCall.args || '{}');
+        argsSignatureSeed = args;
         const projectedResultChars = estimateToolResultProjectionChars(
           toolCall.name,
           asRecord(args) ?? {},
@@ -768,30 +933,46 @@ export class ChatRuntimeToolDispatch {
         const result = rRecord.result;
         streamSeq = rRecord.streamSeq;
         loopState.streamSeq = streamSeq;
-        executedTools.push({
-          toolCallId: toolCall.id,
-          name: toolCall.name,
-          args,
-          result,
-        });
-        toolResults.push({
-          role: 'tool',
-          content: JSON.stringify(result),
-          tool_call_id: toolCall.id,
-        });
-        responseToolOutputs.push({
-          type: 'function_call_output',
-          call_id: toolCall.id,
-          output: JSON.stringify(result),
-        });
+        const returnedErrorMessage = getReturnedToolErrorMessage(result);
+        if (returnedErrorMessage) {
+          const repeatedCount = incrementToolLoopErrorCount(
+            loopState,
+            toolCall.name,
+            argsSignatureSeed,
+            returnedErrorMessage,
+          );
+          if (repeatedCount > TOOL_LOOP_REPEAT_THRESHOLD) {
+            return await emitAndPushLoopGuard(
+              toolCall,
+              argsSignatureSeed,
+              repeatedCount,
+            );
+          }
+        }
+        pushToolAccumulator(toolCall, args, result);
       } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : 'Unknown error';
         const errorResult = {
           status: 'error',
-          error: error instanceof Error ? error.message : 'Unknown error',
+          error: errorMessage,
         };
         const todoErrorCall = toolCall.name === 'plan';
         if (todoErrorCall && todoAutonomousExtensionEnabled) {
           markTodoIterationState(errorResult);
+        }
+        const repeatedCount = incrementToolLoopErrorCount(
+          loopState,
+          toolCall.name,
+          argsSignatureSeed,
+          errorMessage,
+        );
+        if (repeatedCount > TOOL_LOOP_REPEAT_THRESHOLD) {
+          return await emitAndPushLoopGuard(
+            toolCall,
+            argsSignatureSeed,
+            repeatedCount,
+          );
         }
         const seq = await this.deps.streamSequencer.allocate(streamId);
         await this.deps.streamBuffer.append(
@@ -803,30 +984,7 @@ export class ChatRuntimeToolDispatch {
         );
         streamSeq = seq + 1;
         loopState.streamSeq = streamSeq;
-        toolResults.push({
-          role: 'tool',
-          content: JSON.stringify(errorResult),
-          tool_call_id: toolCall.id,
-        });
-        responseToolOutputs.push({
-          type: 'function_call_output',
-          call_id: toolCall.id,
-          output: JSON.stringify(errorResult),
-        });
-        executedTools.push({
-          toolCallId: toolCall.id,
-          name: toolCall.name || 'unknown_tool',
-          args: toolCall.args
-            ? (() => {
-                try {
-                  return JSON.parse(toolCall.args);
-                } catch {
-                  return toolCall.args;
-                }
-              })()
-            : undefined,
-          result: errorResult,
-        });
+        pushToolAccumulator(toolCall, argsSignatureSeed, errorResult);
       }
     }
     return {

--- a/packages/chat-core/src/runtime.ts
+++ b/packages/chat-core/src/runtime.ts
@@ -1190,6 +1190,14 @@ export interface AssistantRunLoopState {
   contextBudgetReplanAttempts: number;
   continueGenerationLoop: boolean;
   /**
+   * In-memory tracker for repeated identical server-tool error signatures
+   * during one assistant turn. A signature is computed from the tuple
+   * `(toolName, normalizedArgsSignature, normalizedErrorSignature)`.
+   * Counts persist on the loop state so the same-tool repeated-error
+   * breaker can fire across tool-loop iterations.
+   */
+  toolErrorSignatureCounts?: Record<string, number>;
+  /**
    * BR14b Lot 21c — surfaces the `useCodexTransport` boolean computed by
    * chat-service (`selectedProviderId === 'openai' && selectedModel ===
    * 'gpt-5.5' && (await getOpenAITransportMode()) === 'codex'`) on the

--- a/packages/chat-core/tests/runtime-tool-dispatch.test.ts
+++ b/packages/chat-core/tests/runtime-tool-dispatch.test.ts
@@ -734,4 +734,142 @@ describe('ChatRuntime.consumeToolCalls (Lot 21c / 21e-2)', () => {
     expect(result.streamSeq).toBe(15);
     expect(loopState.streamSeq).toBe(15);
   });
+
+  it('trips a terminal loop breaker after repeated identical returned tool errors in one assistant turn', async () => {
+    let requestSeq = 0;
+    const execStub = vi.fn(async () => {
+      requestSeq += 1;
+      return {
+        result: {
+          status: 'error',
+          code: 'code_runtime_error',
+          error: `Sandbox execution failed for request req_${requestSeq}`,
+        },
+        streamSeq: 10,
+      } as unknown as ExecuteServerToolResult;
+    });
+    const { runtime } = buildFixture({ executeServerTool: execStub });
+    const loopState = buildLoopState();
+    const repeatedArgs = '{"format":"docx","entityId":"org-1"}';
+
+    loopState.toolCalls = [
+      { id: 'tc-docx-1', name: 'document_generate', args: repeatedArgs },
+    ];
+    const first = await runtime.consumeToolCalls(buildInput(loopState));
+    expect(JSON.parse(first.responseToolOutputs[0]?.output ?? '{}')).toEqual({
+      status: 'error',
+      code: 'code_runtime_error',
+      error: 'Sandbox execution failed for request req_1',
+    });
+    expect(loopState.continueGenerationLoop).toBe(true);
+
+    loopState.toolCalls = [
+      { id: 'tc-docx-2', name: 'document_generate', args: repeatedArgs },
+    ];
+    const second = await runtime.consumeToolCalls(buildInput(loopState));
+    expect(JSON.parse(second.responseToolOutputs[0]?.output ?? '{}')).toEqual({
+      status: 'error',
+      code: 'code_runtime_error',
+      error: 'Sandbox execution failed for request req_2',
+    });
+    expect(loopState.continueGenerationLoop).toBe(true);
+
+    loopState.toolCalls = [
+      { id: 'tc-docx-3', name: 'document_generate', args: repeatedArgs },
+    ];
+    const third = await runtime.consumeToolCalls(buildInput(loopState));
+    const breakerOutput = JSON.parse(third.responseToolOutputs[0]?.output ?? '{}');
+
+    expect(execStub).toHaveBeenCalledTimes(3);
+    expect(loopState.continueGenerationLoop).toBe(false);
+    expect(third.shouldBreakLoop).toBe(true);
+    expect(breakerOutput.status).toBe('error');
+    expect(breakerOutput.code).toBe('tool_loop_repeated_error');
+    expect(breakerOutput.error).toContain('document_generate');
+    expect(breakerOutput.error).toContain('Stop retrying this tool call');
+  });
+
+  it('normalizes noisy thrown tool errors before tripping the loop breaker', async () => {
+    let requestSeq = 0;
+    const execStub = vi.fn(async () => {
+      requestSeq += 1;
+      throw new Error(
+        `Sandbox transport failed for request req_${requestSeq} trace trace_${requestSeq}`,
+      );
+    });
+    const { runtime } = buildFixture({ executeServerTool: execStub });
+    const loopState = buildLoopState();
+    const repeatedArgs = '{"format":"docx","entityId":"org-1"}';
+
+    loopState.toolCalls = [
+      { id: 'tc-docx-throw-1', name: 'document_generate', args: repeatedArgs },
+    ];
+    const first = await runtime.consumeToolCalls(buildInput(loopState));
+    expect(JSON.parse(first.responseToolOutputs[0]?.output ?? '{}')).toEqual({
+      status: 'error',
+      error: 'Sandbox transport failed for request req_1 trace trace_1',
+    });
+    expect(loopState.continueGenerationLoop).toBe(true);
+
+    loopState.toolCalls = [
+      { id: 'tc-docx-throw-2', name: 'document_generate', args: repeatedArgs },
+    ];
+    const second = await runtime.consumeToolCalls(buildInput(loopState));
+    expect(JSON.parse(second.responseToolOutputs[0]?.output ?? '{}')).toEqual({
+      status: 'error',
+      error: 'Sandbox transport failed for request req_2 trace trace_2',
+    });
+    expect(loopState.continueGenerationLoop).toBe(true);
+
+    loopState.toolCalls = [
+      { id: 'tc-docx-throw-3', name: 'document_generate', args: repeatedArgs },
+    ];
+    const third = await runtime.consumeToolCalls(buildInput(loopState));
+    const breakerOutput = JSON.parse(third.responseToolOutputs[0]?.output ?? '{}');
+
+    expect(execStub).toHaveBeenCalledTimes(3);
+    expect(loopState.continueGenerationLoop).toBe(false);
+    expect(third.shouldBreakLoop).toBe(true);
+    expect(breakerOutput.status).toBe('error');
+    expect(breakerOutput.code).toBe('tool_loop_repeated_error');
+    expect(breakerOutput.error).toContain('document_generate');
+  });
+
+  it('does not trip the repeated-error breaker when tool arguments change meaningfully', async () => {
+    const execStub = vi.fn(async () => ({
+      result: {
+        status: 'error',
+        code: 'code_runtime_error',
+        error: 'Sandbox execution failed for request req_67890',
+      },
+      streamSeq: 10,
+    }) as unknown as ExecuteServerToolResult);
+    const { runtime } = buildFixture({ executeServerTool: execStub });
+    const loopState = buildLoopState();
+
+    loopState.toolCalls = [
+      {
+        id: 'tc-docx-1',
+        name: 'document_generate',
+        args: '{"format":"docx","entityId":"org-1"}',
+      },
+    ];
+    await runtime.consumeToolCalls(buildInput(loopState));
+
+    loopState.toolCalls = [
+      {
+        id: 'tc-docx-2',
+        name: 'document_generate',
+        args: '{"format":"docx","entityId":"org-2"}',
+      },
+    ];
+    const second = await runtime.consumeToolCalls(buildInput(loopState));
+    const secondOutput = JSON.parse(second.responseToolOutputs[0]?.output ?? '{}');
+
+    expect(execStub).toHaveBeenCalledTimes(2);
+    expect(loopState.continueGenerationLoop).toBe(true);
+    expect(second.shouldBreakLoop).toBe(false);
+    expect(secondOutput.code).toBe('code_runtime_error');
+    expect(secondOutput.code).not.toBe('tool_loop_repeated_error');
+  });
 });


### PR DESCRIPTION
# Fix: Chat Loop Guard

## Objective
Reapply the repeated-tool-error loop breaker (chat-core dispatch breaker + chat-service outer-loop sync) plus the chat-ui stream projection compaction on current `main`, after BR-38a/BR-41a refactored the dispatch into `ChatRuntime.consumeToolCalls`. Prevent repeated tool-call/tool-error loops from freezing or saturating the browser tab while preserving legitimate multi-step tool use.

## Scope / Guardrails
- Scope limited to chat assistant turn execution, tool-call error handling, chat stream projection, chat rendering, and focused tests.
- No database migration planned.
- Make-only workflow, no direct Docker/npm commands.
- Root workspace `/home/antoinefa/src/sentropic` is reserved for user dev/UAT (`ENV=dev`) and must remain stable.
- Branch development happens in isolated worktree `tmp/fix-chat-loop-guard`.
- Automated test campaigns must run on dedicated environments, never on root `dev`.
- In every `make` command, `ENV=<env>` must be passed as the last argument.
- All new text in code, docs, tests, commits, and PR body must be English.
- Start by reading current `ChatRuntime.consumeToolCalls` structure before reimplementing; do not pattern-match the closed PR #183 diff blindly — the post-Lot-21e-2 dispatch lives inside chat-core now.
- Do not add arbitrary timeouts or hide tool errors from the user.
- Do not introduce a generic max-iteration cap; the guard must trigger only on signature-repeated errors.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths (implementation scope)**:
  - `BRANCH.md`
  - `package-lock.json`
  - `api/src/services/chat-service.ts`
  - `api/tests/unit/chat-service-tools.test.ts`
  - `packages/chat-core/src/runtime-tool-dispatch.ts`
  - `packages/chat-core/src/runtime.ts`
  - `packages/chat-core/src/runtime-run-prepare.ts`
  - `packages/chat-core/tests/runtime-tool-dispatch.test.ts`
  - `packages/chat-core/package.json`
  - `packages/chat-ui/src/utils/chat-run-projection.ts`
  - `packages/chat-ui/src/client/streamHistory.ts`
  - `packages/chat-ui/tests/stream-throughput.test.ts`
  - `packages/chat-ui/tests/chat-run-projection.test.ts`
  - `packages/chat-ui/package.json`
  - `ui/tests/utils/chat-run-projection.test.ts`
- **Forbidden Paths (must not change in this branch)**:
  - `Makefile`
  - `docker-compose*.yml`
  - `.cursor/rules/**`
  - `packages/skills/**`
  - `plan/NN-BRANCH_*.md` (any branch file)
- **Conditional Paths (allowed only with explicit exception)**:
  - `api/drizzle/*.sql`
  - `.github/workflows/**`
  - `api/src/services/llm-runtime/**`
  - `api/src/routes/**`
  - `e2e/tests/03-chat.spec.ts`
  - `e2e/tests/06-streams.spec.ts`
  - `e2e/tests/08-chat-heavy.spec.ts`
  - `ui/src/lib/components/chat/**`
  - `ui/src/lib/stores/streamHub.ts`
  - `spec/**`
- **Exception process**:
  - Declare exception ID `CLG2-EXn` in `## Feedback Loop` before touching any conditional or forbidden path.
  - Include reason, impact, and rollback strategy.

## Feedback Loop
- [ ] Branch context: replaces closed PR #183 (fix/chat-loop-guard-analysis, 397 commits behind main when closed). Old worktree `tmp/fix-chat-loop-guard-analysis` and its branch remain untouched as historical reference.
- [ ] Before/after measurement carried over from the old branch (live-run on 2026-06-02 in `tmp/fix-chat-loop-guard-analysis` with sync line removed): pre-fix scenario rides to **11 LLM calls** (`BASE_MAX_ITERATIONS=10` + 1 pass-2 fallback); post-fix breaker caps at **4 LLM calls** (3 tentatives + pass-2). Reduction 64 %. Reapply target on current main MUST preserve this signature.

## AI Flaky tests
- Acceptance rule:
  - Accept only non-systematic provider/network/model nondeterminism as `flaky accepted`.
  - Non-systematic means at least one success on the same commit and same command.
  - Never amend tests with additive timeouts.
  - If flaky, analyze impact vs `main`: if unrelated, accept and record command + failing test file + signature in `BRANCH.md`; if related, treat as blocking.
  - Capture explicit user sign-off before merge.
- Pre-recorded flaky carried from PR #183: `api/tests/ai/chat-sync.test.ts` (`should generate assistant response with AI` 15 s timeout; `should generate response with tool calls` jobCompleted false at 30 s). Signature: provider/network latency under CI parallel load. If it recurs on this branch, re-validate the signature on this commit (same-commit CI rerun + local repro) before reusing the prior sign-off.

## Orchestration Mode (AI-selected)
- [x] **Mono-branch + cherry-pick** (default for orthogonal tasks; single final test cycle)
- [ ] **Multi-branch**
- Rationale: the loop guard breaker, the api-side sync, and the UI projection bound form one runtime defect class and need one integrated test cycle.

## UAT Management (in orchestration context)
- **Mono-branch**: UAT performed on the integrated branch after push, on the user's root workspace (`ENV=dev`).
- Branch diagnostics and automated tests run from `tmp/fix-chat-loop-guard`.

## Plan / Todo (lot-based)
- [ ] **Lot 0 — Baseline & constraints**
  - [x] Read `rules/MASTER.md`, `rules/workflow.md`, `rules/conductor.md`, `rules/subagents.md`, `rules/testing.md`.
  - [x] Confirm isolated worktree `tmp/fix-chat-loop-guard` based on `origin/main` (`90323a6b`).
  - [x] Copy root `.env` into the worktree.
  - [x] Define environment mapping: branch dev `ENV=fix-chat-loop-guard`, tests `ENV=test-fix-chat-loop-guard`, e2e `ENV=e2e-fix-chat-loop-guard`.
  - [x] Define ports: API `9096`, UI `5296`, Maildev UI `1196` (carried over from PR #183 ports; free at branch start).
  - [x] Confirm command style: `make ... API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=<env>` with `ENV` last.
  - [x] Confirm scope and guardrails.

- [x] **Lot 1 — chat-core repeated-tool-error breaker (post-Lot-21e refactor)**
  - [x] Read `packages/chat-core/src/runtime-tool-dispatch.ts` on current main; locate the per-tool dispatch body and the catch path (`{status:'error'}` envelope returns and thrown errors).
  - [x] Add `toolErrorSignatureCounts?: Record<string, number>` to `AssistantRunLoopState` in `packages/chat-core/src/runtime.ts`.
  - [x] Initialize `toolErrorSignatureCounts: {}` in `packages/chat-core/src/runtime-run-prepare.ts` next to `continueGenerationLoop`.
  - [x] In `runtime-tool-dispatch.ts`:
    - [x] Add signature helpers: `normalizeLoopGuardText`, `normalizeLoopGuardArgs` (strip request_id/trace_id/timestamps/UUIDs/numeric IDs), `buildToolLoopSignature(toolName, args, errorMessage)`.
    - [x] Add `incrementToolLoopErrorCount(loopState, toolName, args, errorMessage)` and `getReturnedToolErrorMessage(result)` (detects `{status:'error', code?, error?|message?}` returns that do not throw).
    - [x] On the 3rd identical normalized signature (threshold = 2 → trip on count > 2), set `loopState.continueGenerationLoop = false`, emit a `tool_call_result` carrying `{status:'error', code:'tool_loop_repeated_error', error:..., repeat_count, tool_name}`, return `shouldBreakLoop: true` and exit the per-tool loop early.
    - [x] Refactor success/error accumulator pushes into a single `pushToolAccumulator` helper to avoid double-tracking the signature.
  - [x] Add `packages/chat-core/tests/runtime-tool-dispatch.test.ts`:
    - [x] `trips a terminal loop breaker after repeated identical returned tool errors in one assistant turn`
    - [x] `normalizes noisy thrown tool errors before tripping the loop breaker`
    - [x] `does not trip the repeated-error breaker when tool arguments change meaningfully`
  - [x] Bump `packages/chat-core/package.json` (patch 0.1.3 → 0.1.4 — new optional state field on `AssistantRunLoopState`, additive, stays within consumers' `^0.1.2` range; aligned `package-lock.json` chat-core entry).
  - [x] Lot gate:
    - [x] `make typecheck-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
    - [x] `make test-pkg-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard` (21 files, 248 tests; `runtime-tool-dispatch.test.ts` 22 → 25 tests)

- [x] **Lot 2 — chat-service outer-loop sync line**
  - [x] Read `api/src/services/chat-service.ts` around the post-`consumeToolCalls` "thin invocation + state sync" block (L3887-3893 on current main): identified insertion after `streamSeq`/`contextBudgetReplanAttempts` are synced back.
  - [x] Add `continueGenerationLoop = loopState.continueGenerationLoop;` immediately after the existing sync of `streamSeq` and `contextBudgetReplanAttempts` so the outer `while (continueGenerationLoop)` honors the breaker's stop signal.
  - [x] Add regression test `should stop repeated identical tool validation errors before the max-iteration fallback` in `api/tests/unit/chat-service-tools.test.ts`:
    - [x] Mock `callLLMStream` to always emit a `plan` tool call with invalid `{action:'unknown'}` args when tools are enabled.
    - [x] Assert `calls.length === 4` (3 tool-enabled attempts + 1 pass-2 with `toolChoice: 'none'`).
    - [x] Confirm the pre-existing `should continue beyond 10 iterations when active TODO can progress without user input` still passes (legitimate progression untouched).
  - [x] Lot gate:
    - [x] `make typecheck-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
    - [x] `make lint-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
    - [x] `make test-api-unit SCOPE=tests/unit/chat-service-tools.test.ts API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard` (17 tests, including the new `should stop repeated identical tool validation errors before the max-iteration fallback`)

- [ ] **Lot 3 — chat-ui stream projection compaction** *(deferred)*
  - On-main analysis: `packages/chat-ui/src/utils/chat-run-projection.ts` (200 LOC) already deduplicates by `sequence` in both `appendLiveProjectionEvent` (line 198) and `mergeProjectionHistoryEvents` (Map by sequence). The original PR #183 compaction targeted the live unbounded delta flood. With the Lot 1 backend breaker capping repeated identical tool errors at **3 attempts + 1 pass-2 = 4 LLM calls** per turn, the flood is structurally bounded upstream — the secondary UI compaction is speculative without direct evidence on current main.
  - Decision: defer chat-ui projection compaction. Reopen only if the UAT in Lot N-2 surfaces residual tab saturation after the backend breaker. If reopened, do so on a dedicated `fix/chat-ui-projection-compaction` branch with concrete reproduction (failing `stream-throughput.test.ts` asserting unbounded growth on a synthetic flood) before code changes.

- [ ] **Lot N-2 — UAT (root workspace, `ENV=dev`)**
  - [ ] Web app: repeated identical tool-error loop terminates cleanly without freezing the browser tab.
  - [ ] Web app: normal multi-step tool workflow (legitimate progressing plan/todo) still works.
  - [ ] Web app: DOCX organization generation still completes.
  - [ ] Web app: PPTX organization generation still completes.
  - [ ] Web app: breaker-stopped loop shows an actionable user-visible error (`tool_loop_repeated_error` surface).

- [ ] **Lot N — Final validation**
  - [ ] `make typecheck-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make lint-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make typecheck-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make lint-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make typecheck-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make typecheck-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make test-pkg-chat-core API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make test-chat-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make test-api API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make test-ui API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard`
  - [ ] `make test-api-ai API_TEST_WORKERS=1 API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=test-fix-chat-loop-guard` (document any flaky signatures vs the carry-over note above)
  - [ ] `git diff --check`
  - [ ] Confirm `packages/chat-core/package.json` version bump if `packages/chat-core/src/**` changed.
  - [ ] Confirm `packages/chat-ui/package.json` version bump if `packages/chat-ui/src/**` changed.
  - [ ] Build before e2e: `make build-api build-ui-image API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=e2e-fix-chat-loop-guard`
  - [ ] E2E chat smoke: `make test-e2e E2E_SPEC=tests/03-chat.spec.ts WORKERS=1 RETRIES=0 API_PORT=9096 UI_PORT=5296 MAILDEV_UI_PORT=1196 ENV=e2e-fix-chat-loop-guard`
  - [ ] Create PR using `BRANCH.md` text as PR body (link the closed PR #183 in the description for context).
  - [ ] Verify PR CI.
  - [ ] Once UAT + CI are both OK, commit removal of `BRANCH.md`, push, and merge.
