### PR TITLE
chore: run prepare-node-workspace npm ci as host-uid (stop creating root-owned node_modules)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1564,7 +1564,8 @@ clean-db: ## Clean database files and restart services [SKIP_CONFIRM=true to ski
 .PHONY: prepare-node-workspace
 prepare-node-workspace: build-llm-mesh build-flow build-auth-hono build-auth-client ## Prepare mounted workspace node_modules and package dist for dev/test runtime
 	$(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml build api
-	$(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml run --rm --no-deps api sh -lc 'cd /workspace && npm ci --workspaces --include-workspace-root --ignore-scripts --audit=false'
+	$(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml run --rm --no-deps api sh -lc 'chown -R '"$$(id -u):$$(id -g)"' /workspace/node_modules 2>/dev/null || true'
+	$(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml run --rm --no-deps -u "$$(id -u):$$(id -g)" -e HOME=/tmp -e npm_config_cache=/tmp/npm-cache api sh -lc 'cd /workspace && npm ci --workspaces --include-workspace-root --ignore-scripts --audit=false'
 
 .PHONY: dev
 dev: prepare-node-workspace ## Start UI and API in watch mode
@@ -1612,7 +1613,8 @@ up-api-test: prepare-node-workspace ## Start the api stack in detached mode with
 
 .PHONY: up-api-test-ci
 up-api-test-ci: build-llm-mesh build-flow build-auth-hono build-auth-client ## Start the api stack in detached mode for CI (reuse prebuilt API image, no rebuild)
-	DISABLE_RATE_LIMIT=true $(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -lc 'cd /workspace && npm ci --workspaces --include-workspace-root && cd /workspace/api && npm run db:migrate'
+	DISABLE_RATE_LIMIT=true $(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml run --rm api sh -lc 'chown -R '"$$(id -u):$$(id -g)"' /workspace/node_modules 2>/dev/null || true'
+	DISABLE_RATE_LIMIT=true $(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml run --rm -u "$$(id -u):$$(id -g)" -e HOME=/tmp -e npm_config_cache=/tmp/npm-cache api sh -lc 'cd /workspace && npm ci --workspaces --include-workspace-root && cd /workspace/api && npm run db:migrate'
 	DISABLE_RATE_LIMIT=true $(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml up -d api --wait api
 
 .PHONY: up-ui


### PR DESCRIPTION
## Problem

`prepare-node-workspace` (and the CI sibling `up-api-test-ci`) ran the workspace `npm ci` as **root** via `docker compose run` (no `-u`), creating `node_modules` (workspace root + `api/` + `ui/` + `packages/*`) owned by root. A later host-uid install (`install-internal-packages`, which uses `-u "$(id -u):$(id -g)"`) then could not `rmdir` those dirs → recurring `EACCES` cruft.

## Root cause (deeper than just the missing `-u`)

Adding `-u` to the `npm ci` is necessary but not sufficient. The api image is built with `/workspace/node_modules` populated **as root** (`api/Dockerfile:60` `RUN npm ci ...`, no `USER` directive). `docker-compose.dev.yml` mounts a **named volume** `workspace_node_modules` at `/workspace/node_modules`; on first creation Docker seeds that volume from the image's root-owned content. A host-uid `npm ci` then fails on `rmdir /workspace/node_modules/.bin` (EACCES) because the pre-seeded `.bin` is root-owned — reproduced on a fresh worktree.

## Fix (Makefile only)

Two changes, mirroring the existing working host-uid pattern (`install-internal-packages` at Makefile:1058 and the `chown` repair at Makefile:1053):

1. Add `-u "$(id -u):$(id -g)" -e HOME=/tmp -e npm_config_cache=/tmp/npm-cache` to the workspace `npm ci` invocations in `prepare-node-workspace` and `up-api-test-ci`.
2. Add a one-shot root `chown -R "$(id -u):$(id -g)" /workspace/node_modules` step (scoped to the volume mount, `|| true`) immediately before each host-uid `npm ci`, to neutralize the root-owned content the named volume inherits from the image build. This is the piece that makes the host-uid install actually succeed.

The `up-api-test-ci` sibling got the same treatment: its `npm run db:migrate` writes to the DB, not the filesystem, so running it host-uid is safe and keeps the fix durable across both paths.

## Proof (fresh worktree off origin/main, first bringup creates node_modules)

`make up-api-test API_PORT=9240 UI_PORT=5440 MAILDEV_UI_PORT=1340 ENV=chore-prepare-node-uid` → all containers **Healthy**:

```
chore-prepare-node-uid-api-1            Up (healthy)  0.0.0.0:9240->8787/tcp
chore-prepare-node-uid-postgres-1       Up (healthy)
chore-prepare-node-uid-maildev-1        Up (healthy)
chore-prepare-node-uid-scw-tem-mock-1   Up
```

API health endpoint: `{"status":"ok","services":{"database":"ok","tables":{"settings":"accessible","jobQueue":"accessible"}}}`

Host-side ownership of the bind-mounted node_modules (the recurring cruft) — now **host-owned (uid 1000 = antoinefa)**, zero non-host-owned children:

```
./api/node_modules  antoinefa:antoinefa  uid=1000
./ui/node_modules   antoinefa:antoinefa  uid=1000
```

(`./node_modules` root is the empty anchor dir for the `workspace_node_modules` named volume; its real contents live inside the volume and are node-owned in-container after the chown — no host cruft.)

Without the fix, the same fresh-worktree bringup failed with `EACCES: permission denied, rmdir '/workspace/node_modules/.bin'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)