### PR TITLE
docs(BR-39e): social federation design (STUDY+EVOL) — Google/GitHub/MS/Apple/Facebook

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,9 +1,11 @@
-# Feature: BR-39e Social/Enterprise Federation — grounded STUDY
+# Feature: BR-39e Social/Enterprise Federation — STUDY + committed EVOL
 
 ## Objective
 Produce a grounded, decision-grade options/trade-offs study for adding upstream social/enterprise
-login federation (Google/GitHub/Microsoft/Apple/Facebook) to the Sentropic IdP. STUDY only — frames
-owner-gated decisions, no implementation.
+login federation (Google/GitHub/Microsoft/Apple/Facebook) to the Sentropic IdP, then consolidate it
+into a COMMITTED design (EVOL) encoding the owner decisions (OD1-OD4, ratified 2026-07-09) and the
+reconciled Opus-4.8 + Codex-5.5xhigh review refinements (R1-R9) as numbered decisions D1..D18, ready
+for harness-plan. Spec only — no implementation, no package/schema/migration edits.
 
 ## Scope / Guardrails
 - Spec artifact only. No code, no package, no auth-hono/api source edits, no migration.
@@ -15,6 +17,7 @@ owner-gated decisions, no implementation.
 ## Branch Scope Boundaries (MANDATORY)
 - **Allowed Paths (implementation scope)**:
   - `spec/SPEC_STUDY_39E_SOCIAL_FEDERATION.md`
+  - `spec/SPEC_EVOL_39E_SOCIAL_FEDERATION.md`
   - `BRANCH.md`
 - **Forbidden Paths (must not change in this branch)**:
   - `Makefile`
@@ -45,3 +48,13 @@ owner-gated decisions, no implementation.
   - [x] `## Owner decisions (batched)` D-1..D-8 with inline context.
   - [x] `## Adjacent: DS header on auth screens` (options a/b/c + reco).
   - [x] Lot gate: study committed; no push/PR.
+- [x] **Lot 2 — Consolidate the committed EVOL**
+  - [x] Encode OD1-OD4 (5 providers, SAFE linking, federation port in auth-hono, AppChrome brand) as
+        committed direction.
+  - [x] Fold R1-R9 (flow-state vs sealed continuation, subject-first lookup, no-email challenge,
+        Google-only auto-link, arctic+jose, security round-trip, fixed redirect, lifecycle, Apple lot)
+        as numbered decisions D1..D18.
+  - [x] Broker architecture grounded (token-handler.ts:363 / userinfo-handler.ts:40 no-leak),
+        `identities` shape + federation port contract + transactional linking algorithm.
+  - [x] Per-provider matrix, v1 lot breakdown (Lot 0-6 + Lot A), keystone test matrix, open items.
+  - [x] Lot gate: EVOL committed; no push/PR.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,47 @@
+# Feature: BR-39e Social/Enterprise Federation — grounded STUDY
+
+## Objective
+Produce a grounded, decision-grade options/trade-offs study for adding upstream social/enterprise
+login federation (Google/GitHub/Microsoft/Apple/Facebook) to the Sentropic IdP. STUDY only — frames
+owner-gated decisions, no implementation.
+
+## Scope / Guardrails
+- Spec artifact only. No code, no package, no auth-hono/api source edits, no migration.
+- Make-only workflow, no direct Docker commands.
+- Root workspace reserved for user dev/UAT (`ENV=dev`); work happens in `tmp/auth-federation-study`.
+- No push, no PR (study rung).
+- All new text in English.
+
+## Branch Scope Boundaries (MANDATORY)
+- **Allowed Paths (implementation scope)**:
+  - `spec/SPEC_STUDY_39E_SOCIAL_FEDERATION.md`
+  - `BRANCH.md`
+- **Forbidden Paths (must not change in this branch)**:
+  - `Makefile`
+  - `docker-compose*.yml`
+  - `.cursor/rules/**`
+  - `packages/auth-hono/**`, `packages/auth-ui/**`, `api/**`, `apps/**`, `ui/**`
+  - any other `spec/**` or `plan/NN-BRANCH_*.md`
+- **Conditional Paths (allowed only with explicit exception)**:
+  - none
+
+## Feedback Loop
+- (none)
+
+## Orchestration Mode (AI-selected)
+- [x] **Mono-branch + cherry-pick** (single study artifact; no sub-workstreams)
+- [ ] **Multi-branch**
+- Rationale: one non-code spec deliverable; no CI, no independent validation streams.
+
+## Plan / Todo (lot-based)
+- [x] **Lot 0 — Ground on current main**
+  - [x] Read auth-hono IdP (ports/contracts/session/oauth authorize/state-codec/router).
+  - [x] Read user+identity model (`api/src/db/schema.ts`), confirm NO `identities` table.
+  - [x] Read enrollment path (`api/src/routes/auth/register.ts`), magic-link, secret-crypto.
+  - [x] Read auth-ui `AuthLogin`/`AuthRegister` + auth-idp `+layout.svelte` (AppChrome) + `ui/` Header.
+- [x] **Lot 1 — Write the study**
+  - [x] Providers + quirks, build approach (arctic vs alternatives), broker model, `identities` +
+        linking policy (verified-email gate), security, IdP routes, UI, multi-tenant, roadmap.
+  - [x] `## Owner decisions (batched)` D-1..D-8 with inline context.
+  - [x] `## Adjacent: DS header on auth screens` (options a/b/c + reco).
+  - [x] Lot gate: study committed; no push/PR.

--- a/spec/SPEC_EVOL_39E_SOCIAL_FEDERATION.md
+++ b/spec/SPEC_EVOL_39E_SOCIAL_FEDERATION.md
@@ -1,0 +1,476 @@
+# SPEC_EVOL_39E_SOCIAL_FEDERATION — Committed Design for Upstream Social/Enterprise Federation
+
+Status: EVOL (committed design). Decision-grade, grounded, ready for `harness-plan`. Spec only — NO
+implementation code, NO schema/migration edits.
+
+Rung: harness-brainstorm EVOL. Input: `spec/SPEC_STUDY_39E_SOCIAL_FEDERATION.md` (the STUDY, left
+as-is). This EVOL encodes the owner decisions ratified 2026-07-09 (OD1–OD4) and the reconciled
+Opus-4.8 + Codex-5.5xhigh review refinements (R1–R9) as HARD design constraints.
+
+Lineage: BR-39e (federation-first). This is the *social/enterprise login federation* half of 39e:
+letting a human enroll/sign in to the Sentropic IdP via Google / GitHub / Microsoft / Apple /
+Facebook, while the IdP remains the single OIDC authority downstream apps trust.
+
+---
+
+## 1. Purpose + broker architecture (grounded)
+
+### 1.1 Purpose
+
+Add **upstream Relying-Party (RP) capability** to `@sentropic/auth-hono` so a human can enroll or sign
+in through an external identity provider, without the IdP ceding any downstream trust. The IdP already
+owns every downstream primitive — OAuth2/OIDC *server*, sessions, users, workspace provisioning,
+secret-crypto — and a clean browser-bounce continuation seam. The one missing capability is RP-side
+federation. That absence is the whole of BR-39e-federation.
+
+### 1.2 Grounding (cited, current main)
+
+- **IdP is an OAuth2/OIDC *server*, not a client.** Full `authorize → consent → token → userinfo →
+  JWKS + discovery + revoke + introspect + DPoP + resource-indicators` live under
+  `packages/auth-hono/src/oauth/*`. `@sentropic/auth-hono` is at **0.11.1**
+  (`packages/auth-hono/package.json`). No RP/social seam exists anywhere (`grep -riE
+  'arctic|oslo|openid-client|@auth/core|lucia' packages/ api/` → nothing).
+- **The continuation seam is the integration point.** `oauth/authorize-handler.ts:42-44` reads
+  `?continue=` and calls `resumeLoginContinuation`; when there is no session it seals an HMAC
+  `OAuthContinuationState` (`oauth/state-codec.ts:1`, `createOAuthHmacStateCodec` line 39) and 302s the
+  browser to `loginUrl` / `registerUrl` (lines 94-103). **Federation is a new way to satisfy that
+  `loginUrl` bounce — strictly *upstream* of the OAuth server.**
+- **User model** (`api/src/db/schema.ts:140`): `users(id, email UNIQUE nullable, displayName, role,
+  accountStatus, emailVerified default false, …)`. Email is the de-facto natural key. **No `identities`
+  table exists.** The `IdentityType` in `@sentropic/oauth-verify` is a token-subject tag, orthogonal to
+  a federated-link table.
+- **Enrollment shape to reuse** (`api/src/routes/auth/register.ts`): email-proof-gated → find-or-create
+  user → `ensureWorkspaceForUser(userId)` (`api/src/services/workspace-service.ts:55`) → mint session.
+  Cold users are `role='editor'` (first `ADMIN_EMAIL` → `admin_app`),
+  `accountStatus='pending_admin_approval'`, `approvalDueAt=+48h` (register.ts:296-298).
+- **Session mint is a clean port call**: `createAuthSessionService(...).createSession({ user,
+  deviceInfo })` (`packages/auth-hono/src/session.ts:44-86`) → signed session token + refresh + DB row.
+  A federation callback ends exactly here.
+- **Secret-at-rest pattern**: `api/src/services/secret-crypto.ts` — AES-256-GCM, `enc:v1:` prefix,
+  key = SHA-256(JWT_SECRET). Reuse it for any stored provider material; do not invent a third store.
+
+### 1.3 Broker architecture (the invariant)
+
+**BROKER — non-negotiable.** On a successful upstream callback the IdP mints its **OWN** Sentropic
+session and its **OWN** downstream tokens exactly as passkey/magic-link do today. The external provider
+establishes *who the human is* for the enrollment/login moment, then is discarded from the downstream
+trust path. Downstream apps see **one issuer** (`auth.sent-tech.ca`) and one token format whether the
+human enrolled by passkey or by Google.
+
+**Grounded no-leak proof** (this is why broker is *free* here, not a rewrite):
+- The downstream access/id token is minted by `oauth/token-handler.ts:363` (`jwks.signJwt`) purely from
+  `codePayload` + the `users` row — it never reads any external-provider token.
+- `oauth/userinfo-handler.ts:40-44` returns `sub/name/email/email_verified` sourced **only** from
+  `options.ports.users.findById` — never from a provider.
+- Therefore federation slots in *above* these handlers, and the external token has no path downstream.
+  Making that a **test-enforced invariant** (§7 K-LEAK) costs no re-architecture.
+
+Pass-through (forwarding the external id_token, or making downstream apps trust Google directly) is
+**REJECTED**: it multiplies downstream issuers, leaks provider tokens, and defeats the single-authority
+design the whole `oauth/*` stack exists to provide.
+
+### 1.4 The seam picture
+
+```
+downstream app ──/authorize?…──▶ authorize-handler ──(no session)──▶ loginUrl bounce
+                                        ▲                                   │
+                                        │ ?continue=<sealed>                │  user clicks "Continue with Google"
+                                        │                                   ▼
+                        resumeLoginContinuation ◀── federation callback ◀── /auth/federation/:provider/{start,callback}
+                                                     (mints Sentropic session, then resumes the sealed continuation)
+                                                                │
+                                                       external provider (Google/…)  ← RP round-trip lives ONLY here
+```
+
+Federation replaces *how the session is established*, not the downstream token issuance. The
+continuation `state-codec.ts` is the single integration seam — no change to token-handler, consent,
+JWKS, or userinfo behavior.
+
+---
+
+## 2. Committed decisions (D1..D18)
+
+Each decision states the **invariant** and **why**. D1–D18 fold OD1–OD4 and R1–R9.
+
+- **D1 — Broker model, external tokens never leak downstream.** *Invariant*: federation is upstream of
+  the OAuth server; the callback mints a Sentropic session (`session.ts:createSession`) and the sealed
+  continuation resumes normally; the external access/id/refresh token is used server-side inside the
+  callback only, then dropped (v1 stores none). *Why*: single downstream issuer; grounded no-leak at
+  `token-handler.ts:363` / `userinfo-handler.ts:40`. (Folds STUDY §3.)
+
+- **D2 — v1 providers = ALL FIVE for LOGIN (OD1).** *Invariant*: Google, GitHub, Microsoft, Apple,
+  Facebook all support enrollment + login in v1. *Why*: owner-ratified breadth. Auto-link trust is a
+  *separate* narrower decision (D8/R4).
+
+- **D3 — RP protocol library = `arctic`, adopted as a dependency-spike (R5).** *Invariant*: `arctic`
+  provides the typed per-provider OAuth2/OIDC clients (authorization-URL builder + code→token exchange
+  + Apple client-secret helper). Pin the version, gate it through the SCA/security CI. **Do NOT add
+  `oslo`** as a second crypto substrate — use `jose` (already in the repo: `oauth-verify`, `auth-hono
+  userinfo/state-store`, `auth-client`) for JWT/PKCE crypto. Callback logic, session, and linking stay
+  ours. *Why*: arctic supplies exactly the missing RP layer and nothing we already own; swapping it
+  later is local to the callback. Auth.js/openauth would be a rewrite. (Refines STUDY §2 / D-2.)
+
+- **D4 — Packaging = optional `federation?` port INSIDE `@sentropic/auth-hono` (OD3).** *Invariant*:
+  additive-minor bump **0.11.1 → 0.12.0**; a new `federation?` optional port bag in
+  `packages/auth-hono/src/ports.ts` (mirrors `tenant?`/`consentStore?`/`invites?` at
+  `ports.ts:357-362`), legacy behavior when absent. **No new published package.** *Why*: owner-ratified;
+  no second consumer yet; matches "package extraction activated by real app consumption"
+  (rules/architecture.md). (Refines STUDY §2 / D-3.)
+
+- **D5 — Federation flow-state is SERVER-SIDE and distinct from the sealed continuation (R1, CRITICAL).**
+  *Invariant*: the upstream-provider CSRF `state`, OIDC `nonce`, PKCE `code_verifier`, and a *pointer*
+  to the sealed OAuth continuation are held in a dedicated **one-time federation flow-state** —
+  persisted server-side (a new short-lived table) and referenced by an opaque id carried through the
+  provider round-trip in a bound `HttpOnly; Secure; SameSite=Lax` cookie. It is verified-and-DELETED on
+  callback (single-use). **The sealed HMAC `continue` is NEVER sent through an external provider** — it
+  is browser-visible and carries `clientId/redirectUri/scopes/tenant`, and it is NOT the upstream CSRF
+  state. *Why*: sending the continuation upstream leaks the downstream authorize parameters to the
+  provider and conflates two unrelated CSRF contexts; the flow-state store is the correct binding.
+
+- **D6 — Linking key = `(provider, provider_subject)`, resolved FIRST (R2).** *Invariant*: the callback
+  resolves identity **only** by `(provider, provider_subject)` first (`findIdentityBySubject`). Only if
+  absent does it consider an **exact normalized** provider-verified-email collision. It **does NOT reuse
+  `register.ts`'s fuzzy lookup** (email → `displayName===email` → local-part, register.ts:113-136).
+  *Why*: the subject is the stable authoritative key; the fuzzy lookup is a registration convenience
+  that would create false collisions and a takeover surface in the federation path.
+
+- **D7 — SAFE linking policy: auto-link only into a NON-credentialed shell; credentialed collision →
+  authenticated manual-link, never silent merge (OD2).** *Invariant*: three cases keyed on
+  `(provider, provider_subject)` — (1) known identity → log in that `user_id`; (2) unknown identity, no
+  email collision → transactional find/upsert user + insert identity + `ensureWorkspaceForUser`; (3)
+  unknown identity, email collides — auto-link is permitted **only** when the collided target is a
+  **non-credentialed shell user** (no webauthn credential, never a completed sign-in factor) **and** the
+  provider is on the auto-link allowlist (D8). A collision with an **already-credentialed** account
+  **ALWAYS** routes to the authenticated manual-link path (log in with the existing factor first, then
+  link from settings). *Why*: closes account-takeover/confused-deputy; a credentialed account is a real
+  human's — it is never silently absorbed by a provider assertion.
+
+- **D8 — Auto-link trust allowlist = GOOGLE ONLY in v1 (R4).** *Invariant*: all five providers do
+  LOGIN; only **Google** may AUTO-LINK on a provider-verified email into a non-credentialed shell in
+  v1. Microsoft (needs a `tid`/`oid`/`issuer` policy), GitHub (email unverifiable without extra proof),
+  Apple (private-relay), and Facebook route their email collisions to the **authenticated manual-link**
+  path until per-provider proof rules exist. *Why*: only Google's `email_verified` is trusted enough for
+  silent auto-link in v1; the rest need a per-provider trust decision not yet specified.
+
+- **D9 — No-email providers trigger an email-verification CHALLENGE, never a silent no-email user
+  (R3).** *Invariant*: `users.create` requires `email: string` and the account policy rejects an
+  unverified email; when a provider yields no usable verified email (GitHub private/no-primary,
+  Facebook absent/declined), the callback **routes into a local email-verification challenge** (reuse
+  the existing `email_verification_codes` flow) before any user/identity row is written. *Why*: a
+  no-email user breaks the email-natural-key model and the account-policy contract; the challenge
+  re-establishes a verified email the IdP owns.
+
+- **D10 — Per-provider state + nonce + PKCE(S256), CSRF on callback, session rotation (R6).**
+  *Invariant*: every start generates a random `state` + (for OIDC providers) a `nonce` + PKCE
+  `code_challenge=S256` where the provider supports it; the callback verifies all three (mismatch →
+  reject) and rotates the Sentropic session id on federation login (anti session-fixation). External
+  provider tokens never reach the browser or a downstream RP. *Why*: mirrors the IdP's own S256 rigor
+  (`authorize-handler.ts:232`) upstream; session rotation prevents fixation; §1.3 no-leak invariant.
+
+- **D11 — Redirect target is a FIXED internal page; `validateRedirectUri` does NOT apply (R7).**
+  *Invariant*: on callback success, if a sealed continuation is present, resume via
+  `resumeLoginContinuation` (client-validated already). If there is **no** continuation, land on a
+  **fixed internal post-login page** (or a relative-only allowlist) — **never** a raw caller-supplied
+  `returnTo`. *Why*: `oauth/redirect-utils.ts:13` `validateRedirectUri` requires an `OauthClientRecord`
+  and only checks a client's registered `redirectUris`; a bare federation `returnTo` has no client, so
+  that guard cannot protect it — a fixed page is the only safe default.
+
+- **D12 — Identity lifecycle: unlink forbids removing the last sign-in factor (R8).** *Invariant*: an
+  authenticated unlink flow removes an identity + deletes any stored provider token, but **refuses**
+  when it would leave the user with zero sign-in factors (no other identity AND no webauthn credential
+  AND no magic-link-capable email) — lockout guard. *Why*: unlink must never brick an account.
+
+- **D13 — Email-recycling rule: `(provider, subject)` binding is authoritative (R8).** *Invariant*: a
+  changed provider email never re-links or re-collides an existing identity; `email_at_link` is audit
+  metadata only, `(provider, provider_subject)` is the single truth. *Why*: providers recycle/rotate
+  emails; binding to the subject prevents an old-email collision from hijacking a new owner.
+
+- **D14 — Audit + rate-limit + GDPR (R8).** *Invariant*: link/login/unlink emit events via the existing
+  `auditLog` port (`ports.ts:250`); start/callback are rate-limited keyed on IP (reuse the email-code
+  policy window); the `identities` FK is `ON DELETE CASCADE` from `users` (GDPR erasure removes stored
+  provider profile). *Why*: observability, anti-enumeration/abuse, right-to-erasure.
+
+- **D15 — Secret placement = env/SealedSecret in the auth-idp deploy bundle; stored provider tokens (if
+  any) via `secret-crypto.ts` (R6, STUDY D-6).** *Invariant*: per-provider `client_id`/`client_secret`
+  and Apple's `.p8` + `key_id`/`team_id` live as env / SealedSecret at deploy (like `JWT_SECRET`); Apple's
+  ES256 client-secret JWT is **minted at runtime** from the `.p8`, never stored as a static string. Any
+  persisted provider refresh token is encrypted with the `enc:v1:` AES-256-GCM helper. *Why*: reuse the
+  established secret store; no third store; runtime-minted Apple secret is required by Apple's design.
+
+- **D16 — Apple is its OWN v1 lot (R9).** *Invariant*: Apple's `client_secret` is a short-lived ES256
+  JWT minted at runtime from a `.p8`; `response_mode=form_post` makes the callback a **POST** with
+  body-encoded params; name+email arrive **only on first authorization** (in the POST body, not the
+  id_token) and must be captured then or lost; the email may be a `@privaterelay.appleid.com` address
+  (treat as provider-verified but provider-scoped). *Why*: material extra surface that must not
+  contaminate the GET-callback providers.
+
+- **D17 — auth-ui `federationProviders` prop + DS-styled buttons + link/unlink flows; additive-minor
+  (OD-adjacent, STUDY D-7).** *Invariant*: `@sentropic/auth-ui` gains an optional
+  `federationProviders?: Array<{ id, label, icon }>` prop on `AuthLogin`/`AuthRegister` (empty = no
+  change, legacy hosts unaffected); buttons are plain `<Button>` links to
+  `/auth/federation/:provider/start?…` (a browser redirect, **not** an `AuthUiTransport` XHR); an
+  authenticated link/unlink surface (alongside `AuthDevices.svelte`) drives the safe manual-link path.
+  DS-styled via the host `ThemeProvider`; provider glyphs coordinated with the DS owner. Bump
+  0.6.0 → 0.7.0. *Why*: additive contract; the manual-link flow is the safe collision path from D7.
+
+- **D18 — v1 landing = same personal-workspace + pending-approval path as an email registrant (STUDY
+  D-8).** *Invariant*: a social-enrolled user follows the exact cold-register path —
+  `ensureWorkspaceForUser` + `accountStatus='pending_admin_approval'` + no tenant claim until an
+  approved `tenant_memberships` row exists. Domain-based tenant auto-provisioning is **deferred** to the
+  Microsoft/enterprise lot. *Why*: no special-casing; enterprise auto-join depends on verified-domain
+  trust not in v1 scope.
+
+---
+
+## 3. Data shape + federation port contract + transactional linking
+
+### 3.1 `identities` table (additive, one migration, no change to `users`)
+
+```
+identities (
+  id                          text PK,
+  user_id                     text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider                    text NOT NULL,     -- 'google'|'github'|'microsoft'|'apple'|'facebook'
+  provider_subject            text NOT NULL,     -- STABLE subject: Google sub, GitHub numeric id,
+                                                 --   MS oid (paired with tid), Apple sub, FB id — NOT the email
+  email_at_link               text,              -- provider-asserted email at link time (audit only, D13)
+  email_verified_by_provider  boolean NOT NULL,  -- did the provider assert this email verified?
+  provider_tenant             text,              -- MS `tid` (null for others); part of the MS subject policy
+  token_secret                text,              -- nullable; enc:v1: AES-256-GCM if a provider token is stored
+  linked_at                   timestamptz NOT NULL,
+  last_login_at               timestamptz,
+  UNIQUE (provider, provider_subject)            -- one external identity ↔ exactly one user (D6)
+)
+```
+
+Index on `user_id` (list a user's identities for the settings surface and the unlink lockout check).
+`token_secret` stays null in v1 (broker drops the provider token; D1). This is also 39h groundwork (an
+identities spine the token/claim layer can later reference).
+
+### 3.2 Federation port contract (added to `AuthHonoPorts` as optional `federation?`)
+
+Method signatures (design; exact TS lands in the build branch):
+
+```
+interface AuthHonoIdentityRecord {
+  id: string; userId: string; provider: string; providerSubject: string;
+  emailAtLink: string | null; emailVerifiedByProvider: boolean;
+  providerTenant: string | null; linkedAt: Date; lastLoginAt: Date | null;
+}
+
+interface AuthHonoFederationFlowState {
+  id: string;                    // opaque; the pointer carried in the bound cookie (D5)
+  provider: string;
+  upstreamState: string;         // CSRF state sent to the provider
+  nonce: string | null;          // OIDC nonce (null for pure OAuth2)
+  codeVerifier: string | null;   // PKCE verifier (null where unsupported)
+  continuationToken: string | null;  // POINTER to the sealed OAuth continuation (never sent upstream)
+  createdAt: Date; expiresAt: Date;
+}
+
+interface AuthHonoFederationPort {
+  // identity linkage (D6)
+  findIdentityBySubject(provider: string, providerSubject: string): Promise<AuthHonoIdentityRecord | null>;
+  findIdentitiesForUser(userId: string): Promise<AuthHonoIdentityRecord[]>;   // unlink lockout (D12)
+  linkIdentity(input: {
+    userId: string; provider: string; providerSubject: string;
+    emailAtLink: string | null; emailVerifiedByProvider: boolean;
+    providerTenant?: string | null; now: Date;
+  }): Promise<AuthHonoIdentityRecord>;                                        // enforces UNIQUE(provider,subject)
+  unlinkIdentity(userId: string, provider: string, providerSubject: string): Promise<boolean>;
+  touchLogin(identityId: string, now: Date): Promise<void>;
+
+  // one-time federation flow-state (D5)
+  createFlowState(input: Omit<AuthHonoFederationFlowState, 'id' | 'createdAt'> & { now: Date }): Promise<AuthHonoFederationFlowState>;
+  consumeFlowState(id: string, now: Date): Promise<AuthHonoFederationFlowState | null>;  // verify-and-DELETE, single-use
+}
+```
+
+The user find/upsert reuses the existing `users` port (`create`/`findByEmail`/`findById`,
+`ports.ts:63-69`); the federation port only owns identity rows + flow-state. Legacy behavior when the
+`federation?` port is absent (no federation routes mounted).
+
+### 3.3 Transactional linking algorithm (callback, steps — no code)
+
+Given a verified provider result `{ provider, subject, email?, emailVerifiedByProvider }`:
+
+1. **Consume flow-state** by the cookie-pointer id (`consumeFlowState`, verify-and-delete, D5). Reject
+   if missing/expired.
+2. **Verify** upstream `state` == flow-state `upstreamState`; verify `nonce` in id_token (OIDC);
+   verify PKCE by using the flow-state `codeVerifier` in the token exchange. Any mismatch → reject
+   (K-STATE).
+3. **Subject-first** (D6): `id = findIdentityBySubject(provider, subject)`.
+   - If found → `touchLogin`; load user; **rotate session** (D10); resume continuation or fixed page
+     (D11). DONE (case 1).
+4. If no email or the email is unverified and the provider is not trusted for this path → **email
+   challenge** (D9): drive `email_verification_codes`; on success treat the challenge email as the
+   verified email and continue at step 5 with it.
+5. **No subject match** → decide by exact normalized `email`:
+   - `collision = users.findByEmail(normalizedEmail)` (exact, D6 — NOT the fuzzy register lookup).
+   - **No collision** → transactional block: `users.create({ email, emailVerified:true,
+     role/status from accountPolicy })` **then** `linkIdentity(...)`; on the UNIQUE(provider,subject)
+     conflict (concurrent callback) **re-read** via `findIdentityBySubject` and log that user in
+     instead (idempotent). Then `ensureWorkspaceForUser`, rotate session, resume. DONE (case 2).
+   - **Collision with a NON-credentialed shell user AND provider on the auto-link allowlist (D8 =
+     Google only) AND `emailVerifiedByProvider`** → `linkIdentity(existingUserId, …)`; rotate session;
+     resume. DONE (case 3a, SAFE auto-link).
+   - **Collision with an ALREADY-CREDENTIALED user, OR provider not on the allowlist, OR unverified
+     email** → **do NOT merge**. Route to the authenticated manual-link path: ask the human to sign in
+     with their existing factor, then link this identity from settings (D7). DONE (case 3b).
+6. **Manual-link path** (authenticated, from settings): the logged-in user starts a federation flow
+   flagged `linkTo=<their userId>`; on callback, `linkIdentity(currentUserId, …)` after the same
+   state/nonce/PKCE checks — this is the ONLY path that attaches a provider to a credentialed account.
+
+"Non-credentialed shell user" = a `users` row with no `webauthn_credentials` and no completed sign-in
+factor (e.g. an invited-but-never-enrolled or magic-link-only-unused shell). The credentialed check is
+`findIdentitiesForUser` + a webauthn-credential lookup via the host adapter.
+
+---
+
+## 4. Per-provider matrix
+
+| Provider | Protocol | Verified email in v1 | Auto-link (v1) | Special handling |
+|---|---|---|---|---|
+| **Google** | Clean OIDC (discovery, id_token, `email_verified`, PKCE S256) | Yes — `email_verified` claim | **AUTO-LINK** (into non-credentialed shell only, D7/D8) | Reference case. `sub` = stable subject. Nonce + PKCE. |
+| **GitHub** | OAuth2 only (no OIDC/id_token) | Via `GET /user/emails` (`verified` + `primary`); may be **private/absent** | Manual-link only | Numeric account `id` = subject. Fetch identity + emails via REST. No verified/no email → **email challenge (D9)**. PKCE optional (send S256 if the app type supports it). |
+| **Microsoft** | OIDC (Entra ID) | `email`/`preferred_username`; verification varies | Manual-link only (v1) | `common`/`consumers`/`organizations`/`{tenant}` endpoint changes `iss` + who signs in. `sub` is per-(app,tenant) → subject = `oid`, store `tid` in `provider_tenant` and enforce an issuer/`tid` policy before any future auto-link. Nonce + PKCE. |
+| **Apple** | OIDC-ish (Sign in with Apple) | `email` + `email_verified`; may be `@privaterelay.appleid.com` | Manual-link only (v1) | **Dedicated lot (D16).** `client_secret` = ES256 JWT minted at runtime from `.p8` (`key_id`/`team_id`). **`response_mode=form_post` → POST callback** (body-parsed). Name+email **only on first auth**, in the POST body — capture immediately. `sub` = subject. Private-relay email = verified but provider-scoped (never cross-link relay emails). |
+| **Facebook** | OAuth2 + limited OIDC | Email may be **absent/declined**, weak verification | Manual-link only | Graph API for profile. Lowest assurance. No/unverified email → **email challenge (D9)**. FB `id` = subject. |
+
+**One callback route, two parsers**: GET for Google/GitHub/Microsoft/Facebook, **POST (form_post)** for
+Apple. The route detects the method and parses body vs query accordingly (§6).
+
+---
+
+## 5. v1 lot breakdown (reversible, ordered — ready for harness-plan)
+
+Each lot = scope + keystone test(s). Lots 1–5 are additive behind the same seam (no re-architecture).
+
+- **Lot 0 — `identities` table + federation port + flow-state store.**
+  Scope: one migration for `identities` (§3.1) + a `federation_flow_states` short-lived table; the
+  `federation?` optional port contract in `auth-hono/ports.ts` (§3.2, legacy when absent); host repo
+  adapter (Drizzle) implementing it; the bound-cookie helper for the flow-state pointer.
+  *Keystone*: K-UNIQUE (UNIQUE(provider,subject) rejects a duplicate insert); K-FLOW
+  (`consumeFlowState` is single-use: second consume returns null).
+
+- **Lot 1 — Broker core + Google (auto-link).**
+  Scope: `arctic` dependency-spike (pinned, SCA-gated, D3); `/auth/federation/:provider/{start,callback}`
+  routes (GET); start builds the auth URL with state+nonce+PKCE and sets the bound flow-state cookie
+  carrying the continuation *pointer* (D5); Google callback → verified identity → transactional linking
+  algorithm (§3.3) with Google on the auto-link allowlist; session rotation; resume via
+  `resumeLoginContinuation` or fixed page (D11); audit events (D14).
+  *Keystone*: K-SUBJECT (subject-first ordering); K-AUTOLINK-SHELL (Google verified-email auto-links a
+  non-credentialed shell); K-NOLEAK (external token never appears in a downstream token/response);
+  K-SEALED (sealed continuation is never sent upstream); K-ROTATE (session id rotates).
+
+- **Lot 2 — GitHub (email challenge + manual-link).**
+  Scope: GitHub OAuth2 (no id_token); numeric-id subject; `GET /user/emails` for the primary+verified
+  email; private/absent/unverified email → email-verification challenge (D9); collisions route to
+  manual-link (not auto-link, D8).
+  *Keystone*: K-GH-CHALLENGE (private/no-email GitHub → challenge, no silent no-email user);
+  K-GH-MANUAL (GitHub email collision with a credentialed account → manual-link, never merge).
+
+- **Lot 3 — Microsoft (Entra).**
+  Scope: OIDC with tenant-endpoint config; subject = `oid`, store `tid` (`provider_tenant`) + enforce
+  issuer/`tid` policy; nonce + PKCE; manual-link only in v1.
+  *Keystone*: K-MS-SUBJECT (subject is `oid`+`tid`, not the per-app `sub`; a `sub` collision across
+  tenants does not merge users).
+
+- **Lot 4 — Apple (dedicated, D16).**
+  Scope: ES256 client-secret JWT minted at runtime from `.p8` (via `jose`, D15); `response_mode=form_post`
+  → the callback accepts POST + parses the body; capture first-auth name/email from the POST body;
+  private-relay email handled as verified-but-scoped; manual-link only.
+  *Keystone*: K-APPLE-FORMPOST (POST-body callback parsed; first-auth name/email captured; missing GET
+  query does not break the callback); K-APPLE-SECRET (a valid ES256 client-secret JWT is minted).
+
+- **Lot 5 — Facebook.**
+  Scope: OAuth2 + Graph profile; absent/declined email → email challenge (D9); manual-link only.
+  *Keystone*: K-FB-CHALLENGE (absent email → challenge, no silent no-email user).
+
+- **Lot 6 — auth-ui provider buttons + link/unlink flows (D17).**
+  Scope: `federationProviders?` prop on `AuthLogin`/`AuthRegister` (empty = legacy); DS-styled `<Button>`
+  links to `/auth/federation/:provider/start`; authenticated link/unlink surface with the last-factor
+  lockout guard (D12); auth-idp host wiring; UAT.
+  *Keystone*: K-UI-LEGACY (no `federationProviders` → zero UI change; existing tests green);
+  K-UNLINK-LASTFACTOR (unlink refused when it would remove the last sign-in factor).
+
+- **Lot A (separate, small — OD4) — AppChrome brand header on auth screens.**
+  Scope: configure the DS `AppChrome` brand zone so `apps/auth-idp/web/src/routes/+layout.svelte:21`
+  matches the app brand exactly (feed the same brand tokens the `ui/` header uses). Minimal, reversible;
+  **DS-owned change — coordinate with the DS owner**, do not fork `AppChrome` app-locally. Option (a)
+  (promote a shared `AppHeaderShell` consumed by both `ui/` and auth-idp) is the later, principled
+  upgrade if the owner wants one brand header everywhere.
+  *Keystone*: visual/UAT parity check — auth screens render the app brand; no `ui/` refactor, no DS fork.
+
+Ordering rationale: Lot 0 unblocks everything; Lot 1 proves the broker + auto-link on the easy case;
+Lots 2–5 each add one provider behind the same seam; Lot 6 surfaces them; Lot A is independent DS work.
+
+---
+
+## 6. IdP surface — new routes (upstream of the OAuth server)
+
+- `GET /auth/federation/:provider/start` — build the provider authorization URL (state+nonce+PKCE),
+  create the server-side flow-state (D5), set the bound `HttpOnly; Secure; SameSite=Lax` cookie carrying
+  the flow-state id, and — if the user arrived via a downstream `/authorize → loginUrl` bounce — record
+  the sealed continuation *pointer* inside the flow-state (never in a provider param). 302 to the
+  provider. Optional `linkTo` flag for the authenticated manual-link path (§3.3 step 6).
+- `GET|POST /auth/federation/:provider/callback` — **GET** for Google/GitHub/Microsoft/Facebook, **POST
+  (form_post)** for Apple. Consume flow-state, verify state/nonce/PKCE, exchange code→token (arctic),
+  fetch verified identity, run the linking algorithm (§3.3), `ensureWorkspaceForUser`, mint + rotate the
+  Sentropic session (`session.ts:createSession`), then resume: sealed continuation present →
+  `resumeLoginContinuation` (finishes downstream SSO exactly as after passkey login); else → fixed
+  internal page (D11).
+
+Route mounting mirrors the existing pattern (`api/src/routes/auth/index.ts` mounts
+`register`/`login`/`magic-link` etc.): a new `federation.ts` router mounted at `/federation`, active only
+when the host wires the `federation?` port.
+
+**Discovery impact: NONE on the RP side.** `/.well-known/openid-configuration`
+(`oauth/wellknown-handler.ts`) describes us *as an issuer to downstream apps*; being an RP to Google adds
+nothing. We consume providers' discovery (or arctic's hardcoded endpoints); we publish no new metadata.
+
+**Interplay invariant**: a social-enrolled user is, to the OAuth server, just a normal `users` row with
+a live session; they use the Sentropic OAuth server for downstream SSO identically to a passkey user.
+No change to token-handler, consent, JWKS, or userinfo.
+
+---
+
+## 7. Keystone test matrix (adversarial)
+
+| ID | Assertion | Lot |
+|---|---|---|
+| **K-SUBJECT** | Callback resolves by `(provider, subject)` FIRST; a matching subject logs in that user even if the provider email now differs (D6/D13). | 1 |
+| **K-AUTOLINK-SHELL** | Google verified-email collision with a **non-credentialed shell** → auto-links into it (D7/D8). | 1 |
+| **K-NOMERGE-CRED** | Verified-email collision with an **already-credentialed** account → routes to manual-link; NO silent merge, NO new identity attached (D7/OD2). | 1/2 |
+| **K-NOMERGE-UNVERIFIED** | Unverified/absent provider email NEVER auto-links to any existing user (D7/D9). | 1/2 |
+| **K-STATE** | Callback with a mismatched/expired/replayed `state`, `nonce`, or PKCE verifier is rejected (D5/D10). | 1 |
+| **K-SEALED** | The sealed OAuth `continue` (HMAC) is NEVER present in any parameter sent to the external provider; the flow-state cookie carries only the opaque pointer (D5/R1). | 1 |
+| **K-NOLEAK** | No external access/id/refresh token appears in any Sentropic id_token, access token, userinfo response, or browser-visible payload (D1/§1.3). | 1 |
+| **K-ROTATE** | The Sentropic session id after federation login differs from any pre-existing session id (anti-fixation, D10). | 1 |
+| **K-FLOW** | Federation flow-state is single-use: a second `consumeFlowState` returns null (D5). | 0 |
+| **K-UNIQUE** | A duplicate `(provider, subject)` insert is rejected; the concurrent-callback re-read logs the existing user in (D6/§3.3). | 0/1 |
+| **K-GH-CHALLENGE** | GitHub with a private/absent/unverified email → email-verification challenge; no silent no-email user created (D9). | 2 |
+| **K-MS-SUBJECT** | Microsoft subject = `oid`(+`tid`); a per-app `sub` collision across tenants does NOT merge users (D6). | 3 |
+| **K-APPLE-FORMPOST** | Apple callback parses POST-body params; first-auth name/email captured; a GET-query-only parse would fail (D16). | 4 |
+| **K-APPLE-SECRET** | A valid short-lived ES256 client-secret JWT is minted from the `.p8` at runtime (D15/D16). | 4 |
+| **K-FB-CHALLENGE** | Facebook with absent email → email challenge; no silent no-email user (D9). | 5 |
+| **K-UNLINK-LASTFACTOR** | Unlink is refused when it would remove the user's last sign-in factor (D12). | 6 |
+| **K-UI-LEGACY** | With no `federationProviders` prop, `AuthLogin`/`AuthRegister` render unchanged; existing auth-ui tests stay green (D17). | 6 |
+
+---
+
+## 8. Open items still gated (not blocking v1 lot 0/1)
+
+- **DS-owner coordination (Lot A + provider glyphs, D17/OD4)**: `AppChrome` brand-zone config and the
+  provider-icon set are DS-owned; confirm the brand tokens and whether the glyphs enter the DS icon set
+  or are inlined as licensed marks. Reversible; does not gate the backend lots.
+- **Per-provider auto-link expansion beyond Google (D8)**: adding Microsoft/GitHub/Apple/Facebook to the
+  auto-link allowlist requires per-provider proof rules (MS issuer/`tid`, GitHub extra verification,
+  Apple relay policy) — a later owner decision; v1 keeps them manual-link only.
+- **Provider console registration (owner/ops, D15)**: each provider needs the exact callback URL
+  (`https://auth.sent-tech.ca/auth/federation/{provider}/callback`) registered; Apple needs the domain +
+  return URL verified. Out-of-band owner task per provider before that provider's lot goes live.
+- **Domain-based tenant auto-provisioning (D18)**: deferred to the Microsoft/enterprise lot; depends on
+  verified-domain trust + membership-approval, out of v1 scope.
+- **arctic version pin + SCA gate (D3)**: confirm the pinned version passes `security-sast-sca` before
+  Lot 1 merges.

--- a/spec/SPEC_STUDY_39E_SOCIAL_FEDERATION.md
+++ b/spec/SPEC_STUDY_39E_SOCIAL_FEDERATION.md
@@ -1,0 +1,443 @@
+# SPEC_STUDY_39E_SOCIAL_FEDERATION — Upstream Social/Enterprise Federation for the Sentropic IdP
+
+Status: STUDY (options + trade-offs + recommendations). Non-decisional. This document FRAMES
+owner-gated calls; it does not decide them. Rung: harness-brainstorm STUDY.
+
+Lineage: BR-39e (federation-first), previously deferred (memory: "39c app-clients/scopes/OAuth
+multi-tenant deferred"; roadmap: "39e (multi-tenant, federation-first)"). This study scopes the
+*social/enterprise login federation* half of 39e: letting a human enroll/sign in to the Sentropic
+IdP via Google / GitHub / Microsoft / Apple / Facebook, while the IdP remains the single OIDC
+authority downstream apps trust.
+
+---
+
+## 0. Grounding — the IdP as it exists on main today (cited)
+
+The Sentropic IdP is a hand-rolled Hono auth stack (`@sentropic/auth-hono` **0.11.1**,
+`packages/auth-hono/package.json`), consumed by `api/` and by the standalone IdP app
+`apps/auth-idp/web` (SvelteKit), live at `auth.sent-tech.ca`.
+
+Facts that shape this study:
+
+- **Enrollment/login methods present**: WebAuthn/passkey (register + authenticate), magic-link,
+  email-verification-code, plus a session/refresh model. Method surface is a fixed contract:
+  `AUTH_HONO_AUTH_UI_METHODS` in `packages/auth-hono/src/contracts.ts:3` — the 12 methods are all
+  passkey / email / magic-link / session / credential-management. **There is ZERO external/social
+  provider seam anywhere**: `grep -riE 'arctic|openid-client|@auth/core|lucia|openauth|passport'`
+  over `packages/*` and `api/` returns nothing. No provider button exists in
+  `packages/auth-ui/src/components/AuthLogin.svelte` or `AuthRegister.svelte`.
+- **The IdP is an OIDC/OAuth2 *server*** (Authorization Server), not a client. Full authorize →
+  consent → token → userinfo → JWKS + discovery + revoke + introspect + DPoP + RFC 8707 resource
+  indicators + RFC 9207 iss + PRM live under `packages/auth-hono/src/oauth/*`. The authorize handler
+  (`oauth/authorize-handler.ts`) already seals an HMAC "continuation" state
+  (`oauth/state-codec.ts:1` `OAuthContinuationState`) to bounce the browser to `loginUrl` /
+  `registerUrl` / `consentUrl` and resume — **this is the exact hook where a federated-IdP round-trip
+  slots in** (federation is a way to satisfy `loginUrl`, upstream of the OAuth server).
+- **User + identity model** (`api/src/db/schema.ts`):
+  - `users` (line 140): `id`, `email` (unique, nullable), `displayName`, `role`, `accountStatus`,
+    `emailVerified` (default false), approval fields. Email is the de-facto natural key.
+  - `webauthn_credentials` (162), `user_sessions` (179), `magic_links` (211),
+    `email_verification_codes` (224), `oauth_consents` (332, `(userId,clientId)` unique).
+  - **No `identities` table exists.** The only "identity-type" concept is
+    `IdentityType = 'user' | 'service' | 'agent' | 'nhi' | 'mcp_connector'` re-exported from
+    `@sentropic/oauth-verify` (`packages/oauth-verify/src/index.ts:23`) — a *token-subject-type* tag,
+    NOT a federated-identity link table. So an `identities` table must be **added** (39h groundwork).
+- **How a user record is created today** (`api/src/routes/auth/register.ts`): registration is
+  email-proof-gated (email-verification JWT OR `sit_` invite token). New users are created with role
+  `editor` (or `admin_app` for the first `ADMIN_EMAIL`) and `accountStatus='pending_admin_approval'`
+  (approval due +48h), then `ensureWorkspaceForUser(userId)`
+  (`api/src/services/workspace-service.ts:55`) provisions a personal workspace. Magic-link has its
+  own create-on-verify path (`packages/auth-hono/src/magic-link.ts:135`), setting `emailVerified=true`.
+  **This "proof-of-email → find-or-create user → ensure workspace → mint session" shape is exactly
+  what a federation callback must reuse** — a verified-email assertion from Google is *another kind of
+  email proof*.
+- **Secret-at-rest pattern already in the repo**: `api/src/services/secret-crypto.ts` — AES-256-GCM
+  (`enc:v1:` prefix, key = SHA-256(JWT_SECRET)) used to encrypt OAuth *outbound* connector tokens in
+  `document_connector_accounts.tokenSecret` (`schema.ts:400`, consumed by
+  `api/src/services/google-drive-connector-accounts.ts`) and `llm_provider_accounts.tokenSecret`
+  (`schema.ts:432`). **Federation client secrets + Apple's key material should reuse this pattern
+  (or SealedSecret at deploy) — do not invent a third secret store.**
+- **Session mint** is a clean port call: `createAuthSessionService(...).createSession({ user, deviceInfo })`
+  (`packages/auth-hono/src/session.ts:44`) issues the signed session token + refresh + DB row. A
+  federation callback ends here, identical to passkey/magic-link finalization.
+
+Net: the IdP has every downstream primitive (OAuth server, sessions, users, workspace provisioning,
+secret-crypto) and a clean browser-bounce continuation hook — but **no upstream RP capability at all**.
+That absence is the whole of BR-39e-federation.
+
+---
+
+## 1. Providers in scope + per-provider quirks
+
+All five are OAuth2 authorization-code flows, but they diverge sharply in protocol cleanliness and in
+whether they yield a *verified* email (the security pivot of §4).
+
+| Provider | Protocol | Verified email? | Quirks that shape design |
+|---|---|---|---|
+| **Google** | Clean OIDC (discovery, id_token, `email_verified`) | Yes, `email_verified` claim | The reference case. PKCE supported. `sub` is the stable subject. Minimal friction. |
+| **GitHub** | OAuth2 **only** (no OIDC, no id_token) | Emails via `GET /user/emails`; each has `verified` + `primary` | Must call the REST API for identity + emails; the account `id` (numeric) is the stable subject. No PKCE historically (now supported for some app types — treat as optional). Email may be private → may get no email at all. |
+| **Microsoft** | OIDC (Entra ID) | `email`/`preferred_username`; verification varies | **Tenant vs `common` endpoint**: `common`/`consumers`/`organizations`/`{tenant}` change who can sign in and the `iss`. `sub` is per-(app,tenant) — pair with the immutable `oid` + `tid` for a stable global subject. Personal (MSA) vs work/school accounts behave differently. |
+| **Apple** | OIDC-ish (Sign in with Apple) | `email` + `email_verified`; may be a **private-relay** address | **Hardest.** `client_secret` is a **short-lived ES256 JWT you sign** with a downloaded `.p8` key (not a static string). **`response_mode=form_post`** → the callback is a **POST** with the params in the body, not a GET query. **Name + email arrive ONLY on the first authorization** and are in the POST body, not the id_token — must be captured then or lost forever. Private-relay email (`@privaterelay.appleid.com`) forwards to the real inbox; treat as verified but understand it is provider-scoped. |
+| **Facebook** | OAuth2 + limited OIDC | Email *may* be absent (user can decline / unverified) | Graph API for profile; email is not guaranteed and verification signal is weak. Lowest identity assurance of the five. |
+
+**Recommended v1 subset + order** (reversible slice):
+
+1. **Google** first — cleanest OIDC, highest verified-email assurance, largest coverage. Proves the
+   broker + `identities` table + auto-link policy end-to-end on the easy case.
+2. **GitHub** second — the developer-audience provider (relevant to the app-foundry / agent audience);
+   forces the "OAuth2-not-OIDC + email-via-API + email-may-be-private" code path early, which is where
+   the abstraction earns its keep.
+3. **Microsoft** — first enterprise provider; introduces tenant-endpoint config. Gate to when a B2B
+   need is real.
+4. **Apple** — defer to a dedicated lot: JWT client_secret + form_post + first-auth-only name are a
+   material extra surface. Required only if there is a consumer-iOS / App-Store distribution need.
+5. **Facebook** — lowest priority / assurance; add only on explicit demand.
+
+**Recommendation**: v1 ships **Google + GitHub**. Microsoft/Apple/Facebook are additive later lots
+behind the same seam (no re-architecture — that is the point of the abstraction in §2).
+
+**OPEN OWNER DECISION D-1**: confirm the v1 provider subset (proposed Google + GitHub) and the
+priority order for the rest.
+
+---
+
+## 2. Build approach — library vs hand-rolled RP
+
+The IdP is deliberately hand-rolled (no framework auth). A social-login library must fit *that* grain:
+give us typed per-provider OAuth2 clients and leave sessions/users/routing to our existing code.
+
+| Option | What it is | Fit with hand-rolled Hono | Apple/MS coverage | Dep/security surface | Control |
+|---|---|---|---|---|---|
+| **arctic** (+ **oslo** for PKCE/JWT/state primitives) | A thin, typed library of ~50 per-provider OAuth2 clients (authorization URL builder + code→token exchange + refresh). **No sessions, no DB, no framework.** | **Excellent** — it is *only* the RP protocol layer; we keep our authorize/continuation/session code untouched. | Google/GitHub/MS/Apple/Facebook all first-class; Apple's ES256 client_secret helper exists in the oslo/arctic orbit. | Small, focused, actively maintained; we still own the callback logic (where the real security lives). | High — we write the callback, linking, session mint. |
+| **@auth/core (Auth.js)** | Full auth framework: providers + session strategy + adapters + its own routing/CSRF model. | **Poor** — it wants to *own* the session and route layer; wrapping it around our OAuth *server* + WebAuthn + magic-link means two competing session models. Adapter friction against our schema. | Excellent provider coverage. | Large; opinionated; couples us to its release cadence and its session semantics. | Low — we cede session/routing control. |
+| **Lucia** | (Now largely a "reference/learning" resource rather than a maintained lib after the maintainer's 2024/25 wind-down.) | N/A — not a stable dependency to adopt. | N/A | N/A | N/A |
+| **openauth** | A standalone OAuth *server*/issuer (SST). It is an *IdP*, overlapping what we already have. | **Wrong layer** — it competes with `auth-hono`'s OAuth server, not with the missing RP piece. | Some. | Would mean replacing our IdP, not extending it. | N/A |
+
+**Recommendation: adopt `arctic` (with `oslo` for PKCE/state/JWT helpers) as the RP protocol layer;
+keep everything else hand-rolled.** Rationale: arctic supplies exactly the piece we lack (typed
+provider clients incl. Apple's awkward client_secret and the form_post-friendly token exchange) and
+*nothing* we already own. Auth.js/openauth both want to own layers we already have working in
+production; adopting them is a rewrite, not an extension. arctic keeps the security-critical callback
+(state/nonce/PKCE verification, linking policy, session mint) in our code where it is auditable.
+
+Packaging: add federation as a **new capability inside `@sentropic/auth-hono`** (new
+`src/federation/*` module + optional `federation` port bag), OR as a sibling `@sentropic/auth-federation`
+that depends on auth-hono. Prefer **inside auth-hono behind an optional port** (mirrors how `tenant`,
+`consentStore`, `invites` are already optional ports in `ports.ts:341` — legacy behavior when absent),
+so hosts opt in by wiring a `federation` port and provider configs; no new published package until a
+second consumer needs it (architecture.md: "package extraction activated by real app consumption").
+
+**OPEN OWNER DECISION D-2**: approve `arctic + oslo` as the RP library (vs hand-rolling the OAuth2
+clients, vs Auth.js). Reversible: arctic is used only inside the callback; swapping it later is local.
+
+**OPEN OWNER DECISION D-3**: packaging — federation as an **optional port inside `@sentropic/auth-hono`**
+(recommended, additive-minor bump 0.12.0) vs a new `@sentropic/auth-federation` package. New-package =
+publish/versioning surface; owner-gated per repo norms.
+
+---
+
+## 3. Federation model — broker vs pass-through
+
+**BROKER (recommended, non-negotiable invariant).** The Sentropic IdP acts as an **OIDC/OAuth2 RP to
+the external provider only for the enrollment/login moment**. On a successful upstream callback the IdP
+**mints its OWN Sentropic session + its OWN downstream tokens** exactly as passkey/magic-link do today
+(`session.ts:createSession`; downstream apps then still go through *our* OAuth server in
+`oauth/authorize-handler.ts`). The external provider is used to *establish who the human is*, then
+discarded from the downstream trust path.
+
+**Invariant (must be a test): external tokens NEVER leak downstream.** The Google/GitHub/Apple
+access_token, id_token, and refresh_token are used only server-side inside the callback to fetch the
+verified identity, then either dropped or stored encrypted for *re-auth only* — they are **never** put
+in a Sentropic id_token/access_token, never returned to the browser, never forwarded to a downstream
+RP. Downstream apps see one issuer (`auth.sent-tech.ca`) and one token format, whether the human
+enrolled by passkey or by Google. Federation is strictly **upstream** of the Sentropic IdP (§6).
+
+Pass-through (forwarding the external id_token or making downstream apps trust Google directly) is
+**rejected**: it multiplies the issuers downstream apps must trust, leaks provider tokens, and defeats
+the single-authority design that the whole `oauth/*` stack exists to provide.
+
+**OPEN OWNER DECISION**: none — broker is the recommendation and the only model consistent with the
+existing OAuth-server architecture. (Recorded here for completeness; owner may veto.)
+
+---
+
+## 4. Account model + linking policy (the security core)
+
+### 4a. Storage: new `identities` table (recommended)
+
+No `identities` table exists today (§0). Add one — additive, one migration
+(`api/drizzle/*.sql`), no change to `users`:
+
+```
+identities (
+  id                       text PK,
+  user_id                  text NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  provider                 text NOT NULL,          -- 'google' | 'github' | 'microsoft' | 'apple' | 'facebook'
+  provider_subject         text NOT NULL,          -- the provider's STABLE subject (Google sub, GitHub numeric id,
+                                                    --   MS oid+tid, Apple sub, FB id) — NOT the email
+  email_at_link            text,                    -- the email asserted by the provider at link time (audit)
+  email_verified_by_provider boolean NOT NULL,      -- did the provider assert this email as verified?
+  linked_at                timestamp NOT NULL,
+  last_login_at            timestamp,
+  UNIQUE (provider, provider_subject)               -- one external identity maps to exactly one user
+)
+```
+
+Rationale for a table (not columns on `users`): a user may link *several* providers; the natural key
+downstream is `(provider, provider_subject)`, not email; and `IdentityType` in oauth-verify is a
+token-subject tag, orthogonal to this link table. This is also the 39h groundwork (an `identities`
+spine the token/claim layer can reference later). Encrypted provider refresh tokens (if stored for
+re-auth) reuse `secret-crypto.ts` in a nullable `token_secret` column — but v1 need not store them at
+all (broker uses the provider once and drops it).
+
+### 4b. Linking policy — the confused-deputy / account-takeover surface
+
+Three cases at callback time, keyed on `(provider, provider_subject)`:
+
+1. **Known identity** (`(provider, provider_subject)` already in `identities`): log in that `user_id`.
+   Simple, no email involved. Safe.
+2. **Unknown identity, no email collision**: create a new `users` row (proof-of-email = the provider
+   assertion, if verified) + `identities` row + `ensureWorkspaceForUser`. Mirrors cold register.
+3. **Unknown identity, email collides with an existing Sentropic user**: the dangerous case.
+
+**Auto-link rule (recommended, strict):** auto-link the new external identity to the existing
+Sentropic user **ONLY IF the provider asserts the email as VERIFIED** (`email_verified` true /
+GitHub email `verified:true` / Apple `email_verified`) **AND** policy allows auto-link for that
+provider. Otherwise **do NOT auto-link** — instead require the user to prove control of the existing
+account (log in with the existing passkey/magic-link first, *then* link from an authenticated settings
+flow), or surface a "an account with this email exists — sign in to link" challenge.
+
+**Why this is load-bearing (spell out the attack):**
+- **Account takeover via unverified email.** GitHub lets you list an email you do not own if it is
+  unverified; Facebook may return an unverified/absent email; a malicious provider app could assert
+  any string. If we auto-linked on *unverified* email, an attacker who controls a social account
+  claiming `victim@corp.com` (unverified) would be silently merged into the victim's Sentropic user —
+  full takeover. **Verified-email gate closes this.**
+- **Confused deputy.** Treating "the provider says this email" as "the human controls this email" is
+  the classic confused-deputy: the IdP is deputized by the provider's assertion. Only a *verified*
+  assertion + a per-provider trust decision (we trust Google's `email_verified`; we may not trust
+  Facebook's) is safe. Private-relay Apple emails are provider-verified and safe to treat as verified,
+  but they are provider-scoped (a different relay per app) — do not cross-link relay emails across
+  providers.
+- **No email at all** (GitHub private, Facebook declined): case 2/collision cannot be evaluated →
+  create a fresh user with no email, or ask the user to add+verify one; never guess.
+
+**OPEN OWNER DECISION D-4**: ratify the linking policy — **auto-link to an existing user ONLY on a
+provider-verified email; unverified/absent email = create-fresh-or-challenge, never silent merge.**
+Also: is *any* auto-link acceptable in v1, or must first-time collision ALWAYS require an authenticated
+manual link (most conservative)? Recommendation: allow auto-link on verified email for Google;
+require manual-link-when-authenticated for the rest until each provider's verification is trusted.
+
+**OPEN OWNER DECISION D-5**: per-provider "trust this provider's `email_verified`" allowlist —
+default-trust Google + Microsoft; default-DISTRUST GitHub-unverified + Facebook (they fall to the
+manual/challenge path). Owner sets the initial trust map.
+
+---
+
+## 5. Security
+
+Every item below is a callback-side concern the RP library (arctic) does not decide for us:
+
+- **State** (CSRF/session-fixation on the callback): generate a random `state` per start, bind it to
+  the browser (short-lived HttpOnly cookie or the existing HMAC continuation `state-codec.ts`), verify
+  it exactly on callback. Reuse `createOAuthHmacStateCodec` / `sha256Base64url` (`oauth/crypto-utils.ts`)
+  rather than a new primitive.
+- **Nonce** (OIDC replay): for OIDC providers (Google/MS/Apple) generate a `nonce`, send it, and verify
+  it in the returned id_token.
+- **PKCE** where supported (Google, MS, Apple, GitHub-modern): always send `code_challenge=S256`; the
+  IdP's own authorize handler already mandates S256 (`authorize-handler.ts:232`) — mirror that rigor
+  upstream.
+- **Open-redirect on `returnTo`**: the post-login `returnTo` / `continue` MUST be validated against the
+  same allowlist logic the OAuth server already applies to `redirect_uri`
+  (`oauth/redirect-utils.ts validateRedirectUri`). Never redirect to an arbitrary caller-supplied URL.
+- **Apple `form_post`**: the callback route must accept **POST** (body-encoded params) for Apple, GET
+  for the others — one route, two parsers. Capture Apple's first-auth name/email from the POST body
+  immediately (it never comes again).
+- **Secret storage**: per-provider `client_id`/`client_secret` and Apple's `.p8` key + key_id/team_id
+  are secrets. Store as env / SealedSecret at deploy (like `JWT_SECRET`), and if any provider
+  refresh token is persisted, encrypt with `secret-crypto.ts` (`enc:v1:` AES-256-GCM). Apple's ES256
+  client_secret JWT is minted at runtime from the `.p8` — never stored as a static string.
+- **Redirect URI registration** (owner action): each provider console needs the exact callback URL
+  (`https://auth.sent-tech.ca/auth/federation/{provider}/callback`) registered; Apple needs the domain
+  + return URL verified. This is an out-of-band owner/ops task per provider.
+- **Rate-limit / abuse**: the start endpoint should be rate-limited like the email endpoints
+  (`AuthHonoEmailCodePolicy` window) to prevent enumeration/spam.
+
+**OPEN OWNER DECISION D-6**: secret placement — env/SealedSecret for client secrets (recommended,
+matches `JWT_SECRET`) vs a DB-backed per-provider config table (needed only if providers are
+tenant-configurable at runtime — defer). And: where do provider secrets live for the standalone IdP
+deploy (auth.sent-tech.ca) — same SealedSecret bundle as the auth-idp image.
+
+---
+
+## 6. IdP surface — new routes + interplay with the existing OAuth server
+
+New RP-side routes (all *upstream* of the OAuth server):
+
+- `GET /auth/federation/:provider/start` — build the provider authorization URL (state+nonce+PKCE),
+  set the state cookie, carry the sealed `continue` (the pending OAuth authorize continuation, if the
+  user arrived via a downstream app's `/authorize` → `loginUrl` bounce), 302 to the provider.
+- `GET|POST /auth/federation/:provider/callback` — verify state/nonce/PKCE, exchange code→token
+  (arctic), fetch verified identity, apply §4 linking policy, `ensureWorkspaceForUser`, mint the
+  Sentropic session (`session.ts:createSession`), then **resume**: if a sealed `continue` is present,
+  redirect back into `/authorize?continue=…` so the OAuth server finishes the downstream SSO exactly
+  as it does after passkey login (`authorize-handler.ts resumeLoginContinuation`); else redirect to the
+  post-login app.
+
+**Discovery impact: NONE on the RP side.** Our `/.well-known/openid-configuration`
+(`oauth/wellknown-handler.ts`) describes us *as an issuer to downstream apps*; being an RP to Google
+adds nothing to it. We *consume* the providers' discovery documents (or hardcode their endpoints via
+arctic), we do not publish new metadata.
+
+**Interplay invariant**: a social-enrolled user is, from the OAuth server's perspective, just a normal
+`users` row with a live session. They subsequently use the **Sentropic** OAuth server for downstream
+app SSO identically to a passkey user. Federation replaces *how the session is established*, not the
+downstream token issuance. The continuation `state-codec.ts` is the single integration seam — no change
+to token-handler, consent, JWKS, or userinfo.
+
+---
+
+## 7. UI — provider buttons (auth-ui, DS-styled)
+
+Add a DS-styled provider-button row to `packages/auth-ui/src/components/AuthLogin.svelte` and
+`AuthRegister.svelte` (both already import `@sentropic/design-system-svelte` `Button`). The buttons are
+plain links/`<Button>`s to `/auth/federation/:provider/start?…` (federation is a browser redirect, not
+an XHR through the `AuthUiTransport` fetch contract) — so this is additive props, not a transport
+change:
+
+- A `federationProviders?: Array<{ id, label, icon }>` prop (empty = no change; legacy hosts unaffected).
+- Buttons render under the passkey primary action ("or continue with Google / GitHub"), DS-themed via
+  the host's `ThemeProvider` (auth-idp already wraps in `entropicTheme` — layout §Adjacent).
+- Three flows share the same button but differ in copy/handler intent:
+  - **Enrollment** (register screen): first social login → create user.
+  - **Login** (login screen): returning social user.
+  - **Link-existing-account** (authenticated settings, e.g. alongside `AuthDevices.svelte`): a
+    logged-in user adds a provider — this is the *safe* linking path from §4 (proves account control).
+
+DS coordination: buttons must use DS components/tokens (no bespoke brand-colored buttons) to satisfy
+the "reuse UI, no entropy" rule. Provider glyphs are the one asset that may need adding to the DS icon
+set (coordinate with DS owner) or inlined as licensed brand marks.
+
+**OPEN OWNER DECISION D-7**: auth-ui minor bump adding `federationProviders` prop + button row —
+additive-minor (recommended, no breaking change). Confirm the link-existing-account flow is in v1 or
+deferred (recommend: include, it is the safe collision path from §4).
+
+---
+
+## 8. Multi-tenant landing
+
+Where does a social-enrolled user land? Today registration → `ensureWorkspaceForUser` (a personal
+workspace) and `accountStatus='pending_admin_approval'`. Tenancy is modeled by `tenant_memberships`
+(`schema.ts:820`, status `requested|invited|approved|…`) and the optional `AuthHonoTenantPort`
+(`ports.ts:296`) that derives the `tid` claim only from an **approved** membership.
+
+For v1: a social-enrolled user follows the **exact same path as a cold email registrant** — personal
+workspace + `pending_admin_approval` + no tenant claim until an approved `tenant_memberships` row
+exists. No special-casing. Enterprise auto-provisioning ("anyone with an `@corp.com` Microsoft login
+auto-joins tenant corp") is a **Microsoft-era, BR-39e-tenancy concern — deferred**; it depends on the
+verified-domain trust of §4/§5 and the membership-approval flow, and should not gate v1
+(Google/GitHub).
+
+**OPEN OWNER DECISION D-8**: confirm v1 lands social users in the same personal-workspace +
+pending-approval path as email registrants (recommended), deferring domain-based tenant
+auto-provisioning to the Microsoft/enterprise lot.
+
+---
+
+## 9. Spec-ladder + roadmap (reversible v1 slice)
+
+**v1 (reversible, minimal, owner-gated at D-1..D-8):**
+- Broker model (§3), external tokens never leak downstream (test-enforced invariant).
+- `arctic + oslo` RP layer, wired as an **optional `federation` port inside `@sentropic/auth-hono`**
+  (legacy behavior when absent).
+- New `identities` table (one migration), UNIQUE `(provider, provider_subject)`.
+- Providers **Google + GitHub** only.
+- Linking policy: **auto-link only on provider-verified email (Google); manual-link-when-authenticated
+  for GitHub-unverified**; never silent-merge on unverified/absent email.
+- Routes `/auth/federation/:provider/{start,callback}`; resume via existing continuation seam.
+- auth-ui `federationProviders` prop + DS-styled button row; link-existing-account flow included.
+- Social users land in personal-workspace + pending-approval (no tenant special-casing).
+
+**Gated / later lots (each additive behind the same seam):**
+- Microsoft (tenant-endpoint config) → introduces enterprise + domain-trust.
+- Apple (JWT client_secret + form_post + first-auth capture) → dedicated lot.
+- Facebook (lowest assurance) → on demand.
+- Domain-based tenant auto-provisioning (BR-39e tenancy).
+- 39h: `identities` referenced by the token/claim layer (identity-type spine).
+
+Suggested lot decomposition for the build branch (harness-plan later):
+- Lot 0 — `identities` table + migration + repo port.
+- Lot 1 — federation port contract in auth-hono + arctic wiring (Google).
+- Lot 2 — callback + linking policy + tests (verified-email gate is the keystone test).
+- Lot 3 — GitHub (OAuth2/email-via-API/private-email path).
+- Lot 4 — auth-ui buttons + auth-idp host wiring + UAT.
+
+---
+
+## 10. Owner decisions (batched)
+
+Each decision below has inline context (source + stakes + consequence). These are the calls this study
+FRAMES; the owner decides.
+
+- **D-1 — v1 provider subset & order.** *Source*: §1. *Stakes*: scope/effort of v1; each provider is a
+  distinct code path (OIDC-clean vs OAuth2-only vs form_post). *Consequence*: picks what ships first and
+  what is deferred. *Reco*: Google + GitHub in v1; MS → Apple → Facebook as later lots.
+- **D-2 — RP library.** *Source*: §2. *Stakes*: dependency + security-maintenance surface; framework
+  lock-in. *Consequence*: `arctic + oslo` keeps sessions/routing hand-rolled; Auth.js/openauth would be
+  a rewrite. *Reco*: `arctic + oslo`; reversible (used only in the callback).
+- **D-3 — packaging.** *Source*: §2. *Stakes*: new published package vs additive port; versioning norms
+  ("no new package without a decision"). *Consequence*: optional `federation` port inside
+  `@sentropic/auth-hono` (0.12.0 additive-minor) vs new `@sentropic/auth-federation`. *Reco*: optional
+  port inside auth-hono.
+- **D-4 — linking policy (SECURITY).** *Source*: §4. *Stakes*: account-takeover / confused-deputy — the
+  single most dangerous decision. *Consequence*: auto-link to an existing user ONLY on provider-verified
+  email; unverified/absent = create-fresh-or-challenge, never silent merge. *Reco*: ratify as stated;
+  in v1 allow verified-email auto-link for Google only, manual-link-when-authenticated elsewhere.
+- **D-5 — per-provider verified-email trust map.** *Source*: §4/§5. *Stakes*: which provider's
+  `email_verified` we trust for auto-link. *Consequence*: default-trust Google/Microsoft;
+  default-distrust GitHub-unverified/Facebook (→ manual path). *Reco*: adopt that default map.
+- **D-6 — secret placement.** *Source*: §5. *Stakes*: where client secrets + Apple `.p8` live; runtime
+  vs deploy config. *Consequence*: env/SealedSecret (matches `JWT_SECRET`) vs DB config table.
+  *Reco*: env/SealedSecret in the auth-idp deploy bundle; reuse `secret-crypto.ts` for any stored
+  provider refresh token.
+- **D-7 — auth-ui prop + flows.** *Source*: §7. *Stakes*: additive-minor UI contract change; whether the
+  link-existing-account flow ships in v1. *Consequence*: `federationProviders` prop + DS button row;
+  include the safe manual-link flow. *Reco*: additive-minor; include link flow.
+- **D-8 — multi-tenant landing.** *Source*: §8. *Stakes*: enterprise auto-provisioning scope creep.
+  *Consequence*: v1 = same personal-workspace + pending-approval as email registrants; domain-based
+  tenant auto-join deferred to the Microsoft/enterprise lot. *Reco*: confirm deferral.
+
+---
+
+## Adjacent: DS header on auth screens
+
+Two chromes exist today and they diverge:
+- The **canonical brand header is app-local**: `ui/src/lib/components/Header.svelte` — a rich,
+  session-aware header (brand SENT, right burger, workspace-scope selectors, identity/lang accordions,
+  chat-widget-aware compaction). It is *not* a DS component; it is `ui/`-specific.
+- The **IdP auth screens use the DS chrome**: `apps/auth-idp/web/src/routes/+layout.svelte:21` renders
+  `@sentropic/design-system-svelte` `AppChrome brandName="SENT" productName="Sentropic ID"` inside the
+  `entropicTheme` `ThemeProvider`. `AppChrome` gives brand + built-in language selector but not the
+  app-specific session/workspace machinery of `ui/`'s Header.
+
+So the two are *not* duplicates of the same component — they serve different surfaces (full app vs
+IdP screens). The reversible options for coherence:
+
+- **(a) Promote a shared DS chrome** consumed by BOTH `ui/` and `apps/auth-idp/web`: extract the
+  brand-zone + burger shell into a DS component (`AppChrome` variant or a new `AppHeaderShell`), and
+  have `ui/`'s Header compose it while keeping its app-local session/workspace logic as slotted
+  content. Pros: single brand source of truth, no entropy, DS-owned brand change propagates
+  everywhere. Cons: a DS-owned change (coordination + version bump); `ui/`'s Header is heavily
+  app-coupled, so only the *shell* is shared, not the whole component.
+- **(b) Configure `AppChrome`'s brand zone** so the IdP screens match the app brand exactly (feed
+  `AppChrome` the same brand tokens/slot `ui/`'s Header uses). Pros: cheapest, no `ui/` refactor,
+  stays within the DS's existing extension points. Cons: two implementations remain; brand parity is
+  by-configuration, not by-construction.
+- **(c) App-local duplicate** of the header inside auth-idp — **rejected** (entropy; two brand
+  headers drift; violates reuse/no-entropy).
+
+**Recommendation: (b) now, (a) if/when a second host needs the shared shell.** (b) achieves brand parity
+on the auth screens immediately with a DS-config change and no `ui/` risk; it is fully reversible into
+(a) later. Both (a) and (b) are **DS-owned changes** — coordinate with the design-system owner before
+touching `AppChrome`; do not fork it app-locally. If the owner wants one brand header everywhere as a
+principle, choose (a) and scope it as a DS branch (extract shell → `ui/` composes → auth-idp consumes).


### PR DESCRIPTION
## BR-39e — upstream social federation (design only)

Owner-directed (2026-07-09): let users enroll via Google, GitHub, Microsoft, Apple, Facebook.

**Design docs (no code):**
- `spec/SPEC_STUDY_39E_SOCIAL_FEDERATION.md` — options/trade-offs (grounded on main).
- `spec/SPEC_EVOL_39E_SOCIAL_FEDERATION.md` — committed design, D1–D18, v1 lot breakdown, keystone test matrix.

**Method:** harness-brainstorm STUDY→EVOL + double adversarial review (Opus 4.8 + Codex 5.5-xhigh, both SOUND-WITH-GAPS → all security gaps folded in).

**Owner decisions ratified:** all-5 providers (login) · safe linking `(provider,subject)`-first, no silent merge into credentialed accounts, Google-only auto-link v1 · optional `federation?` port in `@sentropic/auth-hono` (0.12.0) · AppChrome brand header on auth screens.

**Key security invariants:** broker (external tokens never leak downstream) · server-side one-time flow-state (never send the sealed `continue` upstream) · per-provider state+nonce+PKCE + session rotation · no-email providers → email-verification challenge.

**Out-of-band prerequisites (owner/ops):** register OAuth apps + redirect URIs on the 5 provider consoles; DS-owner coordination for the brand header + provider glyphs.

Design for architect + auth-lane (39etc) review before build. No code/schema/migration in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)