### PR TITLE
fix(chat): eliminate stream-event/trace FK write-order race (chat-tools flake)

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,50 @@
+# Fix: chat persistence write-order FK race (chat_stream_events / chat_generation_traces)
+
+## Objective
+Eliminate the deterministic-under-load FK race where `chat_stream_events.message_id` (and `chat_generation_traces.session_id`/`assistant_message_id`) reference a `chat_messages`/`chat_sessions` row that is not (or no longer) committed — causing `insert ... violates foreign key constraint` → job failure → `chat-tools` AI shard flaking. Guarantee the parent message/session row exists for the whole window any stream event or generation trace references it.
+
+## Scope / Guardrails
+- Owning area: `packages/chat-core` runtime (checkpoint/finalization/messages) + the API adapters `api/src/services/chat/*` it drives.
+- Make-only workflow, no direct Docker commands. Tests on `ENV=test-fixrace` only, never dev.
+- One migration max in `api/drizzle/*.sql` (only if a deferred/ordering constraint change is truly required — prefer code ordering over schema change).
+- All new text in English.
+
+## Branch Scope Boundaries (MANDATORY)
+- **Allowed Paths**:
+  - `packages/chat-core/src/**`
+  - `packages/chat-core/tests/**`
+  - `api/src/services/chat/**`
+  - `api/src/services/chat-trace.ts`
+  - `api/tests/ai/chat-tools.test.ts`
+  - `api/tests/**` (only persistence/race regression tests)
+  - `BRANCH.md`
+- **Forbidden Paths**:
+  - `Makefile`
+  - `docker-compose*.yml`
+  - `.cursor/rules/**`
+  - `.github/workflows/ci.yml`
+  - app rebrand / unrelated source
+- **Conditional Paths**:
+  - `packages/chat-core/package.json` (version bump — required if `src/**` changes; FIXRACE-EX1)
+  - `api/drizzle/*.sql` (max 1, only if a constraint-ordering migration is unavoidable; FIXRACE-EX2)
+
+## Feedback Loop
+- FIXRACE-EX1: bump `@sentropic/chat-core` version (patch) since `src/**` changes — enforce-package-bump gate. Approved by plan.
+- FIXRACE-Q1: confirm root path — suspected `runtime-checkpoint.ts:223` `deleteAfterSequence` truncation racing with in-flight `streamBuffer.append(messageId)` / `chat-trace` insert; OR `insertMany` sequence-conflict swallow leaving message absent. Status: open until the repro pins it.
+
+## Mode
+- Mono-branch.
+
+## Plan / Todo (lot-based)
+- [x] **Lot 0 — Baseline**: worktree off `origin/main` (`f1c2807e`, post-#240 trigger fix). Forensics: `docs/uat/2026-06-03-chat-tools-fk-forensics.md` (on BR-14e worktree) — FK race reproduced 5/5 locally, intermittent in CI; pre-existing (exists on main), exposed by chat-ui path-filter change.
+- [ ] **Lot 1 — Deterministic repro (systematic-debugging)**
+  - [ ] Add/scope a failing test proving the FK violation deterministically (chat message lifecycle: insert assistant → append stream events → checkpoint truncate; assert no orphan event/trace). Run on `ENV=test-fixrace`.
+- [ ] **Lot 2 — Minimal fix**
+  - [ ] Enforce ordering/atomicity: the assistant `chat_messages` row (and session) is committed before any `chat_stream_events`/`chat_generation_traces` insert that references it; and `deleteAfterSequence` truncation does not orphan in-flight events. Prefer code-level ordering (await commit boundary, or transactional insert+events) over schema change.
+  - [ ] Re-run the repro green; run `make test-api ENV=test-fixrace` (esp. AI shard) + `make test-chat-core`.
+- [ ] **Lot N — Validate + PR**
+  - [ ] Full gates; bump `@sentropic/chat-core`; PR with BRANCH.md body; merge-commit; remove BRANCH.md.
+
+## Notes
+- This is the RACE half of the corrective set; the TRIGGER half (`fix/ci-ai-shard-trigger`, PR #240) is MERGED, so this branch's chat-core changes now correctly retrigger the API integration + AI shard.
+- BR-14e (`chore/sentropic-codebase-finalization`) rebases on main after this merges, then finalizes green.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -29,19 +29,19 @@ Eliminate the deterministic-under-load FK race where `chat_stream_events.message
   - `api/drizzle/*.sql` (max 1, only if a constraint-ordering migration is unavoidable; FIXRACE-EX2)
 
 ## Feedback Loop
-- FIXRACE-EX1: bump `@sentropic/chat-core` version (patch) since `src/**` changes — enforce-package-bump gate. Approved by plan.
-- FIXRACE-Q1: confirm root path — suspected `runtime-checkpoint.ts:223` `deleteAfterSequence` truncation racing with in-flight `streamBuffer.append(messageId)` / `chat-trace` insert; OR `insertMany` sequence-conflict swallow leaving message absent. Status: open until the repro pins it.
+- FIXRACE-EX1: NOT APPLICABLE / WITHDRAWN. The minimal fix lives entirely in the API adapter layer (`api/src/services/chat/postgres-stream-buffer.ts` + `api/src/services/chat-trace.ts`); `packages/chat-core/src/**` was NOT modified. The `enforce-package-bump` gate triggers only on `packages/<pkg>/src/**` changes, so no chat-core version bump is required (public surface unchanged). The orphan-reference handling belongs at the Postgres adapter boundary that actually owns the FK, keeping chat-core transport/DB-agnostic.
+- FIXRACE-Q1: RESOLVED. Root cause = orphaned-reference INSERT, not truncation orphaning. The FKs `chat_stream_events.message_id`, `chat_generation_traces.{session_id,assistant_message_id}` are all `ON DELETE CASCADE` (schema lines 462/498/501), so `deleteAfterSequence` (checkpoint) cannot orphan — Postgres cascades the children. The real race: a parent `chat_messages`/`chat_sessions` row is deleted while the generation job is still flushing stream events / traces (in the AI shard, `cleanupAuthData` afterEach does `db.delete(users)` → cascade session→messages→events/traces while an in-flight or leftover job keeps appending). The post-cascade `postgresStreamBuffer.append(...,messageId)` / `writeChatGenerationTrace(...)` then throw an UNHANDLED FK `23503` (`chat_stream_events_message_id_chat_messages_id_fk` / `chat_generation_traces_session_id_chat_sessions_id_fk`), crashing the job → tool-call assertions fail + 30s timeout. Reproduced deterministically 2/2 in `api/tests/api/chat-persistence-write-order.test.ts` (real Postgres FK, no LLM). Suspect `runtime-checkpoint.ts:223` (truncation) DISPROVEN by the cascade declaration.
 
 ## Mode
 - Mono-branch.
 
 ## Plan / Todo (lot-based)
 - [x] **Lot 0 — Baseline**: worktree off `origin/main` (`f1c2807e`, post-#240 trigger fix). Forensics: `docs/uat/2026-06-03-chat-tools-fk-forensics.md` (on BR-14e worktree) — FK race reproduced 5/5 locally, intermittent in CI; pre-existing (exists on main), exposed by chat-ui path-filter change.
-- [ ] **Lot 1 — Deterministic repro (systematic-debugging)**
-  - [ ] Add/scope a failing test proving the FK violation deterministically (chat message lifecycle: insert assistant → append stream events → checkpoint truncate; assert no orphan event/trace). Run on `ENV=test-fixrace`.
-- [ ] **Lot 2 — Minimal fix**
-  - [ ] Enforce ordering/atomicity: the assistant `chat_messages` row (and session) is committed before any `chat_stream_events`/`chat_generation_traces` insert that references it; and `deleteAfterSequence` truncation does not orphan in-flight events. Prefer code-level ordering (await commit boundary, or transactional insert+events) over schema change.
-  - [ ] Re-run the repro green; run `make test-api ENV=test-fixrace` (esp. AI shard) + `make test-chat-core`.
+- [x] **Lot 1 — Deterministic repro (systematic-debugging)**
+  - [x] Added `api/tests/api/chat-persistence-write-order.test.ts`: real-Postgres FK repro (no LLM). Asserts a stream event / generation trace referencing an already-cascade-deleted parent must NOT crash the write. RED 2/2 with `chat_stream_events_message_id_chat_messages_id_fk` + `chat_generation_traces_session_id_chat_sessions_id_fk` (code `23503`). In-memory store cannot model the FK, so this is correctly an `api/tests/**` integration test on `ENV=test-fixrace`.
+- [x] **Lot 2 — Minimal fix**
+  - [x] Treat the specific parent-FK `23503` as a benign no-op (the `ON DELETE CASCADE` parent — and thus the child — is gone; nothing to keep) in `postgres-stream-buffer.ts` (`append` + `appendAtomically`) and `chat-trace.ts` (`writeChatGenerationTrace`). Constraint-name matched so only the message/session parent FKs are swallowed; all other errors still throw. Public contract preserved (methods still return normally). No schema change (FKs already cascade).
+  - [x] Re-run the repro green; ran the chat-tools AI shard ≥3× consecutively + `make test-pkg-chat-core` + `make test-api-endpoints` regressions.
 - [ ] **Lot N — Validate + PR**
   - [ ] Full gates; bump `@sentropic/chat-core`; PR with BRANCH.md body; merge-commit; remove BRANCH.md.
 

--- a/api/src/services/chat-trace.ts
+++ b/api/src/services/chat-trace.ts
@@ -2,8 +2,29 @@ import { lt } from 'drizzle-orm';
 import { db } from '../db/client';
 import { chatGenerationTraces } from '../db/schema';
 import { createId } from '../utils/id';
+import { findPgError } from '../utils/pg-errors';
 
 export type ChatTracePhase = 'pass1' | 'pass2';
+
+/**
+ * The parent `chat_sessions` / `chat_messages` row referenced by a generation
+ * trace was deleted (e.g. session cascade) while the trace was still being
+ * flushed. Both FKs declare `ON DELETE CASCADE`, so the parent's removal is
+ * meant to take these traces with it — writing a now-orphaned trace is a no-op,
+ * not a fatal error for the generation job. We only swallow these two specific
+ * parent-FK violations; any other FK error still propagates.
+ */
+const isOrphanTraceParentFkError = (error: unknown): boolean => {
+  const pgError = findPgError(error, '23503');
+  if (!pgError) return false;
+  const matches = (needle: string): boolean =>
+    (pgError.constraint?.includes(needle) ?? false) ||
+    (pgError.message?.includes(needle) ?? false);
+  return (
+    matches('chat_generation_traces_session_id_chat_sessions_id_fk') ||
+    matches('chat_generation_traces_assistant_message_id_chat_messages_id_fk')
+  );
+};
 
 export type ChatTraceToolCall = {
   id?: string;
@@ -31,22 +52,32 @@ export async function writeChatGenerationTrace(input: {
 
   type TraceInsert = typeof chatGenerationTraces.$inferInsert;
 
-  await db.insert(chatGenerationTraces).values({
-    id: createId(),
-    sessionId: input.sessionId,
-    assistantMessageId: input.assistantMessageId,
-    userId: input.userId,
-    workspaceId: input.workspaceId ?? null,
-    phase: input.phase,
-    iteration: input.iteration,
-    model: input.model ?? null,
-    toolChoice: input.toolChoice ?? null,
-    tools: (input.tools ?? null) as TraceInsert['tools'],
-    openaiMessages: input.openaiMessages as TraceInsert['openaiMessages'],
-    toolCalls: (input.toolCalls ?? null) as TraceInsert['toolCalls'],
-    meta: (input.meta ?? null) as TraceInsert['meta'],
-    createdAt: new Date()
-  });
+  try {
+    await db.insert(chatGenerationTraces).values({
+      id: createId(),
+      sessionId: input.sessionId,
+      assistantMessageId: input.assistantMessageId,
+      userId: input.userId,
+      workspaceId: input.workspaceId ?? null,
+      phase: input.phase,
+      iteration: input.iteration,
+      model: input.model ?? null,
+      toolChoice: input.toolChoice ?? null,
+      tools: (input.tools ?? null) as TraceInsert['tools'],
+      openaiMessages: input.openaiMessages as TraceInsert['openaiMessages'],
+      toolCalls: (input.toolCalls ?? null) as TraceInsert['toolCalls'],
+      meta: (input.meta ?? null) as TraceInsert['meta'],
+      createdAt: new Date()
+    });
+  } catch (error) {
+    if (isOrphanTraceParentFkError(error)) {
+      // Parent session/message row was deleted (cascade) mid-flight. The
+      // ON DELETE CASCADE FKs mean this trace would be removed anyway, so
+      // dropping it is the correct no-op rather than crashing the job.
+      return;
+    }
+    throw error;
+  }
 }
 
 export async function purgeOldChatTraces(retentionDays: number): Promise<number> {

--- a/api/src/services/chat/postgres-stream-buffer.ts
+++ b/api/src/services/chat/postgres-stream-buffer.ts
@@ -26,6 +26,25 @@ const isStreamSequenceConflictError = (error: unknown): boolean => {
 };
 
 /**
+ * The parent `chat_messages` row referenced by `message_id` was deleted
+ * (e.g. session cascade) while a stream event for it was still being flushed.
+ * The FK declares `ON DELETE CASCADE`, so the parent's removal is meant to take
+ * these events with it — inserting a now-orphaned event is therefore a no-op,
+ * not a fatal error for the generation job. We only swallow the specific
+ * message-FK violation; any other FK error still propagates.
+ */
+const isOrphanMessageFkError = (error: unknown): boolean => {
+  const pgError = findPgError(error, '23503');
+  if (!pgError) return false;
+  return (
+    (pgError.constraint?.includes('chat_stream_events_message_id_chat_messages_id_fk') ??
+      false) ||
+    (pgError.message?.includes('chat_stream_events_message_id_chat_messages_id_fk') ??
+      false)
+  );
+};
+
+/**
  * Per SPEC §4 (Stream protocol) + §5 (Ports list).
  * PostgresStreamBuffer implements StreamBuffer over Drizzle + `chat_stream_events`.
  *
@@ -112,6 +131,12 @@ export class PostgresStreamBuffer implements StreamBuffer {
           nextSequence = await this.getNextSequence(streamId);
           continue;
         }
+        if (isOrphanMessageFkError(error)) {
+          // Parent chat_messages row was deleted (cascade) mid-flight. The
+          // ON DELETE CASCADE FK means this event would be removed anyway, so
+          // dropping it is the correct no-op rather than crashing the job.
+          return nextSequence;
+        }
         throw error;
       }
     }
@@ -137,30 +162,44 @@ export class PostgresStreamBuffer implements StreamBuffer {
   ): Promise<number> {
     const eventId = createId();
     let insertedSequence = 1;
+    let orphaned = false;
 
-    await db.transaction(async (tx) => {
-      await tx.execute(
-        sql`SELECT pg_advisory_xact_lock(hashtext(${STREAM_SEQUENCE_LOCK_NAMESPACE}), hashtext(${streamId}))`,
-      );
+    try {
+      await db.transaction(async (tx) => {
+        await tx.execute(
+          sql`SELECT pg_advisory_xact_lock(hashtext(${STREAM_SEQUENCE_LOCK_NAMESPACE}), hashtext(${streamId}))`,
+        );
 
-      const result = await tx
-        .select({
-          maxSequence: sql<number>`COALESCE(MAX(${chatStreamEvents.sequence}), 0)`,
-        })
-        .from(chatStreamEvents)
-        .where(eq(chatStreamEvents.streamId, streamId));
+        const result = await tx
+          .select({
+            maxSequence: sql<number>`COALESCE(MAX(${chatStreamEvents.sequence}), 0)`,
+          })
+          .from(chatStreamEvents)
+          .where(eq(chatStreamEvents.streamId, streamId));
 
-      insertedSequence = Number(result[0]?.maxSequence ?? 0) + 1;
+        insertedSequence = Number(result[0]?.maxSequence ?? 0) + 1;
 
-      await tx.insert(chatStreamEvents).values({
-        id: eventId,
-        messageId: messageId || null,
-        streamId,
-        eventType,
-        data,
-        sequence: insertedSequence,
+        await tx.insert(chatStreamEvents).values({
+          id: eventId,
+          messageId: messageId || null,
+          streamId,
+          eventType,
+          data,
+          sequence: insertedSequence,
+        });
       });
-    });
+    } catch (error) {
+      if (isOrphanMessageFkError(error)) {
+        // Parent chat_messages row was deleted (cascade) mid-flight. The
+        // ON DELETE CASCADE FK means this event would be removed anyway, so
+        // dropping it is the correct no-op rather than crashing the job.
+        orphaned = true;
+      } else {
+        throw error;
+      }
+    }
+
+    if (orphaned) return insertedSequence;
 
     await this.notifyStreamEvent(streamId, eventType, insertedSequence);
     return insertedSequence;

--- a/api/tests/api/chat-persistence-write-order.test.ts
+++ b/api/tests/api/chat-persistence-write-order.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+import { db } from '../../src/db/client';
+import { chatMessages, chatSessions } from '../../src/db/schema';
+import { postgresChatMessageStore } from '../../src/services/chat/postgres-chat-message-store';
+import { postgresStreamBuffer } from '../../src/services/chat/postgres-stream-buffer';
+import { writeChatGenerationTrace } from '../../src/services/chat-trace';
+import {
+  cleanupAuthData,
+  createAuthenticatedUser,
+} from '../utils/auth-helper';
+import { createTestId } from '../utils/test-helpers';
+
+/**
+ * Regression for the chat persistence write-order FK race.
+ *
+ * Forensics (docs/uat/2026-06-03-chat-tools-fk-forensics.md): the
+ * `chat-tools` AI shard flakes under load with
+ *   - `chat_stream_events_message_id_chat_messages_id_fk`
+ *   - `chat_generation_traces_session_id_chat_sessions_id_fk`
+ *   - `chat_generation_traces_assistant_message_id_chat_messages_id_fk`
+ *
+ * Mechanism (verified): `chat_sessions.user_id` is `ON DELETE CASCADE`, so the
+ * AI-test teardown (`cleanupAuthData` → `db.delete(users)`) cascades to delete
+ * the session + assistant message while the generation job is still flushing
+ * stream events / generation traces. Any in-flight
+ * `postgresStreamBuffer.append(streamId, type, data, seq, messageId)` or
+ * `writeChatGenerationTrace(...)` that lands AFTER the parent row is gone throws
+ * an unhandled FK violation, which fails the chat job → the shard sees missing
+ * tool-call events and times out.
+ *
+ * The invariant under test: a stream event / generation trace whose referenced
+ * `chat_messages` / `chat_sessions` parent row no longer exists must NOT crash
+ * the generation with an unhandled FK violation. The write of an orphaned
+ * reference is a no-op (the parent — and by cascade these children — are gone),
+ * not a fatal error for the job.
+ */
+describe('chat persistence write-order FK race', () => {
+  let user: Awaited<ReturnType<typeof createAuthenticatedUser>>;
+  let sessionId: string;
+  let assistantMessageId: string;
+
+  beforeEach(async () => {
+    user = await createAuthenticatedUser('editor');
+    sessionId = createTestId();
+    assistantMessageId = createTestId();
+
+    await db.insert(chatSessions).values({
+      id: sessionId,
+      userId: user.id,
+      workspaceId: user.workspaceId ?? null,
+      title: 'race repro',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    // Assistant placeholder row (sequence 2 to mimic user@1 + assistant@2).
+    await postgresChatMessageStore.insertMany([
+      {
+        id: assistantMessageId,
+        sessionId,
+        role: 'assistant',
+        content: null,
+        toolCalls: null,
+        toolCallId: null,
+        reasoning: null,
+        model: 'test-model',
+        promptId: null,
+        promptVersionId: null,
+        sequence: 2,
+        createdAt: new Date(),
+      },
+    ]);
+  });
+
+  afterEach(async () => {
+    // Best-effort: rows may already be gone via the simulated cascade.
+    await db.delete(chatMessages).where(eq(chatMessages.id, assistantMessageId));
+    await db.delete(chatSessions).where(eq(chatSessions.id, sessionId));
+    await cleanupAuthData();
+  });
+
+  it('does not crash when a stream event references an already-deleted assistant message', async () => {
+    // First append while the parent exists — must succeed (streamId === messageId).
+    await expect(
+      postgresStreamBuffer.append(
+        assistantMessageId,
+        'status',
+        { state: 'started' },
+        1,
+        assistantMessageId,
+      ),
+    ).resolves.toBeDefined();
+
+    // Simulate the teardown cascade: deleting the session cascades to
+    // chat_messages → chat_stream_events. The assistant row is now gone.
+    await db.delete(chatSessions).where(eq(chatSessions.id, sessionId));
+
+    const survivor = await postgresChatMessageStore.findById(assistantMessageId);
+    expect(survivor).toBeNull(); // confirm the parent is truly gone
+
+    // An in-flight append landing after the cascade references a now-absent
+    // chat_messages row. It must NOT throw an FK violation that would crash the
+    // generation job. Today it throws
+    // `chat_stream_events_message_id_chat_messages_id_fk`.
+    await expect(
+      postgresStreamBuffer.append(
+        assistantMessageId,
+        'content_delta',
+        { delta: 'late chunk' },
+        2,
+        assistantMessageId,
+      ),
+    ).resolves.not.toThrow();
+  });
+
+  it('does not crash when a generation trace references an already-deleted session/message', async () => {
+    // Trace while the parent exists — must succeed.
+    await expect(
+      writeChatGenerationTrace({
+        enabled: true,
+        sessionId,
+        assistantMessageId,
+        userId: user.id,
+        workspaceId: user.workspaceId ?? null,
+        phase: 'pass1',
+        iteration: 1,
+        model: 'test-model',
+        toolChoice: 'auto',
+        tools: null,
+        openaiMessages: { kind: 'executed_tools', messages: [] },
+        toolCalls: null,
+        meta: { kind: 'executed_tools' },
+      }),
+    ).resolves.not.toThrow();
+
+    // Simulate the teardown cascade (session → messages → traces gone).
+    await db.delete(chatSessions).where(eq(chatSessions.id, sessionId));
+
+    // An in-flight trace landing after the cascade references now-absent
+    // chat_sessions + chat_messages rows. It must NOT throw the FK violation
+    // `chat_generation_traces_session_id_chat_sessions_id_fk`.
+    await expect(
+      writeChatGenerationTrace({
+        enabled: true,
+        sessionId,
+        assistantMessageId,
+        userId: user.id,
+        workspaceId: user.workspaceId ?? null,
+        phase: 'pass2',
+        iteration: 1,
+        model: 'test-model',
+        toolChoice: 'none',
+        tools: null,
+        openaiMessages: { kind: 'pass2_prompt', messages: [] },
+        toolCalls: null,
+        meta: { kind: 'pass2_prompt' },
+      }),
+    ).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
# Fix: chat persistence write-order FK race (chat_stream_events / chat_generation_traces)

## Objective
Eliminate the deterministic-under-load FK race where `chat_stream_events.message_id` (and `chat_generation_traces.session_id`/`assistant_message_id`) reference a `chat_messages`/`chat_sessions` row that is not (or no longer) committed — causing `insert ... violates foreign key constraint` → job failure → `chat-tools` AI shard flaking. Guarantee the parent message/session row exists for the whole window any stream event or generation trace references it.

## Scope / Guardrails
- Owning area: `packages/chat-core` runtime (checkpoint/finalization/messages) + the API adapters `api/src/services/chat/*` it drives.
- Make-only workflow, no direct Docker commands. Tests on `ENV=test-fixrace` only, never dev.
- One migration max in `api/drizzle/*.sql` (only if a deferred/ordering constraint change is truly required — prefer code ordering over schema change).
- All new text in English.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths**:
  - `packages/chat-core/src/**`
  - `packages/chat-core/tests/**`
  - `api/src/services/chat/**`
  - `api/src/services/chat-trace.ts`
  - `api/tests/ai/chat-tools.test.ts`
  - `api/tests/**` (only persistence/race regression tests)
  - `BRANCH.md`
- **Forbidden Paths**:
  - `Makefile`
  - `docker-compose*.yml`
  - `.cursor/rules/**`
  - `.github/workflows/ci.yml`
  - app rebrand / unrelated source
- **Conditional Paths**:
  - `packages/chat-core/package.json` (version bump — required if `src/**` changes; FIXRACE-EX1)
  - `api/drizzle/*.sql` (max 1, only if a constraint-ordering migration is unavoidable; FIXRACE-EX2)

## Feedback Loop
- FIXRACE-EX1: NOT APPLICABLE / WITHDRAWN. The minimal fix lives entirely in the API adapter layer (`api/src/services/chat/postgres-stream-buffer.ts` + `api/src/services/chat-trace.ts`); `packages/chat-core/src/**` was NOT modified. The `enforce-package-bump` gate triggers only on `packages/<pkg>/src/**` changes, so no chat-core version bump is required (public surface unchanged). The orphan-reference handling belongs at the Postgres adapter boundary that actually owns the FK, keeping chat-core transport/DB-agnostic.
- FIXRACE-Q1: RESOLVED. Root cause = orphaned-reference INSERT, not truncation orphaning. The FKs `chat_stream_events.message_id`, `chat_generation_traces.{session_id,assistant_message_id}` are all `ON DELETE CASCADE` (schema lines 462/498/501), so `deleteAfterSequence` (checkpoint) cannot orphan — Postgres cascades the children. The real race: a parent `chat_messages`/`chat_sessions` row is deleted while the generation job is still flushing stream events / traces (in the AI shard, `cleanupAuthData` afterEach does `db.delete(users)` → cascade session→messages→events/traces while an in-flight or leftover job keeps appending). The post-cascade `postgresStreamBuffer.append(...,messageId)` / `writeChatGenerationTrace(...)` then throw an UNHANDLED FK `23503` (`chat_stream_events_message_id_chat_messages_id_fk` / `chat_generation_traces_session_id_chat_sessions_id_fk`), crashing the job → tool-call assertions fail + 30s timeout. Reproduced deterministically 2/2 in `api/tests/api/chat-persistence-write-order.test.ts` (real Postgres FK, no LLM). Suspect `runtime-checkpoint.ts:223` (truncation) DISPROVEN by the cascade declaration.

## Mode
- Mono-branch.

## Plan / Todo (lot-based)
- [x] **Lot 0 — Baseline**: worktree off `origin/main` (`f1c2807e`, post-#240 trigger fix). Forensics: `docs/uat/2026-06-03-chat-tools-fk-forensics.md` (on BR-14e worktree) — FK race reproduced 5/5 locally, intermittent in CI; pre-existing (exists on main), exposed by chat-ui path-filter change.
- [x] **Lot 1 — Deterministic repro (systematic-debugging)**
  - [x] Added `api/tests/api/chat-persistence-write-order.test.ts`: real-Postgres FK repro (no LLM). Asserts a stream event / generation trace referencing an already-cascade-deleted parent must NOT crash the write. RED 2/2 with `chat_stream_events_message_id_chat_messages_id_fk` + `chat_generation_traces_session_id_chat_sessions_id_fk` (code `23503`). In-memory store cannot model the FK, so this is correctly an `api/tests/**` integration test on `ENV=test-fixrace`.
- [x] **Lot 2 — Minimal fix**
  - [x] Treat the specific parent-FK `23503` as a benign no-op (the `ON DELETE CASCADE` parent — and thus the child — is gone; nothing to keep) in `postgres-stream-buffer.ts` (`append` + `appendAtomically`) and `chat-trace.ts` (`writeChatGenerationTrace`). Constraint-name matched so only the message/session parent FKs are swallowed; all other errors still throw. Public contract preserved (methods still return normally). No schema change (FKs already cascade).
  - [x] Re-run the repro green; ran the chat-tools AI shard ≥3× consecutively + `make test-pkg-chat-core` + `make test-api-endpoints` regressions.
- [ ] **Lot N — Validate + PR**
  - [ ] Full gates; bump `@sentropic/chat-core`; PR with BRANCH.md body; merge-commit; remove BRANCH.md.

## Notes
- This is the RACE half of the corrective set; the TRIGGER half (`fix/ci-ai-shard-trigger`, PR #240) is MERGED, so this branch's chat-core changes now correctly retrigger the API integration + AI shard.
- BR-14e (`chore/sentropic-codebase-finalization`) rebases on main after this merges, then finalizes green.