### PR TITLE
fix(llm-mesh): fail closed Claude Code OAuth dispatch

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,87 +1,41 @@
-# Feature: llm-gateway Codex Responses contract
+# Feature: Claude Code OAuth upstream fail-closed contract
 
 ## Objective
-Publish the reusable Codex OAuth/Responses semantics in `@sentropic/llm-gateway` so remote can consume the Sentropic-owned gateway package instead of carrying provider semantics in `remote/apps/llm-gateway`.
+Stop documenting/executing the false Claude Code OAuth path where `sk-ant-oat...` is sent as an Anthropic API bearer/key. Model the durable gateway-owned path: Claude Code OAuth tokens are enrollment/refresh credentials only; gateway must mint/refresh an executable Claude API key before dispatch.
 
 ## Scope / Guardrails
-- Scope limited to `@sentropic/llm-gateway` Codex contract helpers, package tests, version bump, lockfile, and llm-gateway spec.
-- One migration max in `api/drizzle/*.sql` (not applicable).
-- Make-only workflow, no direct Docker commands.
-- Root workspace `~/src/top-ai-ideas-fullstack` is reserved for user dev/UAT (`ENV=dev`) and must remain stable.
-- Branch development must happen in isolated worktree `tmp/feat-<slug>` (even for one active branch).
-- Automated test campaigns must run on dedicated environments (`ENV=test` / `ENV=e2e`), never on root `dev`.
-- UAT qualification branch/worktree must be commit-identical to the branch under qualification (same HEAD SHA; no extra commits before sign-off). If subtree/sync is used, record source and target SHAs in `BRANCH.md`.
-- In every `make` command, `ENV=<env>` must be passed as the last argument.
-- All new text in English.
+- Scope limited to llm-mesh auth contract, tests, llm-gateway dependency/version bump if needed, lockfile, and gateway spec.
+- Do not change remote `gw-*` session token semantics.
+- Do not implement speculative network calls to Claude Code private endpoints without verified contract/test seam.
+- Fail closed until executable material exists.
 
-## Branch Scope Boundaries (MANDATORY)
-- **Allowed Paths (implementation scope)**:
-  - `packages/llm-gateway/src/**`
-  - `packages/llm-gateway/tests/**`
+## Branch Scope Boundaries
+- Allowed:
+  - `packages/llm-mesh/src/**`
+  - `packages/llm-mesh/tests/**`
+  - `packages/llm-mesh/package.json`
   - `packages/llm-gateway/package.json`
   - `package-lock.json`
   - `spec/SPEC_EVOL_LLM_GATEWAY.md`
   - `BRANCH.md`
-- **Forbidden Paths (must not change in this branch)**:
+- Forbidden:
   - `Makefile`
-  - `docker-compose*.yml`
-  - `.cursor/rules/**`
-  - `plan/NN-BRANCH_*.md` (except this branch file)
-- **Conditional Paths (allowed only with explicit exception when not already listed in Allowed Paths)**:
-  - `api/drizzle/*.sql` (max 1 file)
   - `.github/workflows/**`
-- **Exception process**:
-  - Declare exception ID `BRxx-EXn` in `## Feedback Loop` before touching any conditional/forbidden path.
-  - Include reason, impact, and rollback strategy.
-  - Mirror the same exception in this file under `## Feedback Loop` (or `## Questions / Notes` if not yet migrated).
+  - runtime API files unrelated to the package contract
 
 ## Feedback Loop
-- `acknowledge`: owner clarified the API-only port is insufficient; reusable gateway semantics must be shipped in the published `@sentropic/llm-gateway` package for remote.
-- `blocked`: local Docker is unavailable (`permission denied while trying to connect to the docker API at unix:///var/run/docker.sock`), so `make lock-root` / `make test-llm-gateway` cannot run locally. CI must validate.
+- Remote hotfix confirmed that Claude Code OAuth `sk-ant-oat...` was incorrectly treated as an Anthropic API credential.
+- Architecture GO: llm-gateway/llm-mesh own provider transport/account policy; remote owns local activation/config UX.
 
-## AI Flaky tests
-- Acceptance rule:
-  - Accept only non-systematic provider/network/model nondeterminism as `flaky accepted`.
-  - Non-systematic means at least one success on the same commit and same command.
-  - Never amend tests with additive timeouts.
-  - If flaky, analyze impact vs `main`: if unrelated, accept and record command + failing test file + signature in `BRANCH.md`; if related, treat as blocking.
-  - Capture explicit user sign-off before merge.
+## Plan
+- [x] Identify false executable path in llm-mesh `validateAdapterAuthSource`.
+- [x] Change `claude-code-account` validation to fail closed for raw OAuth token and accept only gateway-minted executable API key material.
+- [x] Add tests for raw `sk-ant-oat` rejection and minted API key header shape.
+- [x] Update spec with Claude Code OAuth boundary.
+- [x] Bump packages/lockfile.
+- [ ] Open PR and validate in CI.
 
-## Orchestration Mode (AI-selected)
-- [x] **Mono-branch + cherry-pick** (default for orthogonal tasks; single final test cycle)
-- [ ] **Multi-branch** (only if sub-workstreams require independent CI or long-running validation)
-- Rationale: focused package contract change touching one package, tests, lockfile, and spec.
-
-## UAT Management (in orchestration context)
-- **Mono-branch**: UAT is performed on the integrated branch only (after each lot, when UI changes exist).
-- **Multi-branch**: no UAT on sub-branches; UAT happens only after integration on the main branch.
-- UAT checkpoints must be listed as checkboxes inside each relevant lot (no separate UAT section).
-- Execution flow (mandatory):
-  - Develop and run tests in `tmp/feat-<slug>`.
-  - Push branch before UAT.
-  - Run user UAT from root workspace (`~/src/top-ai-ideas-fullstack`, `ENV=dev`).
-  - Switch back to `tmp/feat-<slug>` after UAT.
-
-## Plan / Todo (lot-based)
-- [x] **Lot 0 — Baseline & constraints**
-  - [x] Read the relevant rules and spec.
-  - [x] Create/confirm isolated worktree and run development there.
-  - [x] Confirm command style: `make ... <vars> ENV=<env>` with `ENV` last.
-  - [x] Confirm scope and guardrails.
-
-- [ ] **Lot 1 — Published Codex contract helpers**
-  - [x] Add exported Codex Responses backend constant and helpers to `@sentropic/llm-gateway`.
-  - [x] Cover ChatGPT backend URL, instructions flattening, xhigh→high, max_output_tokens omission, input id stripping, and usage propagation in package tests.
-  - [x] Bump `@sentropic/llm-gateway` to `0.2.0`.
-  - [x] Update root lockfile version entries for the package bump.
-  - [ ] Lot gate:
-    - [ ] `make test-llm-gateway ENV=test-llm-gateway-codex-contract` — blocked locally by Docker socket permission; CI required.
-
-- [x] **Lot N-1 — Docs consolidation**
-  - [x] Update `spec/SPEC_EVOL_LLM_GATEWAY.md` to freeze boundary and published package contract.
-
-- [ ] **Lot N — Final validation**
-  - [ ] Push branch and open PR.
-  - [ ] Verify CI package validation and publish job readiness.
-  - [ ] Merge, then verify `@sentropic/llm-gateway@0.2.0` is published.
-  - [ ] Notify remote to consume `@sentropic/llm-gateway@0.2.0` and remove/deprecate its mirror.
+## Validation
+- `make ...`: blocked in this environment by Docker socket permission.
+- `npm run typecheck --workspace @sentropic/llm-mesh`: blocked in this worktree because local dependencies are absent (`tsc: not found`).
+- CI validation required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3941,11 +3941,12 @@
     "node_modules/@sentropic/llm-gateway": {
       "resolved": "packages/llm-gateway",
       "link": true,
-      "version": "0.2.0"
+      "version": "0.2.1"
     },
     "node_modules/@sentropic/llm-mesh": {
       "resolved": "packages/llm-mesh",
-      "link": true
+      "link": true,
+      "version": "0.5.1"
     },
     "node_modules/@sentropic/mcp-auth": {
       "resolved": "packages/mcp-auth",
@@ -18017,10 +18018,10 @@
     },
     "packages/llm-gateway": {
       "name": "@sentropic/llm-gateway",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@sentropic/llm-mesh": "^0.5.0",
+        "@sentropic/llm-mesh": "^0.5.1",
         "hono": "^4.10.7"
       },
       "devDependencies": {
@@ -18267,7 +18268,7 @@
     },
     "packages/llm-mesh": {
       "name": "@sentropic/llm-mesh",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT"
     },
     "packages/mcp-auth": {

--- a/packages/llm-gateway/package.json
+++ b/packages/llm-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/llm-gateway",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Authenticated, pooled, metered LLM egress gateway for Sentropic (WP16 Layer B). Provider-compatible Anthropic/OpenAI wire over the @sentropic/llm-mesh account pool.",
   "type": "module",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "test": "vitest run tests"
   },
   "dependencies": {
-    "@sentropic/llm-mesh": "^0.5.0",
+    "@sentropic/llm-mesh": "^0.5.1",
     "hono": "^4.10.7"
   },
   "devDependencies": {

--- a/packages/llm-mesh/package.json
+++ b/packages/llm-mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/llm-mesh",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Provider-agnostic LLM access runtime SDK for Sentropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/llm-mesh/src/adapter-auth.ts
+++ b/packages/llm-mesh/src/adapter-auth.ts
@@ -43,13 +43,23 @@ export const validateAdapterAuthSource = (
 
   if (source.type === 'claude-code-account') {
     if (!source.accessToken?.trim()) {
-      return { ok: false, message: 'access token is empty' };
+      return { ok: false, message: 'Claude Code OAuth access token is empty' };
     }
+
+    const executableApiKey = source.executableApiKey?.trim();
+    if (!executableApiKey) {
+      return {
+        ok: false,
+        message: 'Claude Code OAuth token is not an Anthropic API key; gateway must mint an executable Claude API key before dispatch',
+      };
+    }
+
     return {
       ok: true,
       headers: {
-        'Authorization': `Bearer ${source.accessToken.trim()}`,
+        'x-api-key': executableApiKey,
         'anthropic-version': '2023-06-01',
+        ...(source.organizationUuid ? { 'X-Organization-Uuid': source.organizationUuid } : {}),
       },
     };
   }

--- a/packages/llm-mesh/src/auth.ts
+++ b/packages/llm-mesh/src/auth.ts
@@ -90,11 +90,21 @@ export interface AccountTransportAuthMaterial extends AuthMaterialBase {
 export interface ClaudeCodeAccountAuthMaterial extends AuthMaterialBase {
   type: 'claude-code-account';
   provider: 'claude-code';
+  /**
+   * Claude Code OAuth access token (`sk-ant-oat...`). Enrollment/refresh credential
+   * only: it MUST NOT be sent to the Anthropic Messages API as bearer/x-api-key.
+   */
   accessToken: string;
+  /**
+   * Gateway-minted executable Anthropic API key, obtained through the verified
+   * Claude Code OAuth control-plane flow. Until present, dispatch must fail closed.
+   */
+  executableApiKey?: string;
+  organizationUuid?: string | null;
   accountId?: string | null;
   accountLabel?: string | null;
   expiresAt?: string | null;
-  // No refreshToken — refresh is gateway-owned (not llm-mesh, not remote)
+  // OAuth refresh/mint is gateway-owned (not llm-mesh, not remote).
 }
 
 export interface PlannedAccountTransportAuthMaterial extends AuthMaterialBase {
@@ -214,6 +224,7 @@ export const describeAuthMaterial = (
         ...(material.accountId ? { accountId: material.accountId } : {}),
         ...(material.accountLabel ? { accountLabel: material.accountLabel } : {}),
         ...(material.expiresAt ? { expiresAt: material.expiresAt } : {}),
+        ...(material.organizationUuid ? { metadata: { organizationUuid: material.organizationUuid } } : {}),
         ...baseDescriptor,
       };
 

--- a/packages/llm-mesh/tests/auth.test.ts
+++ b/packages/llm-mesh/tests/auth.test.ts
@@ -86,7 +86,9 @@ describe('claude-code-account auth material', () => {
     const material: ClaudeCodeAccountAuthMaterial = {
       type: 'claude-code-account',
       provider: 'claude-code',
-      accessToken: 'sk-ant-access-token',
+      accessToken: 'sk-ant-oat-oauth-token',
+      executableApiKey: 'sk-ant-api03-minted-key',
+      organizationUuid: 'org_uuid_123',
       accountId: 'acct_cc_123',
       accountLabel: 'Fabien (Claude Code)',
       expiresAt: '2026-12-31T00:00:00.000Z',
@@ -98,31 +100,48 @@ describe('claude-code-account auth material', () => {
       accountId: 'acct_cc_123',
       accountLabel: 'Fabien (Claude Code)',
       expiresAt: '2026-12-31T00:00:00.000Z',
+      metadata: { organizationUuid: 'org_uuid_123' },
     });
   });
 
-  it('rejects claude-code-account with an empty access token', () => {
+  it('rejects claude-code-account with an empty OAuth token', () => {
     expect(
       validateAdapterAuthSource({
         type: 'claude-code-account',
         provider: 'claude-code',
         accessToken: '   ',
       }),
-    ).toEqual({ ok: false, message: 'access token is empty' });
+    ).toEqual({ ok: false, message: 'Claude Code OAuth access token is empty' });
   });
 
-  it('accepts claude-code-account with a valid access token and returns Authorization header', () => {
+  it('rejects raw Claude Code OAuth tokens as executable Anthropic API credentials', () => {
     expect(
       validateAdapterAuthSource({
         type: 'claude-code-account',
         provider: 'claude-code',
-        accessToken: 'sk-ant-valid-token',
+        accessToken: 'sk-ant-oat-raw-oauth-token',
+      }),
+    ).toEqual({
+      ok: false,
+      message: 'Claude Code OAuth token is not an Anthropic API key; gateway must mint an executable Claude API key before dispatch',
+    });
+  });
+
+  it('accepts claude-code-account only after the gateway minted an executable API key', () => {
+    expect(
+      validateAdapterAuthSource({
+        type: 'claude-code-account',
+        provider: 'claude-code',
+        accessToken: 'sk-ant-oat-raw-oauth-token',
+        executableApiKey: 'sk-ant-api03-minted-key',
+        organizationUuid: 'org_uuid_123',
       }),
     ).toEqual({
       ok: true,
       headers: {
-        'Authorization': 'Bearer sk-ant-valid-token',
+        'x-api-key': 'sk-ant-api03-minted-key',
         'anthropic-version': '2023-06-01',
+        'X-Organization-Uuid': 'org_uuid_123',
       },
     });
   });

--- a/spec/SPEC_EVOL_LLM_GATEWAY.md
+++ b/spec/SPEC_EVOL_LLM_GATEWAY.md
@@ -91,6 +91,14 @@ admin/status/debug.
 > Codex-supported `high` and documented as a provider-capability downgrade, and Codex `response.completed.response.usage`
 > is preserved into stream `done.data.usage` for BR-47 settlement. This behavior is exported by `@sentropic/llm-gateway`
 > so remote can consume the published package instead of carrying a provider-semantics mirror.
+>
+> **CLAUDE CODE OAUTH FAIL-CLOSED CONTRACT:** Claude Code OAuth access tokens (`sk-ant-oat...`) are NOT Anthropic
+> API keys and MUST NOT be sent to `https://api.anthropic.com/v1/messages` as `Authorization: Bearer` or `x-api-key`.
+> They are enrollment/refresh credentials only. The executable dispatch credential is a gateway-minted Anthropic API
+> key produced by the verified Claude Code OAuth control-plane flow (e.g. validate/profile/create_api_key with the
+> required organization scope/header, once ratified). Until the gateway has such an executable key, `claude-code-account`
+> dispatch MUST fail closed. Remote may configure local Claude to use the gateway token (`gw-*`) but must not own or
+> shadow this provider policy.
 
 ### 3b. Precise contract (for Layer-C/B integration tests)
 - **Request**: provider-NATIVE body passed through verbatim (Anthropic Messages `{model,messages,max_tokens,


### PR DESCRIPTION
# Feature: Claude Code OAuth upstream fail-closed contract

## Objective
Stop documenting/executing the false Claude Code OAuth path where `sk-ant-oat...` is sent as an Anthropic API bearer/key. Model the durable gateway-owned path: Claude Code OAuth tokens are enrollment/refresh credentials only; gateway must mint/refresh an executable Claude API key before dispatch.

## Scope / Guardrails
- Scope limited to llm-mesh auth contract, tests, llm-gateway dependency/version bump if needed, lockfile, and gateway spec.
- Do not change remote `gw-*` session token semantics.
- Do not implement speculative network calls to Claude Code private endpoints without verified contract/test seam.
- Fail closed until executable material exists.

## Branch Scope Boundaries
- Allowed:
  - `packages/llm-mesh/src/**`
  - `packages/llm-mesh/tests/**`
  - `packages/llm-mesh/package.json`
  - `packages/llm-gateway/package.json`
  - `package-lock.json`
  - `spec/SPEC_EVOL_LLM_GATEWAY.md`
  - `BRANCH.md`
- Forbidden:
  - `Makefile`
  - `.github/workflows/**`
  - runtime API files unrelated to the package contract

## Feedback Loop
- Remote hotfix confirmed that Claude Code OAuth `sk-ant-oat...` was incorrectly treated as an Anthropic API credential.
- Architecture GO: llm-gateway/llm-mesh own provider transport/account policy; remote owns local activation/config UX.

## Plan
- [x] Identify false executable path in llm-mesh `validateAdapterAuthSource`.
- [x] Change `claude-code-account` validation to fail closed for raw OAuth token and accept only gateway-minted executable API key material.
- [x] Add tests for raw `sk-ant-oat` rejection and minted API key header shape.
- [x] Update spec with Claude Code OAuth boundary.
- [x] Bump packages/lockfile.
- [ ] Open PR and validate in CI.

## Validation
- `make ...`: blocked in this environment by Docker socket permission.
- `npm run typecheck --workspace @sentropic/llm-mesh`: blocked in this worktree because local dependencies are absent (`tsc: not found`).
- CI validation required.
