### PR TITLE
fix(sec): exception-aware npm-audit gate — unblock ui/api Docker builds (unreachable image-size DoS, no patch)

### DIFF
--- a/.security/audit-allowlist.json
+++ b/.security/audit-allowlist.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Machine-readable allowlist for .security/audit-gate.mjs (the exception-aware npm-audit gate used in api/Dockerfile + ui/Dockerfile). Each entry allows ONE GHSA to not fail the HIGH/CRITICAL gate until review_due. Human record + full justification: .security/vulnerability-register.yaml. Keep the two in sync.",
+  "allow": [
+    {
+      "ghsa": "GHSA-w3rx-r6r6-pgpr",
+      "package": "image-size",
+      "severity": "high",
+      "reason": "DoS via ICNS parser infinite loop. No patched version exists (<=2.0.2 all vulnerable, first_patched=null). Unreachable in sentropic: pptxgenjs@4.0.1 never imports image-size (dead declared dep) AND the pptx export passes no image bytes (no addImage; text/shape/table + color-only backgrounds). false_positive/unreachable.",
+      "review_due": "2026-09-08"
+    },
+    {
+      "ghsa": "GHSA-5p2g-fcmc-qvqq",
+      "package": "image-size",
+      "severity": "high",
+      "reason": "DoS via JXL/HEIF parser infinite loops. Same as GHSA-w3rx-r6r6-pgpr: no patched version, unreachable dead transitive dependency.",
+      "review_due": "2026-09-08"
+    }
+  ]
+}

--- a/.security/audit-gate.mjs
+++ b/.security/audit-gate.mjs
@@ -1,0 +1,82 @@
+// Exception-aware npm-audit gate (replaces the raw `npm audit --audit-level=high`
+// in api/Dockerfile + ui/Dockerfile). It FAILS the build on any HIGH/CRITICAL
+// advisory whose GHSA id is NOT in .security/audit-allowlist.json, and FAILS
+// unconditionally once an allowlisted entry passes its review_due (so time-boxed
+// exceptions cannot linger silently). Human record + justification for each
+// allowlisted GHSA lives in .security/vulnerability-register.yaml.
+//
+// Usage (mirrors the audit scope of each Dockerfile stage):
+//   node .security/audit-gate.mjs --omit=dev --workspaces --include-workspace-root
+//   node .security/audit-gate.mjs --omit=dev
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const args = process.argv.slice(2).join(' ') || '--omit=dev';
+// AUDIT_GATE_TODAY overridable only for tests; production uses the real date.
+const today = process.env.AUDIT_GATE_TODAY || new Date().toISOString().slice(0, 10);
+
+const allowlist = JSON.parse(
+  readFileSync(new URL('./audit-allowlist.json', import.meta.url), 'utf8'),
+);
+const allowed = new Map((allowlist.allow || []).map((e) => [e.ghsa, e]));
+
+// Hard-expire: a past-due exception fails the build so it must be revisited.
+const expired = [...allowed.values()].filter((e) => today > e.review_due);
+if (expired.length) {
+  console.error('audit-gate: FAIL — allowlist entries past review_due, revisit:');
+  for (const e of expired) console.error(`  ${e.ghsa} (review_due ${e.review_due})`);
+  process.exit(1);
+}
+
+// npm audit exits non-zero when vulnerabilities exist; capture stdout either way.
+let raw = '';
+try {
+  raw = execSync(`npm audit --json ${args}`, { encoding: 'utf8', maxBuffer: 32 * 1024 * 1024 });
+} catch (e) {
+  raw = e.stdout ? e.stdout.toString() : '';
+}
+if (!raw) {
+  console.error('audit-gate: FAIL — no audit output');
+  process.exit(1);
+}
+const vulns = JSON.parse(raw).vulnerabilities || {};
+
+// Collect every GHSA id reachable for a package through the `via` graph.
+const ghsaOf = (name, seen = new Set()) => {
+  if (seen.has(name)) return [];
+  seen.add(name);
+  const v = vulns[name];
+  if (!v) return [];
+  const ids = [];
+  for (const via of v.via || []) {
+    if (typeof via === 'string') ids.push(...ghsaOf(via, seen));
+    else if (via && via.url) {
+      const m = via.url.match(/GHSA-[a-z0-9-]+/i);
+      if (m) ids.push(m[0]);
+    }
+  }
+  return ids;
+};
+
+const offenders = [];
+for (const [name, v] of Object.entries(vulns)) {
+  if (!['high', 'critical'].includes(v.severity)) continue;
+  const ids = [...new Set(ghsaOf(name))];
+  const unallowed = ids.filter((g) => !allowed.has(g));
+  // Fail if we cannot map it to any GHSA, or any of its GHSAs is not allowlisted.
+  if (ids.length === 0 || unallowed.length) {
+    offenders.push(
+      `${name} (${v.severity}) ghsa=[${ids.join(',') || 'unresolved'}]` +
+        (unallowed.length ? ` unallowlisted=[${unallowed.join(',')}]` : ''),
+    );
+  }
+}
+
+if (offenders.length) {
+  console.error('audit-gate: FAIL — unallowlisted HIGH/CRITICAL advisories:');
+  for (const o of offenders) console.error('  ' + o);
+  process.exit(1);
+}
+console.log(
+  `audit-gate: OK — only allowlisted HIGH/CRITICAL remain [${[...allowed.keys()].join(', ')}]`,
+);

--- a/.security/vulnerability-register.yaml
+++ b/.security/vulnerability-register.yaml
@@ -111,3 +111,23 @@ vulnerability_register:
       discovered: 2026-02-19
       review_due: 2026-02-26
       planned_fix: Upgrade npm/base image when npm bundle includes fixed minimatch and remove this exception after container scan passes
+
+    # image-size ICNS/JXL/HEIF DoS via pptxgenjs 4.0.1 (dead transitive, unreachable)
+    GHSA-w3rx-r6r6-pgpr_and_GHSA-5p2g-fcmc-qvqq_image-size_1.2.1:
+      category: false_positive
+      risk: HIGH
+      description: image-size DoS via infinite loops in the ICNS parser (GHSA-w3rx-r6r6-pgpr) and the JXL/HEIF parsers (GHSA-5p2g-fcmc-qvqq), CVSS 7.5 each. Pulled transitively by pptxgenjs 4.0.1. Trips the Docker npm-audit HIGH gate (api base + production stages, ui base stage).
+      file: package-lock.json (root; image-size <= 2.0.2 via pptxgenjs)
+      cwe: CWE-835
+      fix_goal: 1m
+      justification: |
+        No patched image-size version exists: both advisories are vulnerable "<= 2.0.2" with first_patched_version = null; the latest published image-size is 2.0.2 (2025-04-02), inside the vulnerable range. A forward override is therefore impossible, and pptxgenjs (latest 4.0.1) offers no upstream exit.
+        Unreachable in sentropic — double barrier, verified not inferred:
+        (1) pptxgenjs@4.0.1 never imports image-size: the string appears in no published code file of the tarball (only package.json); the sole consumer getSizeFromImage() is a commented "FIXME: TODO: currently unused" block that references require('sizeof') (wrong name); package.json declares browser:{image-size:false}. The declared dependency is dead.
+        (2) sentropic passes no image bytes to pptxgenjs: addImage is absent from the entire repo; the exposed pptx surface is addText/addShape/addTable only; backgrounds are color-only ({color:...}, never {path}/{data}).
+        The CVSS 7.5 vector is DoS on parsing an attacker-supplied image; the sentropic pptx export parses no image at all. Classification: false_positive / unreachable.
+        Analysis: cyber lane (gh api /advisories + published-tarball inspection) + infra lane (GitHub advisories + repo-wide grep). Enforced by .security/audit-gate.mjs + .security/audit-allowlist.json, which make the Docker npm-audit gate exception-aware (this entry is the human record; the allowlist is the machine list).
+      status: accepted_temporary
+      discovered: 2026-08-08
+      review_due: 2026-09-08
+      planned_fix: Open an upstream pptxgenjs issue to drop the dead image-size dependency; remove this exception once pptxgenjs ships without image-size (or a patched image-size is published) and the gate passes clean.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,41 @@
+# Fix(sec): exception-aware npm-audit gate — unblock ui/api Docker builds
+
+## Objective
+- [x] Lift the repo-wide `--audit-level=high` Docker gate that reds every ui/api build (blocks all ui lanes + PR CI).
+- [x] Root cause: `image-size` (GHSA-w3rx-r6r6-pgpr + GHSA-5p2g-fcmc-qvqq, DoS parsers) pulled transitively by `pptxgenjs@4.0.1` in the ROOT lockfile. `#517` (mermaid in `ui/package-lock.json`) is a NO-OP — the Docker build audits the ROOT lockfile; mermaid is only moderate anyway.
+- [x] No forward fix exists (`image-size <= 2.0.2` all vulnerable, `first_patched_version = null`), and the DoS is unreachable in sentropic → a targeted, expiring audit exception is the right unblock.
+
+## Scope / Guardrails
+- [x] `.security/audit-gate.mjs` (new) + `.security/audit-allowlist.json` (new): exception-aware wrapper — fails on any HIGH/CRITICAL GHSA not allowlisted, and fails after `review_due`.
+- [x] `.security/vulnerability-register.yaml`: `false_positive` entry for the 2 GHSAs (human record).
+- [x] `api/Dockerfile` (base + production gates) + `ui/Dockerfile` (base gate): replace raw `npm audit` with the wrapper. `api/Dockerfile:99` (auth-idp/web sub-tree, no image-size) left as raw audit.
+- [x] No `package.json` / lockfile change (npm ci stays valid). mermaid override bump DEFERRED (needs a full lockfile regen; moderate/non-blocking) — fast-follow.
+
+## Branch Scope Boundaries (MANDATORY)
+- **Allowed Paths (implementation scope)**:
+  - `.security/audit-gate.mjs`, `.security/audit-allowlist.json`, `.security/vulnerability-register.yaml`
+  - `api/Dockerfile`, `ui/Dockerfile`, `BRANCH.md`
+- **Forbidden Paths (must not change in this branch)**:
+  - `Makefile`, `docker-compose*.yml`, `package.json`, `package-lock.json`, `api/src/**`, `ui/src/**`, `packages/**`
+- **Conditional Paths**: none.
+
+## Feedback Loop
+- [x] `SEC-IMGSIZE-A` — RESOLVED. Option A (forward override) is IMPOSSIBLE: no patched image-size exists (`<= 2.0.2` vulnerable, `first_patched=null`, latest 2.0.2). Confirmed by cyber (gh api /advisories + npm registry) and infra (GitHub advisories). Conductor decision A/B/C: A preferred if a patch exists, else B (expiring exception), C (breaking pptxgenjs downgrade) REJECTED.
+- [x] `SEC-IMGSIZE-B` — Reachability NULL, double barrier (verified): (1) pptxgenjs@4.0.1 never imports image-size — dead declared dep (commented `FIXME: currently unused` consumer, `browser:{image-size:false}`); (2) sentropic passes no image bytes — no `addImage` in the repo, pptx surface = text/shape/table, backgrounds color-only. The CVSS 7.5 DoS on attacker-image parsing has no reachable path → `false_positive`.
+- [x] `SEC-IMGSIZE-VERIFY` — `make build-ui-image` green: `audit-gate: OK — only allowlisted HIGH/CRITICAL remain`, full ui build `Successfully built`.
+- [ ] `SEC-IMGSIZE-EXPIRY` — exception `review_due` 2026-09-08. Follow-up: upstream pptxgenjs issue to drop the dead image-size dependency, then remove the exception.
+- [ ] `SEC-IMGSIZE-MERMAID` — DEFERRED fast-follow: bump the `mermaid` root override `^11.15.0 -> ^11.16.1` (clears the moderate mermaid advisory) via a dedicated delete-lockfile regen. Moderate, non-blocking, out of this urgent unblock.
+
+## AI Flaky tests
+- Not applicable: security-gate + Dockerfile change only.
+
+## Orchestration Mode (AI-selected)
+- [x] Mono-branch + cherry-pick.
+- [ ] Multi-branch.
+- Rationale: one atomic security-gate change; conductor holds the merge GO.
+
+## Plan / Todo (lot-based)
+- [x] Lot 0 — RCA: gate = 4 Dockerfile lines audit the ROOT lockfile; #517 no-op; blocker = image-size HIGH.
+- [x] Lot 1 — Build the exception-aware wrapper + allowlist + register entry; wire the 3 real gates.
+- [x] Lot 2 — Verify via `make build-ui-image` (REGISTRY=local): gate passes, build green.
+- [ ] Lot 3 — Handover: draft PR; merge on conductor GO; report main-green to conductor + chat; open the pptxgenjs upstream follow-up.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -66,8 +66,10 @@ COPY packages/connector-host/package.json ./packages/connector-host/package.json
 COPY packages/mcp-connector-google/package.json ./packages/mcp-connector-google/package.json
 RUN if [ -f package-lock.json ]; then npm ci --workspaces --include-workspace-root; \
     else npm install --workspaces --include-workspace-root; fi
-# Security: Audit production dependencies for HIGH/CRITICAL vulnerabilities
-RUN npm audit --audit-level=high --omit=dev --workspaces --include-workspace-root
+# Security: audit production deps for HIGH/CRITICAL. Exception-aware gate
+# (GHSA allowlist + expiry) — see .security/audit-gate.mjs + vulnerability-register.yaml.
+COPY .security/audit-gate.mjs .security/audit-allowlist.json ./.security/
+RUN node .security/audit-gate.mjs --omit=dev --workspaces --include-workspace-root
 COPY . .
 RUN npm --workspace @sentropic/oauth-verify run build
 RUN npm --workspace @sentropic/auth-hono run build
@@ -126,7 +128,8 @@ FROM base AS production
 WORKDIR /workspace
 ENV NODE_ENV=production
 RUN npm prune --omit=dev --workspaces --include-workspace-root
-RUN npm audit --audit-level=high --omit=dev --workspaces --include-workspace-root
+# Exception-aware gate (inherits .security/ from the base stage's COPY . .).
+RUN node .security/audit-gate.mjs --omit=dev --workspaces --include-workspace-root
 COPY --from=build /workspace/api/dist /workspace/api/dist
 # BR-39 deploy (D4-a) — bundle the standalone IdP entrypoint + its login/consent
 # screens into the SAME image. The api runtime is untouched (default CMD below);

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -8,8 +8,10 @@ COPY ui/package.json ./ui/package.json
 COPY packages/llm-mesh/package.json ./packages/llm-mesh/package.json
 RUN if [ -f package-lock.json ]; then npm ci --workspaces --include-workspace-root; \
     else npm install --workspaces --include-workspace-root; fi
-# Security: Audit production dependencies for HIGH/CRITICAL vulnerabilities
-RUN npm audit --audit-level=high --omit=dev --workspaces --include-workspace-root
+# Security: audit production deps for HIGH/CRITICAL. Exception-aware gate
+# (GHSA allowlist + expiry) — see .security/audit-gate.mjs + vulnerability-register.yaml.
+COPY .security/audit-gate.mjs .security/audit-allowlist.json ./.security/
+RUN node .security/audit-gate.mjs --omit=dev --workspaces --include-workspace-root
 COPY . .
 
 FROM base AS development


### PR DESCRIPTION
# Fix(sec): exception-aware npm-audit gate — unblock ui/api Docker builds

## Objective
- [x] Lift the repo-wide `--audit-level=high` Docker gate that reds every ui/api build (blocks all ui lanes + PR CI).
- [x] Root cause: `image-size` (GHSA-w3rx-r6r6-pgpr + GHSA-5p2g-fcmc-qvqq, DoS parsers) pulled transitively by `pptxgenjs@4.0.1` in the ROOT lockfile. `#517` (mermaid in `ui/package-lock.json`) is a NO-OP — the Docker build audits the ROOT lockfile; mermaid is only moderate anyway.
- [x] No forward fix exists (`image-size <= 2.0.2` all vulnerable, `first_patched_version = null`), and the DoS is unreachable in sentropic → a targeted, expiring audit exception is the right unblock.

## Scope / Guardrails
- [x] `.security/audit-gate.mjs` (new) + `.security/audit-allowlist.json` (new): exception-aware wrapper — fails on any HIGH/CRITICAL GHSA not allowlisted, and fails after `review_due`.
- [x] `.security/vulnerability-register.yaml`: `false_positive` entry for the 2 GHSAs (human record).
- [x] `api/Dockerfile` (base + production gates) + `ui/Dockerfile` (base gate): replace raw `npm audit` with the wrapper. `api/Dockerfile:99` (auth-idp/web sub-tree, no image-size) left as raw audit.
- [x] No `package.json` / lockfile change (npm ci stays valid). mermaid override bump DEFERRED (needs a full lockfile regen; moderate/non-blocking) — fast-follow.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths (implementation scope)**:
  - `.security/audit-gate.mjs`, `.security/audit-allowlist.json`, `.security/vulnerability-register.yaml`
  - `api/Dockerfile`, `ui/Dockerfile`, `BRANCH.md`
- **Forbidden Paths (must not change in this branch)**:
  - `Makefile`, `docker-compose*.yml`, `package.json`, `package-lock.json`, `api/src/**`, `ui/src/**`, `packages/**`
- **Conditional Paths**: none.

## Feedback Loop
- [x] `SEC-IMGSIZE-A` — RESOLVED. Option A (forward override) is IMPOSSIBLE: no patched image-size exists (`<= 2.0.2` vulnerable, `first_patched=null`, latest 2.0.2). Confirmed by cyber (gh api /advisories + npm registry) and infra (GitHub advisories). Conductor decision A/B/C: A preferred if a patch exists, else B (expiring exception), C (breaking pptxgenjs downgrade) REJECTED.
- [x] `SEC-IMGSIZE-B` — Reachability NULL, double barrier (verified): (1) pptxgenjs@4.0.1 never imports image-size — dead declared dep (commented `FIXME: currently unused` consumer, `browser:{image-size:false}`); (2) sentropic passes no image bytes — no `addImage` in the repo, pptx surface = text/shape/table, backgrounds color-only. The CVSS 7.5 DoS on attacker-image parsing has no reachable path → `false_positive`.
- [x] `SEC-IMGSIZE-VERIFY` — `make build-ui-image` green: `audit-gate: OK — only allowlisted HIGH/CRITICAL remain`, full ui build `Successfully built`.
- [ ] `SEC-IMGSIZE-EXPIRY` — exception `review_due` 2026-09-08. Follow-up: upstream pptxgenjs issue to drop the dead image-size dependency, then remove the exception.
- [ ] `SEC-IMGSIZE-MERMAID` — DEFERRED fast-follow: bump the `mermaid` root override `^11.15.0 -> ^11.16.1` (clears the moderate mermaid advisory) via a dedicated delete-lockfile regen. Moderate, non-blocking, out of this urgent unblock.

## AI Flaky tests
- Not applicable: security-gate + Dockerfile change only.

## Orchestration Mode (AI-selected)
- [x] Mono-branch + cherry-pick.
- [ ] Multi-branch.
- Rationale: one atomic security-gate change; conductor holds the merge GO.

## Plan / Todo (lot-based)
- [x] Lot 0 — RCA: gate = 4 Dockerfile lines audit the ROOT lockfile; #517 no-op; blocker = image-size HIGH.
- [x] Lot 1 — Build the exception-aware wrapper + allowlist + register entry; wire the 3 real gates.
- [x] Lot 2 — Verify via `make build-ui-image` (REGISTRY=local): gate passes, build green.
- [ ] Lot 3 — Handover: draft PR; merge on conductor GO; report main-green to conductor + chat; open the pptxgenjs upstream follow-up.
