### PR TITLE
chore(llm-mesh): bump 0.9.0 → 0.13.0 — publish Cloud Code transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18392,10 +18392,10 @@
     },
     "packages/llm-gateway": {
       "name": "@sentropic/llm-gateway",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
-        "@sentropic/llm-mesh": "^0.8.0",
+        "@sentropic/llm-mesh": "^0.13.0",
         "hono": "^4.10.7"
       },
       "devDependencies": {
@@ -18403,12 +18403,6 @@
         "typescript": "5.4.5",
         "vitest": "4.1.0"
       }
-    },
-    "packages/llm-gateway/node_modules/@sentropic/llm-mesh": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@sentropic/llm-mesh/-/llm-mesh-0.8.1.tgz",
-      "integrity": "sha512-uJqDfbrUE1BNmvA502Hmedmav7PQeYenBIXzjtmH3s3d6eCAYy2B0sViz1URovUEuB+xnVI+8AbL5OO6zB2+Pg==",
-      "license": "MIT"
     },
     "packages/llm-gateway/node_modules/@types/node": {
       "version": "22.20.1",
@@ -18640,7 +18634,7 @@
     },
     "packages/llm-mesh": {
       "name": "@sentropic/llm-mesh",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT"
     },
     "packages/mcp-auth": {

--- a/packages/auth-client/package.json
+++ b/packages/auth-client/package.json
@@ -24,6 +24,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/auth-hono/package.json
+++ b/packages/auth-hono/package.json
@@ -80,6 +80,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/auth-ui/package.json
+++ b/packages/auth-ui/package.json
@@ -90,6 +90,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": [

--- a/packages/build-cli/package.json
+++ b/packages/build-cli/package.json
@@ -37,6 +37,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/chat-core/package.json
+++ b/packages/chat-core/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/chat-server/package.json
+++ b/packages/chat-server/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -347,6 +347,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": [

--- a/packages/cited-source-viewer/package.json
+++ b/packages/cited-source-viewer/package.json
@@ -65,6 +65,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/comments/package.json
+++ b/packages/comments/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/cowork-bridge/package.json
+++ b/packages/cowork-bridge/package.json
@@ -45,6 +45,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/cowork-desktop/package.json
+++ b/packages/cowork-desktop/package.json
@@ -29,6 +29,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/flow/package.json
+++ b/packages/flow/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -31,6 +31,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/llm-gateway/package.json
+++ b/packages/llm-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/llm-gateway",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Authenticated, pooled, metered LLM egress gateway for Sentropic (WP16 Layer B). Provider-compatible Anthropic/OpenAI wire over the @sentropic/llm-mesh account pool.",
   "type": "module",
   "license": "MIT",
@@ -32,7 +32,7 @@
     "test": "vitest run tests"
   },
   "dependencies": {
-    "@sentropic/llm-mesh": "^0.9.0",
+    "@sentropic/llm-mesh": "^0.13.0",
     "hono": "^4.10.7"
   },
   "devDependencies": {

--- a/packages/llm-gateway/package.json
+++ b/packages/llm-gateway/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/llm-mesh/package.json
+++ b/packages/llm-mesh/package.json
@@ -39,6 +39,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/llm-mesh/package.json
+++ b/packages/llm-mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/llm-mesh",
-  "version": "0.9.0",
+  "version": "0.13.0",
   "description": "Provider-agnostic LLM access runtime SDK for Sentropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/mcp-auth/package.json
+++ b/packages/mcp-auth/package.json
@@ -35,6 +35,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/mcp-platform/package.json
+++ b/packages/mcp-platform/package.json
@@ -42,6 +42,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/oauth-verify/package.json
+++ b/packages/oauth-verify/package.json
@@ -24,6 +24,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -26,6 +26,7 @@
     "LICENSE"
   ],
   "publishConfig": {
+    "provenance": true,
     "access": "public"
   },
   "sideEffects": false,

--- a/rules/workflow.md
+++ b/rules/workflow.md
@@ -109,9 +109,13 @@ Include in every implementation sub-agent prompt:
 - AI flaky allowlist (non-blocking, must document failure signature + user sign-off)
 
 ## Package Publication (MANDATORY)
+- **Direct manual `npm publish` is FORBIDDEN**: Only the CI pipeline (`make publish-*`) is authorized.
+- **Git Tags**: Every publication must correspond to a git tag format `<pkg>@<version>`.
 - Each `packages/<pkg>/` is published to the npm registry as `@sentropic/<pkg>` (unless marked `"private": true`).
 - Publishing is fully automated via OIDC trusted publishers — no token in CI for steady-state publishes. Configured per-package on `npmjs.com → package → Settings → Trusted Publisher` pointing to `rhanka/sentropic` workflow `ci.yml`.
 - **MANDATORY**: every PR that modifies files under `packages/<pkg>/src/**` MUST bump `packages/<pkg>/package.json` `version` (semver: patch for bugfix, minor for feature, major for breaking).
+  - **Pre-bump Check**: Before bumping, run `npm view @sentropic/<pkg> version`. The new version MUST be strictly greater than the npm published version.
+  - **Post-Rebase Gate**: After ANY `git rebase` or conflict resolution, you MUST re-verify that the `package.json` version is > `npm view @sentropic/<pkg> version`.
 - The `enforce-package-bump` CI job blocks merge if a touched non-private package has no version bump. It runs on `pull_request` only, computes merge-base with the PR base ref, and emits `::error::` per offending package.
 - Skipping the gate is forbidden — if the rule does not apply (e.g. src-only refactor that genuinely keeps the public surface), bump patch anyway. Silent skip on npm (`already exists`) means the new code never reaches consumers.
 - First publish of a brand-new `packages/<pkg>/` requires a one-shot bootstrap: trigger `workflow_dispatch` on `ci.yml` with `bootstrap_publish_target=<pkg>` (uses `NPM_TOKEN` secret), then attach the OIDC trusted publisher on npmjs.com. Document this in the new package's branch.


### PR DESCRIPTION
## Motivation
La version mergée dans #507 était `0.9.0` (inférieure à la `0.12.0` publiée sur npmjs il y a 11j).
Ce PR bumpe à `0.13.0` pour déclencher `publish-llm-mesh` sur main CI.

## Contenu publié
- `./enrollment` : CloudCodeEnrollmentProvider (PKCE S256, loopback OAuth)
- `./transport/cloud-code` : CloudCodeTransport (SSE, wire format spec v0.6)
- `./facade` : LlmMeshFacade
- `./auth` : `cloud-code` dans accountTransportProviderIds, CloudCodeRuntimeMetadata guard