### PR TITLE
L-C-shell — incremental app→package shell handover (header-first, D1c)

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -84,9 +84,9 @@ Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-f
   - [x] Package: `renderHeaderLeading`/`renderHeaderActions`/`headerGrip` slots on ChatWidget (+ `.d.ts`) + `chat-widget-header-frame.dom.spec.ts` (4). App: mobile-menu + actions blocks wrapped in-place snippets (`renderHeaderLeadingHost`/`renderHeaderActionsHost`), rendered at the same spot — no reindent of the 726-line settings popover (I4).
   - [x] Lot gate GREEN (`ENV=test-lc-shell`): typecheck-ui 0, lint-ui clean, package DOM 212 (order + grip), host-wiring `ChatWidget-header-snippets` (4), FULL test-ui 471/471 zero regression.
 
-- [ ] **Lot S3 — package tab-content routing, host panels unchanged (≤120 lines)**
-  - [ ] Introduce the narrow package content compositor; feed existing jobs/comments/chat snippets; `QueueMonitor` stays inside the jobs snippet (app-only per boundary test).
-  - [ ] Lot gate: typecheck+lint; package DOM selects each tab and sees only its injected panel; host-wiring proves `<QueueMonitor />` still app-only; FULL `make test-ui ENV=test`.
+- [x] **Lot S3 — package tab-content routing, host panels unchanged** — DONE
+  - [x] Package already exposes `renderJobsPanel`/`renderCommentsPanel`/`renderChatPanel` + routes by activeTab. App: the gate-ready branch's jobs/comments/chat panels wrapped in in-place snippets (`renderJobsPanelHost`/`renderCommentsPanelHost`/`renderChatPanelHost`), ready to feed the package slots at S8; `QueueMonitor` stays inside the jobs snippet (app-only, package boundary honored). I4-exact (no reindent).
+  - [x] Lot gate GREEN (`ENV=test-lc-shell`): typecheck-ui 0, lint-ui clean, host-wiring `ChatWidget-content-snippets` (3), FULL test-ui 474/474 zero regression.
 
 - [ ] **Lot S4 — cut conversation host seams in place (≤130 lines)**
   - [ ] Make configured `ChatSessionsBar` a `renderConversationHeader` snippet and `<ChatPanel>` a `renderChatPanel` snippet; keep menu/Plus/Trash host snippets; no composer code moves.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -88,9 +88,9 @@ Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-f
   - [x] Package already exposes `renderJobsPanel`/`renderCommentsPanel`/`renderChatPanel` + routes by activeTab. App: the gate-ready branch's jobs/comments/chat panels wrapped in in-place snippets (`renderJobsPanelHost`/`renderCommentsPanelHost`/`renderChatPanelHost`), ready to feed the package slots at S8; `QueueMonitor` stays inside the jobs snippet (app-only, package boundary honored). I4-exact (no reindent).
   - [x] Lot gate GREEN (`ENV=test-lc-shell`): typecheck-ui 0, lint-ui clean, host-wiring `ChatWidget-content-snippets` (3), FULL test-ui 474/474 zero regression.
 
-- [ ] **Lot S4 — cut conversation host seams in place (≤130 lines)**
-  - [ ] Make configured `ChatSessionsBar` a `renderConversationHeader` snippet and `<ChatPanel>` a `renderChatPanel` snippet; keep menu/Plus/Trash host snippets; no composer code moves.
-  - [ ] Lot gate: typecheck+lint; host-wiring asserts header/body slot placement + Back/menu/icon wiring; keep existing Back DOM contract; preserve mounted `chatPanelRef`; FULL `make test-ui ENV=test`.
+- [x] **Lot S4 — cut conversation host seams in place** — DONE
+  - [x] `ChatSessionsBar` wrapped in `renderConversationHeaderHost` snippet, `<ChatPanel>` (chatPanelRef) in `renderChatBodyHost` snippet, both rendered in place; sessions menu + Plus/Trash icon snippets stay app-owned; no composer code moved; chatPanelRef preserved (I4).
+  - [x] Lot gate GREEN (`ENV=test-lc-shell`): typecheck-ui 0, lint-ui clean, host-wiring `ChatWidget-conversation-seams` (4) + `agents-list` chatPanelRef preserved, FULL test-ui 478/478 zero regression.
 
 - [ ] **Lot S5 — package agents pager prepared (≤145 lines)**
   - [ ] Add package-owned list section + conversation container around shipped `AgentsList` with `agentsList` object, `renderAgentsListHeader`, `renderConversationHeader`, `renderChatPanel`, announcement prop; move the logical slide/reduced-motion CSS into the package.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,0 +1,123 @@
+# Feature: L-C-shell — incremental app→package shell handover (header-first, D1c)
+
+## Objective
+Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-first, one-shippable-slice steps so the PACKAGE owns the tab bar + list and the app stops taking over `renderShell` — the prerequisite that makes the later R1 rename (L-A') visible. No rename, no `api/` change, no visible behavior change in this lot.
+
+## Scope / Guardrails
+- Scope limited to `packages/chat-ui/**` and `ui/**`; `api/**` stays untouched.
+- No R1 rename here: `ChatWidgetTab` literals, user-visible labels, persisted coercion and handoff schema stay unchanged (that is L-A').
+- Every slice additive → `chat-ui` minor bump; baseline is ONE cumulative minor for the whole lot (`0.33.0` → `0.34.0`).
+- Make-only workflow, no direct Docker commands.
+- Root workspace `~/src/sentropic` reserved for owner dev/UAT (`ENV=dev`); never run test campaigns there.
+- Branch development happens only in `tmp/chat-lc-shell`.
+- Unit/DOM gates on `ENV=test`; E2E on `ENV=e2e-lc-shell`, isolated ports, never root `dev`.
+- In every `make` command, `ENV=<env>` is the last argument.
+- Touching `ui/**` → run the FULL `make test-ui` before push, not just the changed file.
+- All new text English; owner UAT in French.
+
+## Branch Scope Boundaries (MANDATORY)
+- **Allowed Paths (implementation scope)**:
+  - `packages/chat-ui/src/components/ChatWidget.svelte`
+  - `packages/chat-ui/src/components/ChatWidget.svelte.d.ts`
+  - `packages/chat-ui/src/components/ChatWidgetTabBar.svelte` (new — extracted tab-bar primitive)
+  - `packages/chat-ui/src/components/ChatWidgetTabBar.svelte.d.ts` (new)
+  - `packages/chat-ui/src/components/AgentsList.svelte`
+  - `packages/chat-ui/package.json`, `packages/chat-ui/export-manifest.json`, `packages/chat-ui/chat-ui-reference-validation.json`
+  - `packages/chat-ui/tests/**` (DOM + reference-validation contracts for the new seams)
+  - `ui/src/lib/components/ChatWidget.svelte`
+  - `ui/src/lib/components/ChatPanel.svelte`
+  - `ui/tests/components/chat/**`
+  - `ui/src/locales/en.json`, `ui/src/locales/fr.json`
+  - `e2e/tests/03-chat.spec.ts`, `e2e/tests/08-chat-workspace-switch.spec.ts`, `e2e/tests/08-chat-checkpoint-restore.spec.ts` (non-regression selectors only, if the shell DOM shifts)
+  - `BRANCH.md`
+- **Forbidden Paths (must not change in this branch)**:
+  - `Makefile`
+  - `docker-compose*.yml`
+  - `.cursor/rules/**`
+  - `api/**`
+  - `packages/cowork-bridge/**`
+  - `plan/NN-BRANCH_*.md` (except this branch file)
+- **Conditional Paths (allowed only with explicit `BRxx-EXn`)**:
+  - `.github/workflows/**` (none expected)
+- **Exception process**:
+  - Declare `BRxx-EXn` in `## Feedback Loop` before touching any conditional/forbidden path (reason + impact + rollback).
+
+## Feedback Loop
+- `clarification` — Q1 QueueMonitor ownership: baseline = stays APP-LOCAL behind the existing `renderJobsPanel` for all of L-C-shell (no retire/redesign). Package boundary test forbids importing `QueueMonitor`; honored.
+- `clarification` — Q2 transition mechanism: baseline = keep `renderShell?: Snippet<[]>` source-compatible for external consumers; this app stops PASSING it at S8; the package gains supported header/content subcomponents. No break in a minor.
+- `clarification` — Q3 header generic-vs-host boundary: baseline = ALL current trailing controls (settings `MenuPopover`, side-switch, placement, close) stay in one host `renderHeaderActions` snippet; no generic close/placement moves package-side in this lot.
+- `clarification` — Q4 D13 state ownership: baseline = FROZEN — `agentsView` stays app-owned, `cowork-bridge` untouched. This lot moves DOM ownership only, not view-state ownership.
+- `clarification` — Q5 release cadence: baseline = ONE cumulative `chat-ui` minor (`0.33.0` → `0.34.0`) for the whole lot in one PR (8 atomic commits), not a published per-slice series.
+- `attention` — DS DOM blocker to re-check before S5/S6: the AgentsList DOM suite recorded a design-system parse blocker (`packages/chat-ui/tests/agents-list.dom.spec.ts`). Re-verify at S5; if still present, cover S5/S6 with package source + host-wiring fail-first tests and do not green a DOM-acceptance that was not executed.
+- `attention` — F5 (typed bubble/wheel glyph) stays blocked on the design-system lane; interim `layers` icon in `AgentsList` is unchanged by this lot.
+
+## AI Flaky tests
+- Accept only non-systematic provider/network/model nondeterminism as `flaky accepted` (one success on same commit+command). Never add timeouts. Record command + file + signature here. Owner sign-off before merge.
+
+## Orchestration Mode (AI-selected)
+- [x] **Mono-branch + cherry-pick** (single lane, incremental slices, one final test cycle)
+- [ ] **Multi-branch**
+- Rationale: one owning lane (chat), strictly ordered slices on a shared file, one cumulative minor — no orthogonal sub-workstreams.
+
+## UAT Management (in orchestration context)
+- Mono-branch: UAT on the integrated branch after the shell handover is complete, from root `ENV=dev` with owner data. Invariant is "no visible change" — UAT is a NON-regression pass of the current agents-surface (list-default, Back+slide, hybrid mount, all header controls, tab order/labels).
+
+## Plan / Todo (lot-based)
+- [ ] **Lot 0 — Baseline & constraints**
+  - [x] Fresh worktree `tmp/chat-lc-shell` from `origin/main` (chat-ui `0.33.0`).
+  - [x] Ground on ratified D1c and the L-C lot row (`spec/SPEC_EVOL_AGENTS_SURFACE.md`).
+  - [x] Lock the 5 fork baselines (Q1–Q5 above) and scope boundaries.
+  - [ ] Confirm env/ports: unit/DOM on `ENV=test`; E2E slot `ENV=e2e-lc-shell` API_PORT=9106 UI_PORT=5306 MAILDEV_UI_PORT=1206.
+
+- [ ] **Lot S1 — move the live tab bar, not a façade (≤145 lines)**
+  - [ ] Extract the app tab-bar literals/labels/callbacks into a package `ChatWidgetTabBar` primitive; replace the app's three buttons; keep the surrounding app header; app opts out of the package default jobs badge (preserve I4).
+  - [ ] Lot gate:
+    - [ ] `make typecheck-ui` + `make lint-ui`
+    - [ ] **UI tests**
+      - [ ] Package DOM (fail-first): `ChatWidgetTabBar` asserts current three-role order, `showCommentsTab` predicate, click callback, badge-off parity → `make test-chat-ui-dom ENV=test`
+      - [ ] Host-wiring (fail-first): the app header imports the primitive and no longer owns the three buttons → `make test-ui SCOPE=tests/components/chat/ChatWidget-shell.test.ts ENV=test`
+      - [ ] Sub-lot gate: FULL `make test-ui ENV=test`
+    - [ ] `chat-ui` minor bump + export/reference-validation entry for `ChatWidgetTabBar`
+
+- [ ] **Lot S2 — package header frame, host controls as slots (≤145 lines)**
+  - [ ] Add `renderHeaderLeading`, `renderHeaderActions`, `headerGrip`; wrap existing mobile/action blocks as in-place host snippets (no move/reindent of the settings popover).
+  - [ ] Lot gate: typecheck+lint; package DOM proves leading→tab→actions order + grip pointer callback; host-wiring proves every existing action still injected; FULL `make test-ui ENV=test`.
+
+- [ ] **Lot S3 — package tab-content routing, host panels unchanged (≤120 lines)**
+  - [ ] Introduce the narrow package content compositor; feed existing jobs/comments/chat snippets; `QueueMonitor` stays inside the jobs snippet (app-only per boundary test).
+  - [ ] Lot gate: typecheck+lint; package DOM selects each tab and sees only its injected panel; host-wiring proves `<QueueMonitor />` still app-only; FULL `make test-ui ENV=test`.
+
+- [ ] **Lot S4 — cut conversation host seams in place (≤130 lines)**
+  - [ ] Make configured `ChatSessionsBar` a `renderConversationHeader` snippet and `<ChatPanel>` a `renderChatPanel` snippet; keep menu/Plus/Trash host snippets; no composer code moves.
+  - [ ] Lot gate: typecheck+lint; host-wiring asserts header/body slot placement + Back/menu/icon wiring; keep existing Back DOM contract; preserve mounted `chatPanelRef`; FULL `make test-ui ENV=test`.
+
+- [ ] **Lot S5 — package agents pager prepared (≤145 lines)**
+  - [ ] Add package-owned list section + conversation container around shipped `AgentsList` with `agentsList` object, `renderAgentsListHeader`, `renderConversationHeader`, `renderChatPanel`, announcement prop; move the logical slide/reduced-motion CSS into the package.
+  - [ ] Re-check the DS DOM blocker first (see Feedback Loop).
+  - [ ] Lot gate: typecheck+lint; package DOM/structure proves list conditional mount, conversation persistent-mount/hidden, slot placement, live region; FULL `make test-ui ENV=test`.
+
+- [ ] **Lot S6 — switch the live pager to package ownership (≤145 lines)**
+  - [ ] Replace the app list/conversation wrapper with the package pager; remove the direct app `<AgentsList>` mount and app-owned motion CSS.
+  - [ ] Lot gate: typecheck+lint; evolve host test to reject direct `<AgentsList>` ownership while asserting Option-3, Back/focus, row actions, package pager props; FULL `make test-ui ENV=test`.
+
+- [ ] **Lot S7 — narrow the extension gate (≤130 lines)**
+  - [ ] Wrap only loading/auth/onboarding in `renderContentGate({ renderReady })`; host calls `renderReady` in its `{:else}` branch.
+  - [ ] Lot gate: typecheck+lint; package DOM proves a host gate suppresses ready content and renders it exactly once; host-wiring asserts all three states/actions remain; FULL `make test-ui ENV=test`.
+
+- [ ] **Lot S8 — remove this app's full-shell takeover (≤120 lines)**
+  - [ ] Promote prepared header/content snippets to the `PackageChatWidget` call; stop passing `renderShell`; package `ChatWidget` composes header + tab bar + gate + panel routing + list. Keep `renderShell` available to external consumers.
+  - [ ] Lot gate: typecheck+lint; app anti-takeover test expects no `renderShell={renderAppChatWidgetShell}`; package DOM renders header + selected panel/list via the default path; FULL `make test-ui ENV=test`.
+
+- [ ] **Lot N-2 — UAT (non-regression, root `ENV=dev`, owner data)**
+  - [ ] Web app: agents list is default when sessions exist and none active; conversation when active/none; Back→slide + focus; hybrid mount; tab order/labels unchanged; all header controls (settings, side-switch, placement, close) present; jobs/comments panels unchanged.
+
+- [ ] **Lot N-1 — Docs consolidation**
+  - [ ] Fold the D1c handover end-state into `spec/SPEC_EVOL_AGENTS_SURFACE.md` (mark L-C-shell shipped; L-A' still pending owner GO).
+
+- [ ] **Lot N — Final validation**
+  - [ ] Typecheck & Lint (ui + chat-ui)
+  - [ ] FULL `make test-ui ENV=test` + `make test-chat-ui-dom ENV=test` + `make test-chat-ui ENV=test`
+  - [ ] E2E non-regression: `make clean test-e2e E2E_SPEC=tests/03-chat.spec.ts API_PORT=9106 UI_PORT=5306 MAILDEV_UI_PORT=1206 ENV=e2e-lc-shell` (03 on AI allowlist) + 08 workspace-switch/checkpoint-restore
+  - [ ] `chat-ui` cumulative minor `0.34.0` verified > npm published
+  - [ ] PR body = this `BRANCH.md`; CI green (AI shards non-blocking allowlist)
+  - [ ] Owner UAT sign-off + owner GO recorded; then remove `BRANCH.md`, push, merge (`--merge` only)

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -50,7 +50,7 @@ Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-f
 - `clarification` — Q5 release cadence: baseline = ONE cumulative `chat-ui` minor (`0.33.0` → `0.34.0`) for the whole lot in one PR (8 atomic commits), not a published per-slice series.
 - `attention` — DS DOM blocker to re-check before S5/S6: the AgentsList DOM suite recorded a design-system parse blocker (`packages/chat-ui/tests/agents-list.dom.spec.ts`). Re-verify at S5; if still present, cover S5/S6 with package source + host-wiring fail-first tests and do not green a DOM-acceptance that was not executed.
 - `attention` — F5 (typed bubble/wheel glyph) stays blocked on the design-system lane; interim `layers` icon in `AgentsList` is unchanged by this lot.
-- `blocked` — S1 ui gates (`make typecheck-ui`, `make lint-ui`, `make test-ui`) cannot run: `up-ui` fails on a repo-wide `npm audit --audit-level=high` for mermaid CVEs (GHSA-3rrr-jr9j-h3q3 + 4 more). PRE-EXISTING on `origin/main` (`mermaid ^11.14.0`); this branch changes zero dependencies (only `packages/chat-ui/package.json` +6 lines, no lockfile). S1 code is otherwise validated: `make test-chat-ui ENV=test-lc-shell` GREEN (1022 tests incl reference-validation + theme-css drift + version pins) and `ChatWidgetTabBar` DOM test GREEN (5); app-swap type-safety verified (app `type Tab = ChatWidgetTab`). Route the mermaid audit to a `fix/sec-*` branch via the conductor; re-run typecheck-ui/test-ui once it lands. Do NOT push S1 until the ui gates can go green.
+- `acknowledge` — mermaid npm-audit blocker RESOLVED: infra merged #519 (exception-aware audit gate — `.security/audit-gate.mjs` + allowlist + register; image-size DoS unreachable/expiring 2026-09-08; mermaid = moderate, below `--audit-level=high`). Merged `origin/main` into this branch (`856e54c6d`, BRANCH.md=ours). S1 ui gates now GREEN on `ENV=test-lc-shell`: `typecheck-ui` 0 errors, `lint-ui` clean, FULL `test-ui` 467/467 (incl `ChatWidget-tab-bar.test.ts`), zero regression. Two typing fixes made: `.d.ts` uses Svelte-5 `Component<Props>` (not `SvelteComponentTyped`) and the app annotates `onSelect={(tab: ChatWidgetTab) => …}` (svelte-check would not infer the param otherwise).
 
 ## AI Flaky tests
 - Accept only non-systematic provider/network/model nondeterminism as `flaky accepted` (one success on same commit+command). Never add timeouts. Record command + file + signature here. Owner sign-off before merge.
@@ -72,13 +72,13 @@ Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-f
 
 - [ ] **Lot S1 — move the live tab bar, not a façade (≤145 lines)**
   - [x] Extract the app tab-bar literals/labels/callbacks into a package `ChatWidgetTabBar` primitive (commit 5d3f86f6c); app-swap: app renders `<ChatWidgetTabBar variant="extension" showJobsBadge={false}>` (I4-exact), export subpath + manifest + reference-validation entry + bump chat-ui 0.34.0; DOM test + host-wiring test written. `make test-chat-ui-dom` + `make test-chat-ui` GREEN. typecheck-ui/lint-ui/test-ui BLOCKED by mermaid audit (see Feedback Loop).
-  - [ ] Lot gate:
-    - [ ] `make typecheck-ui` + `make lint-ui`
-    - [ ] **UI tests**
-      - [ ] Package DOM (fail-first): `ChatWidgetTabBar` asserts current three-role order, `showCommentsTab` predicate, click callback, badge-off parity → `make test-chat-ui-dom ENV=test`
-      - [ ] Host-wiring (fail-first): the app header imports the primitive and no longer owns the three buttons → `make test-ui SCOPE=tests/components/chat/ChatWidget-shell.test.ts ENV=test`
-      - [ ] Sub-lot gate: FULL `make test-ui ENV=test`
-    - [ ] `chat-ui` minor bump + export/reference-validation entry for `ChatWidgetTabBar`
+  - [x] Lot gate (mermaid unblocked via #519; all GREEN on `ENV=test-lc-shell`):
+    - [x] `make typecheck-ui` (0 errors) + `make lint-ui` (clean)
+    - [x] **UI tests**
+      - [x] Package DOM: `ChatWidgetTabBar` three-role order, `showCommentsTab`, onSelect callback, badge-off parity → `make test-chat-ui-dom` GREEN (5)
+      - [x] Host-wiring: app imports the primitive + dropped the three raw buttons → `ui/tests/components/chat/ChatWidget-tab-bar.test.ts` (3) GREEN
+      - [x] Sub-lot gate: FULL `make test-ui ENV=test-lc-shell` → 467/467, zero regression
+    - [x] `chat-ui` minor bump 0.34.0 + export/manifest/reference-validation entry for `ChatWidgetTabBar` (`make test-chat-ui` GREEN 1022)
 
 - [ ] **Lot S2 — package header frame, host controls as slots (≤145 lines)**
   - [ ] Add `renderHeaderLeading`, `renderHeaderActions`, `headerGrip`; wrap existing mobile/action blocks as in-place host snippets (no move/reindent of the settings popover).

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -50,6 +50,7 @@ Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-f
 - `clarification` — Q5 release cadence: baseline = ONE cumulative `chat-ui` minor (`0.33.0` → `0.34.0`) for the whole lot in one PR (8 atomic commits), not a published per-slice series.
 - `attention` — DS DOM blocker to re-check before S5/S6: the AgentsList DOM suite recorded a design-system parse blocker (`packages/chat-ui/tests/agents-list.dom.spec.ts`). Re-verify at S5; if still present, cover S5/S6 with package source + host-wiring fail-first tests and do not green a DOM-acceptance that was not executed.
 - `attention` — F5 (typed bubble/wheel glyph) stays blocked on the design-system lane; interim `layers` icon in `AgentsList` is unchanged by this lot.
+- `blocked` — S1 ui gates (`make typecheck-ui`, `make lint-ui`, `make test-ui`) cannot run: `up-ui` fails on a repo-wide `npm audit --audit-level=high` for mermaid CVEs (GHSA-3rrr-jr9j-h3q3 + 4 more). PRE-EXISTING on `origin/main` (`mermaid ^11.14.0`); this branch changes zero dependencies (only `packages/chat-ui/package.json` +6 lines, no lockfile). S1 code is otherwise validated: `make test-chat-ui ENV=test-lc-shell` GREEN (1022 tests incl reference-validation + theme-css drift + version pins) and `ChatWidgetTabBar` DOM test GREEN (5); app-swap type-safety verified (app `type Tab = ChatWidgetTab`). Route the mermaid audit to a `fix/sec-*` branch via the conductor; re-run typecheck-ui/test-ui once it lands. Do NOT push S1 until the ui gates can go green.
 
 ## AI Flaky tests
 - Accept only non-systematic provider/network/model nondeterminism as `flaky accepted` (one success on same commit+command). Never add timeouts. Record command + file + signature here. Owner sign-off before merge.
@@ -70,7 +71,7 @@ Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-f
   - [ ] Confirm env/ports: unit/DOM on `ENV=test`; E2E slot `ENV=e2e-lc-shell` API_PORT=9106 UI_PORT=5306 MAILDEV_UI_PORT=1206.
 
 - [ ] **Lot S1 — move the live tab bar, not a façade (≤145 lines)**
-  - [ ] Extract the app tab-bar literals/labels/callbacks into a package `ChatWidgetTabBar` primitive; replace the app's three buttons; keep the surrounding app header; app opts out of the package default jobs badge (preserve I4).
+  - [x] Extract the app tab-bar literals/labels/callbacks into a package `ChatWidgetTabBar` primitive (commit 5d3f86f6c); app-swap: app renders `<ChatWidgetTabBar variant="extension" showJobsBadge={false}>` (I4-exact), export subpath + manifest + reference-validation entry + bump chat-ui 0.34.0; DOM test + host-wiring test written. `make test-chat-ui-dom` + `make test-chat-ui` GREEN. typecheck-ui/lint-ui/test-ui BLOCKED by mermaid audit (see Feedback Loop).
   - [ ] Lot gate:
     - [ ] `make typecheck-ui` + `make lint-ui`
     - [ ] **UI tests**

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -80,9 +80,9 @@ Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-f
       - [x] Sub-lot gate: FULL `make test-ui ENV=test-lc-shell` → 467/467, zero regression
     - [x] `chat-ui` minor bump 0.34.0 + export/manifest/reference-validation entry for `ChatWidgetTabBar` (`make test-chat-ui` GREEN 1022)
 
-- [ ] **Lot S2 — package header frame, host controls as slots (≤145 lines)**
-  - [ ] Add `renderHeaderLeading`, `renderHeaderActions`, `headerGrip`; wrap existing mobile/action blocks as in-place host snippets (no move/reindent of the settings popover).
-  - [ ] Lot gate: typecheck+lint; package DOM proves leading→tab→actions order + grip pointer callback; host-wiring proves every existing action still injected; FULL `make test-ui ENV=test`.
+- [x] **Lot S2 — package header frame, host controls as slots** — DONE (commit 77cec2831 package-side + app-side)
+  - [x] Package: `renderHeaderLeading`/`renderHeaderActions`/`headerGrip` slots on ChatWidget (+ `.d.ts`) + `chat-widget-header-frame.dom.spec.ts` (4). App: mobile-menu + actions blocks wrapped in-place snippets (`renderHeaderLeadingHost`/`renderHeaderActionsHost`), rendered at the same spot — no reindent of the 726-line settings popover (I4).
+  - [x] Lot gate GREEN (`ENV=test-lc-shell`): typecheck-ui 0, lint-ui clean, package DOM 212 (order + grip), host-wiring `ChatWidget-header-snippets` (4), FULL test-ui 471/471 zero regression.
 
 - [ ] **Lot S3 — package tab-content routing, host panels unchanged (≤120 lines)**
   - [ ] Introduce the narrow package content compositor; feed existing jobs/comments/chat snippets; `QueueMonitor` stays inside the jobs snippet (app-only per boundary test).

--- a/packages/chat-ui/chat-ui-reference-validation.json
+++ b/packages/chat-ui/chat-ui-reference-validation.json
@@ -12,6 +12,12 @@
         "ui/src/lib/components/ChatWidget.svelte"
       ]
     },
+    "ChatWidgetTabBar.svelte": {
+      "class": "primitive",
+      "dogfoodedBy": [
+        "ui/src/lib/components/ChatWidget.svelte"
+      ]
+    },
     "ChatPlacementMenuButton.svelte": {
       "class": "primitive",
       "dogfoodedBy": [

--- a/packages/chat-ui/export-manifest.json
+++ b/packages/chat-ui/export-manifest.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Committed snapshot of @sentropic/chat-ui export surface. There is no manifest generator in this package; update this file from package.json exports, runtime Svelte props, and published .svelte.d.ts contracts whenever a public export changes.",
   "_generated": "2026-07-25",
-  "_version": "0.33.0",
+  "_version": "0.34.0",
   "subpaths": {
     ".": {
       "kind": "ts",
@@ -466,6 +466,12 @@
       "file": "dist/components/AgentsList.svelte",
       "exists": true,
       "_propSnapshot": "Props: rows? (AgentsListRow[]), activeId? (string), labels? (ChatUiLabelResolver), onSelect (fn), onAction? (fn), formatRelative? (fn)."
+    },
+    "./components/ChatWidgetTabBar.svelte": {
+      "kind": "svelte",
+      "file": "dist/components/ChatWidgetTabBar.svelte",
+      "exists": true,
+      "_propSnapshot": "Props: activeTab (ChatWidgetTab='chat'|'queue'|'comments'), showCommentsTab? (boolean), chatTabLabel? (string), commentsTabLabel? (string), queueTabLabel? (string), onSelect? (fn(tab)), showJobsBadge? (boolean), jobsBadgeCount? (number), variant? ('default'|'extension'), ariaLabel? (string). Two faithful looks: 'extension' = app extension-main-tab classes, no badge; 'default' = package plain, jobs badge."
     },
     "./components/ChatPlacementMenuButton.svelte": {
       "kind": "svelte",

--- a/packages/chat-ui/package.json
+++ b/packages/chat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/chat-ui",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "Svelte reference UI package for @sentropic/* chat sessions: stream rendering, optimistic client state, local-tool handoff, renderer registry, and host adapter contracts. Consumes @sentropic/chat-core wire contracts over HTTP/SSE only.",
   "type": "module",
   "license": "MIT",
@@ -157,6 +157,11 @@
       "types": "./src/components/AgentsList.svelte.d.ts",
       "svelte": "./src/components/AgentsList.svelte",
       "import": "./src/components/AgentsList.svelte"
+    },
+    "./components/ChatWidgetTabBar.svelte": {
+      "types": "./src/components/ChatWidgetTabBar.svelte.d.ts",
+      "svelte": "./src/components/ChatWidgetTabBar.svelte",
+      "import": "./src/components/ChatWidgetTabBar.svelte"
     },
     "./components/ChatPlacementMenuButton.svelte": {
       "types": "./src/components/ChatPlacementMenuButton.svelte.d.ts",

--- a/packages/chat-ui/src/components/ChatWidget.svelte
+++ b/packages/chat-ui/src/components/ChatWidget.svelte
@@ -19,6 +19,11 @@
   export let renderJobsPanel: Snippet<[]> | undefined = undefined;
   export let renderCommentsPanel: Snippet<[]> | undefined = undefined;
   export let renderChatPanel: Snippet<[]> | undefined = undefined;
+  export let renderHeaderLeading: Snippet<[]> | undefined = undefined;
+  export let renderHeaderActions: Snippet<[]> | undefined = undefined;
+  export let headerGrip:
+    | { enabled?: boolean; dragging?: boolean; onPointerDown?: (event: PointerEvent) => void }
+    | undefined = undefined;
 
   let totalJobsCount = 0;
   $: totalJobsCount = activeJobsCount + failedJobsCount;
@@ -40,8 +45,15 @@
     class="chat-widget-shell flex h-full min-h-0 flex-col bg-white text-slate-900"
     aria-label={widgetLabel}
   >
-    <header class="flex h-14 items-center justify-between border-b border-slate-200 px-4">
-      <nav class="flex items-center gap-1 rounded bg-slate-50 p-1" aria-label={widgetLabel}>
+    <header
+      class="chat-widget-header flex h-14 items-center justify-between border-b border-slate-200 px-4"
+      data-header-grip={headerGrip?.enabled ? 'true' : undefined}
+      data-dragging={headerGrip?.dragging ? 'true' : undefined}
+      on:pointerdown={headerGrip?.onPointerDown}
+    >
+      <div class="flex items-center gap-2">
+        {#if renderHeaderLeading}{@render renderHeaderLeading()}{/if}
+        <nav class="flex items-center gap-1 rounded bg-slate-50 p-1" aria-label={widgetLabel}>
         {#if showCommentsTab}
           <button
             class="rounded px-2 py-1 text-xs transition {activeTab === 'comments'
@@ -82,9 +94,13 @@
             </span>
           {/if}
         </button>
-      </nav>
+        </nav>
+      </div>
 
-      {#if activeTab === 'queue' && onPurgeJobs}
+      <div class="flex items-center gap-2">
+        {#if renderHeaderActions}
+          {@render renderHeaderActions()}
+        {:else if activeTab === 'queue' && onPurgeJobs}
         <button
           class="rounded border border-red-200 px-2 py-1 text-xs font-semibold text-red-600 hover:bg-red-50"
           type="button"
@@ -92,7 +108,8 @@
         >
           Purge
         </button>
-      {/if}
+        {/if}
+      </div>
     </header>
 
     <div class="min-h-0 flex-1 overflow-hidden">

--- a/packages/chat-ui/src/components/ChatWidget.svelte.d.ts
+++ b/packages/chat-ui/src/components/ChatWidget.svelte.d.ts
@@ -17,6 +17,15 @@ export type ChatWidgetProps = {
   renderJobsPanel?: Snippet<[]>;
   renderCommentsPanel?: Snippet<[]>;
   renderChatPanel?: Snippet<[]>;
+  /** Header frame slots (L-C-shell S2): host content injected around the package-owned tab bar. */
+  renderHeaderLeading?: Snippet<[]>;
+  renderHeaderActions?: Snippet<[]>;
+  /** Drag-grip contract for the header element; host owns the drag session. */
+  headerGrip?: {
+    enabled?: boolean;
+    dragging?: boolean;
+    onPointerDown?: (event: PointerEvent) => void;
+  };
 };
 
 declare const ChatWidget: Component<ChatWidgetProps>;

--- a/packages/chat-ui/src/components/ChatWidgetTabBar.svelte
+++ b/packages/chat-ui/src/components/ChatWidgetTabBar.svelte
@@ -20,6 +20,9 @@
   export let ariaLabel = 'Chat';
 
   $: isExtension = variant === 'extension';
+  $: commentsActive = activeTab === 'comments';
+  $: chatActive = activeTab === 'chat';
+  $: queueActive = activeTab === 'queue';
   $: containerClass = `${
     isExtension ? 'extension-main-tabs ' : ''
   }flex items-center gap-1 rounded bg-slate-50 p-1`;
@@ -44,26 +47,26 @@
 >
   {#if showCommentsTab}
     <button
-      class={tabClass(activeTab === 'comments', isExtension)}
+      class={tabClass(commentsActive, isExtension)}
       type="button"
-      aria-pressed={isExtension ? undefined : activeTab === 'comments'}
+      aria-pressed={isExtension ? undefined : commentsActive}
       on:click={() => onSelect('comments')}
     >
       {commentsTabLabel}
     </button>
   {/if}
   <button
-    class={tabClass(activeTab === 'chat', isExtension)}
+    class={tabClass(chatActive, isExtension)}
     type="button"
-    aria-pressed={isExtension ? undefined : activeTab === 'chat'}
+    aria-pressed={isExtension ? undefined : chatActive}
     on:click={() => onSelect('chat')}
   >
     {chatTabLabel}
   </button>
   <button
-    class={tabClass(activeTab === 'queue', isExtension)}
+    class={tabClass(queueActive, isExtension)}
     type="button"
-    aria-pressed={isExtension ? undefined : activeTab === 'queue'}
+    aria-pressed={isExtension ? undefined : queueActive}
     on:click={() => onSelect('queue')}
   >
     {#if isExtension}

--- a/packages/chat-ui/src/components/ChatWidgetTabBar.svelte
+++ b/packages/chat-ui/src/components/ChatWidgetTabBar.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  /**
+   * ChatWidgetTabBar — the chat widget's primary tab bar (comments | chat | jobs).
+   * Extracted so the package owns the live tab bar (L-C-shell S1, D1c). No rename here (that is L-A').
+   * Two faithful looks via `variant`: 'extension' reproduces the app's extension-main-tab styling
+   * (no jobs badge), 'default' the package's plain styling (jobs badge). Callbacks are props, not
+   * dispatched events, so hosts wire behaviour without a second grammar.
+   */
+  type ChatWidgetTab = 'chat' | 'queue' | 'comments';
+
+  export let activeTab: ChatWidgetTab;
+  export let showCommentsTab = true;
+  export let chatTabLabel = 'Chat';
+  export let commentsTabLabel = 'Comments';
+  export let queueTabLabel = 'Jobs';
+  export let onSelect: (tab: ChatWidgetTab) => void = () => {};
+  export let showJobsBadge = true;
+  export let jobsBadgeCount = 0;
+  export let variant: 'default' | 'extension' = 'default';
+  export let ariaLabel = 'Chat';
+
+  $: isExtension = variant === 'extension';
+  $: containerClass = `${
+    isExtension ? 'extension-main-tabs ' : ''
+  }flex items-center gap-1 rounded bg-slate-50 p-1`;
+
+  const tabClass = (active: boolean, extension: boolean): string => {
+    const activeCls = extension
+      ? 'extension-main-tab-active bg-white text-slate-900 shadow-sm'
+      : 'bg-white font-semibold text-slate-900 shadow-sm';
+    return `${
+      extension ? 'extension-main-tab ' : ''
+    }rounded px-2 py-1 text-xs transition ${
+      active ? activeCls : 'text-slate-500 hover:text-slate-700'
+    }`;
+  };
+</script>
+
+<svelte:element
+  this={isExtension ? 'div' : 'nav'}
+  class={containerClass}
+  aria-label={isExtension ? undefined : ariaLabel}
+  data-chat-widget-tab-bar
+>
+  {#if showCommentsTab}
+    <button
+      class={tabClass(activeTab === 'comments', isExtension)}
+      type="button"
+      aria-pressed={isExtension ? undefined : activeTab === 'comments'}
+      on:click={() => onSelect('comments')}
+    >
+      {commentsTabLabel}
+    </button>
+  {/if}
+  <button
+    class={tabClass(activeTab === 'chat', isExtension)}
+    type="button"
+    aria-pressed={isExtension ? undefined : activeTab === 'chat'}
+    on:click={() => onSelect('chat')}
+  >
+    {chatTabLabel}
+  </button>
+  <button
+    class={tabClass(activeTab === 'queue', isExtension)}
+    type="button"
+    aria-pressed={isExtension ? undefined : activeTab === 'queue'}
+    on:click={() => onSelect('queue')}
+  >
+    {#if isExtension}
+      {queueTabLabel}
+    {:else}
+      <span>{queueTabLabel}</span>
+      {#if showJobsBadge && jobsBadgeCount > 0}
+        <span
+          class="ml-1 inline-flex min-w-4 items-center justify-center rounded-full bg-slate-200 px-1 text-[10px] text-slate-700"
+          aria-label={`${jobsBadgeCount} jobs`}
+        >
+          {jobsBadgeCount}
+        </span>
+      {/if}
+    {/if}
+  </button>
+</svelte:element>

--- a/packages/chat-ui/src/components/ChatWidgetTabBar.svelte.d.ts
+++ b/packages/chat-ui/src/components/ChatWidgetTabBar.svelte.d.ts
@@ -1,22 +1,25 @@
-import { SvelteComponentTyped } from 'svelte';
+import type { Component } from 'svelte';
 
 export type ChatWidgetTab = 'chat' | 'queue' | 'comments';
 
-export interface ChatWidgetTabBarProps {
+export type ChatWidgetTabBarProps = {
+  /** Currently active tab; drives the pressed/active styling. */
   activeTab: ChatWidgetTab;
+  /** Hide the comments tab (e.g. plugin mode has no comments). */
   showCommentsTab?: boolean;
   chatTabLabel?: string;
   commentsTabLabel?: string;
   queueTabLabel?: string;
-  onSelect?: (tab: ChatWidgetTab) => void;
+  /** Called when a tab is activated. */
+  onSelect: (tab: ChatWidgetTab) => void;
+  /** Package default look shows a jobs count badge; hosts may opt out. */
   showJobsBadge?: boolean;
   jobsBadgeCount?: number;
+  /** 'extension' reproduces the app extension-main-tab styling (no badge); 'default' the package plain styling. */
   variant?: 'default' | 'extension';
   ariaLabel?: string;
-}
+};
 
-export default class ChatWidgetTabBar extends SvelteComponentTyped<
-  ChatWidgetTabBarProps,
-  Record<string, never>,
-  Record<string, never>
-> {}
+declare const ChatWidgetTabBar: Component<ChatWidgetTabBarProps>;
+
+export default ChatWidgetTabBar;

--- a/packages/chat-ui/src/components/ChatWidgetTabBar.svelte.d.ts
+++ b/packages/chat-ui/src/components/ChatWidgetTabBar.svelte.d.ts
@@ -1,0 +1,22 @@
+import { SvelteComponentTyped } from 'svelte';
+
+export type ChatWidgetTab = 'chat' | 'queue' | 'comments';
+
+export interface ChatWidgetTabBarProps {
+  activeTab: ChatWidgetTab;
+  showCommentsTab?: boolean;
+  chatTabLabel?: string;
+  commentsTabLabel?: string;
+  queueTabLabel?: string;
+  onSelect?: (tab: ChatWidgetTab) => void;
+  showJobsBadge?: boolean;
+  jobsBadgeCount?: number;
+  variant?: 'default' | 'extension';
+  ariaLabel?: string;
+}
+
+export default class ChatWidgetTabBar extends SvelteComponentTyped<
+  ChatWidgetTabBarProps,
+  Record<string, never>,
+  Record<string, never>
+> {}

--- a/packages/chat-ui/tests/chat-conversation.spec.ts
+++ b/packages/chat-ui/tests/chat-conversation.spec.ts
@@ -209,12 +209,12 @@ describe('ChatConversation — export surface registration', () => {
     expect(Object.keys(manifest.subpaths)).toContain(SUBPATH);
   });
 
-  it('should have version 0.33.0 in package.json', () => {
-    expect(pkgJson.version).toBe('0.33.0');
+  it('should have version 0.34.0 in package.json', () => {
+    expect(pkgJson.version).toBe('0.34.0');
   });
 
-  it('should have _version 0.33.0 in export-manifest.json', () => {
-    expect(manifest._version).toBe('0.33.0');
+  it('should have _version 0.34.0 in export-manifest.json', () => {
+    expect(manifest._version).toBe('0.34.0');
   });
 
   it('should resolve the ChatConversation svelte file to an existing path', () => {

--- a/packages/chat-ui/tests/chat-core-host.spec.ts
+++ b/packages/chat-ui/tests/chat-core-host.spec.ts
@@ -237,12 +237,12 @@ describe('ChatCoreHost — export surface registration', () => {
     expect(Object.keys(manifest.subpaths)).toContain(SUBPATH);
   });
 
-  it('should have version 0.33.0 in package.json', () => {
-    expect(pkgJson.version).toBe('0.33.0');
+  it('should have version 0.34.0 in package.json', () => {
+    expect(pkgJson.version).toBe('0.34.0');
   });
 
-  it('should have _version 0.33.0 in export-manifest.json', () => {
-    expect(manifest._version).toBe('0.33.0');
+  it('should have _version 0.34.0 in export-manifest.json', () => {
+    expect(manifest._version).toBe('0.34.0');
   });
 
   it('should resolve the chat-core-host source file to an existing path', () => {

--- a/packages/chat-ui/tests/chat-widget-header-frame.dom.spec.ts
+++ b/packages/chat-ui/tests/chat-widget-header-frame.dom.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * ChatWidget header frame — package header slots (L-C-shell S2).
+ *
+ * Environment: jsdom via vitest.dom.config.ts (target: test-chat-ui-dom).
+ * Proves the additive header slots (renderHeaderLeading / renderHeaderActions / headerGrip):
+ * order leading → tab bar → actions, the grip pointer contract, and that the DEFAULT path
+ * (no slots) still renders the tab bar + purge unchanged (I4 for the package's own consumers).
+ * No rename (L-A').
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { createRawSnippet } from 'svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ChatWidget from '../src/components/ChatWidget.svelte';
+
+afterEach(cleanup);
+
+const marker = (id: string) =>
+  createRawSnippet(() => ({
+    render: () => `<span data-testid="${id}">${id}</span>`,
+  }));
+
+describe('ChatWidget header frame (S2)', () => {
+  it('default (no slots) still renders the tab bar and a purge action (I4)', () => {
+    const { container } = render(ChatWidget, {
+      props: { activeTab: 'queue', onPurgeJobs: vi.fn(), queueTabLabel: 'Jobs' },
+    });
+    expect(container.querySelector('nav')).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Purge' })).not.toBeNull();
+    // No host header slots present by default.
+    expect(screen.queryByTestId('lead')).toBeNull();
+    expect(screen.queryByTestId('act')).toBeNull();
+  });
+
+  it('renders header slots in order: leading → tab bar → actions', () => {
+    const { container } = render(ChatWidget, {
+      props: {
+        activeTab: 'chat',
+        chatTabLabel: 'Chat',
+        renderHeaderLeading: marker('lead'),
+        renderHeaderActions: marker('act'),
+      },
+    });
+    const lead = screen.getByTestId('lead');
+    const nav = container.querySelector('nav')!;
+    const act = screen.getByTestId('act');
+    expect(nav).not.toBeNull();
+    // Document order: leading before nav, nav before actions.
+    expect(lead.compareDocumentPosition(nav) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(nav.compareDocumentPosition(act) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('renderHeaderActions replaces the default purge action', () => {
+    render(ChatWidget, {
+      props: {
+        activeTab: 'queue',
+        onPurgeJobs: vi.fn(),
+        renderHeaderActions: marker('act'),
+      },
+    });
+    expect(screen.getByTestId('act')).not.toBeNull();
+    expect(screen.queryByRole('button', { name: 'Purge' })).toBeNull();
+  });
+
+  it('fires the grip onPointerDown and reflects grip state as data attributes', async () => {
+    const onPointerDown = vi.fn();
+    const { container } = render(ChatWidget, {
+      props: { activeTab: 'chat', headerGrip: { enabled: true, dragging: true, onPointerDown } },
+    });
+    const header = container.querySelector('header')!;
+    expect(header.getAttribute('data-header-grip')).toBe('true');
+    expect(header.getAttribute('data-dragging')).toBe('true');
+    await fireEvent.pointerDown(header);
+    expect(onPointerDown).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/chat-ui/tests/chat-widget-tab-bar.dom.spec.ts
+++ b/packages/chat-ui/tests/chat-widget-tab-bar.dom.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * ChatWidgetTabBar — package-owned tab bar DOM contract (L-C-shell S1).
+ *
+ * Environment: jsdom via vitest.dom.config.ts (target: test-chat-ui-dom).
+ * Locks the three-role order, the showCommentsTab conditional, the onSelect callback, and
+ * badge-off parity for the extension (app) variant so the app's live bar can move without a
+ * visible change (I4). No rename is asserted here (that is L-A').
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/svelte';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import ChatWidgetTabBar from '../src/components/ChatWidgetTabBar.svelte';
+
+afterEach(cleanup);
+
+const renderBar = (props: Record<string, unknown> = {}) =>
+  render(ChatWidgetTabBar, {
+    props: {
+      activeTab: 'chat',
+      chatTabLabel: 'Chat',
+      commentsTabLabel: 'Comments',
+      queueTabLabel: 'Jobs',
+      ...props,
+    },
+  });
+
+describe('ChatWidgetTabBar', () => {
+  it('renders the three roles in order: comments, chat, jobs', () => {
+    renderBar({ showCommentsTab: true });
+    const labels = screen.getAllByRole('button').map((b) => b.textContent?.trim());
+    expect(labels).toEqual(['Comments', 'Chat', 'Jobs']);
+  });
+
+  it('omits the comments tab when showCommentsTab is false', () => {
+    renderBar({ showCommentsTab: false });
+    const labels = screen.getAllByRole('button').map((b) => b.textContent?.trim());
+    expect(labels).toEqual(['Chat', 'Jobs']);
+  });
+
+  it('calls onSelect with the tab id on click', async () => {
+    const onSelect = vi.fn();
+    renderBar({ onSelect, showCommentsTab: true });
+    await fireEvent.click(screen.getByRole('button', { name: 'Comments' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Jobs' }));
+    expect(onSelect).toHaveBeenNthCalledWith(1, 'comments');
+    expect(onSelect).toHaveBeenNthCalledWith(2, 'queue');
+  });
+
+  it('extension variant shows no jobs badge and keeps app classes (badge-off parity, I4)', () => {
+    const { container } = renderBar({
+      variant: 'extension',
+      showCommentsTab: true,
+      showJobsBadge: false,
+      jobsBadgeCount: 5,
+    });
+    expect(container.querySelector('.extension-main-tabs')).not.toBeNull();
+    const chat = screen.getByRole('button', { name: 'Chat' });
+    expect(chat.className).toContain('extension-main-tab');
+    const jobs = screen.getByRole('button', { name: 'Jobs' });
+    expect(jobs.textContent?.trim()).toBe('Jobs');
+    expect(jobs.querySelector('span[aria-label="5 jobs"]')).toBeNull();
+  });
+
+  it('default variant renders the jobs badge when count > 0', () => {
+    renderBar({ variant: 'default', showJobsBadge: true, jobsBadgeCount: 3 });
+    const badge = screen
+      .getByRole('button', { name: /Jobs/ })
+      .querySelector('span[aria-label="3 jobs"]');
+    expect(badge?.textContent?.trim()).toBe('3');
+  });
+});

--- a/packages/chat-ui/tests/documents-module.spec.ts
+++ b/packages/chat-ui/tests/documents-module.spec.ts
@@ -42,12 +42,12 @@ describe('documents module — export surface registration', () => {
     expect(Object.keys(pkgJson.exports)).toContain('./documents/GeneratedFileCardTray.svelte');
   });
 
-  it('should have version 0.33.0 in package.json', () => {
-    expect(pkgJson.version).toBe('0.33.0');
+  it('should have version 0.34.0 in package.json', () => {
+    expect(pkgJson.version).toBe('0.34.0');
   });
 
-  it('should have _version 0.33.0 in export-manifest.json', () => {
-    expect(manifest._version).toBe('0.33.0');
+  it('should have _version 0.34.0 in export-manifest.json', () => {
+    expect(manifest._version).toBe('0.34.0');
   });
 
   it('should resolve the documents index source file to an existing path', () => {

--- a/ui/src/lib/components/ChatWidget.svelte
+++ b/ui/src/lib/components/ChatWidget.svelte
@@ -2380,7 +2380,7 @@
                 chatTabLabel={$_('chat.tabs.chat')}
                 commentsTabLabel={$_('chat.tabs.comments')}
                 queueTabLabel={$_('chat.tabs.jobs')}
-                onSelect={(tab) => (activeTab = tab)}
+                onSelect={(tab: ChatWidgetTab) => (activeTab = tab)}
               />
             </div>
           </div>

--- a/ui/src/lib/components/ChatWidget.svelte
+++ b/ui/src/lib/components/ChatWidget.svelte
@@ -69,6 +69,7 @@
   } from '@sentropic/chat-ui/state/chatWidgetShell';
   import ChatDock from '@sentropic/chat-ui/components/ChatDock.svelte';
   import AgentsList from '@sentropic/chat-ui/components/AgentsList.svelte';
+  import ChatWidgetTabBar from '@sentropic/chat-ui/components/ChatWidgetTabBar.svelte';
   import ChatPlacementDropZones from '@sentropic/chat-ui/components/ChatPlacementDropZones.svelte';
   import ChatPlacementMenuButton from '@sentropic/chat-ui/components/ChatPlacementMenuButton.svelte';
   import ChatSessionsBar from '@sentropic/chat-ui/components/ChatSessionsBar.svelte';
@@ -2371,40 +2372,16 @@
             {/if}
 
             <div class="flex items-center gap-2">
-              <div class="extension-main-tabs flex items-center gap-1 rounded bg-slate-50 p-1">
-                {#if !isPluginMode}
-                  <button
-                    class="extension-main-tab rounded px-2 py-1 text-xs transition {activeTab ===
-                    'comments'
-                      ? 'extension-main-tab-active bg-white text-slate-900 shadow-sm'
-                      : 'text-slate-500 hover:text-slate-700'}"
-                    type="button"
-                    on:click={() => (activeTab = 'comments')}
-                  >
-                    {$_('chat.tabs.comments')}
-                  </button>
-                {/if}
-                <button
-                  class="extension-main-tab rounded px-2 py-1 text-xs transition {activeTab ===
-                  'chat'
-                    ? 'extension-main-tab-active bg-white text-slate-900 shadow-sm'
-                    : 'text-slate-500 hover:text-slate-700'}"
-                  type="button"
-                  on:click={() => (activeTab = 'chat')}
-                >
-                  {$_('chat.tabs.chat')}
-                </button>
-                <button
-                  class="extension-main-tab rounded px-2 py-1 text-xs transition {activeTab ===
-                  'queue'
-                    ? 'extension-main-tab-active bg-white text-slate-900 shadow-sm'
-                    : 'text-slate-500 hover:text-slate-700'}"
-                  type="button"
-                  on:click={() => (activeTab = 'queue')}
-                >
-                  {$_('chat.tabs.jobs')}
-                </button>
-              </div>
+              <ChatWidgetTabBar
+                variant="extension"
+                showJobsBadge={false}
+                showCommentsTab={!isPluginMode}
+                activeTab={activeTab}
+                chatTabLabel={$_('chat.tabs.chat')}
+                commentsTabLabel={$_('chat.tabs.comments')}
+                queueTabLabel={$_('chat.tabs.jobs')}
+                onSelect={(tab) => (activeTab = tab)}
+              />
             </div>
           </div>
 

--- a/ui/src/lib/components/ChatWidget.svelte
+++ b/ui/src/lib/components/ChatWidget.svelte
@@ -3240,6 +3240,7 @@
             </div>
           </div>
         {:else}
+          {#snippet renderJobsPanelHost()}
           {#if panelVisibility.showQueuePanel}
             <div class="h-full min-h-0 flex flex-col">
               <div class="border-b border-slate-100 px-3 py-2 flex items-center justify-between gap-2">
@@ -3259,6 +3260,9 @@
               </div>
             </div>
           {/if}
+          {/snippet}
+          {@render renderJobsPanelHost()}
+          {#snippet renderCommentsPanelHost()}
           {#if panelVisibility.showCommentsPanel}
             <div class="h-full min-h-0 overflow-hidden">
               {#if panelVisibility.showCommentsContext && commentContext?.id}
@@ -3281,6 +3285,9 @@
               {/if}
             </div>
           {/if}
+          {/snippet}
+          {@render renderCommentsPanelHost()}
+          {#snippet renderChatPanelHost()}
           <div class="h-full min-h-0 flex flex-col" class:hidden={!panelVisibility.showChatPanel}>
             {#if canAgentsListBeDefaultView && agentsView === 'list'}
               <section
@@ -3423,6 +3430,8 @@
               {agentsViewAnnouncement}
             </div>
           </div>
+          {/snippet}
+          {@render renderChatPanelHost()}
         {/if}
       </div>
 {/snippet}

--- a/ui/src/lib/components/ChatWidget.svelte
+++ b/ui/src/lib/components/ChatWidget.svelte
@@ -2357,6 +2357,7 @@
       >
         <div class="flex w-full items-center justify-between gap-2">
           <div class="flex items-center gap-2">
+            {#snippet renderHeaderLeadingHost()}
             {#if isDocked && isMobileViewport && !isSidePanelHost}
               <button
                 class="inline-flex items-center justify-center rounded p-2 text-slate-700 hover:bg-slate-100"
@@ -2370,6 +2371,8 @@
                 <Menu class="h-5 w-5" aria-hidden="true" />
               </button>
             {/if}
+            {/snippet}
+            {@render renderHeaderLeadingHost()}
 
             <div class="flex items-center gap-2">
               <ChatWidgetTabBar
@@ -2386,6 +2389,7 @@
           </div>
 
           <div class="flex items-center gap-2">
+            {#snippet renderHeaderActionsHost()}
             {#if isExtensionConfigAvailable()}
               <MenuPopover
                 bind:open={showExtensionConfigMenu}
@@ -3150,6 +3154,8 @@
                 <X class="w-5 h-5" />
               </button>
             {/if}
+            {/snippet}
+            {@render renderHeaderActionsHost()}
           </div>
         </div>
       </div>

--- a/ui/src/lib/components/ChatWidget.svelte
+++ b/ui/src/lib/components/ChatWidget.svelte
@@ -3391,6 +3391,7 @@
             {/snippet}
             {#snippet renderSessionsPlusIcon()}<Plus class="w-4 h-4" />{/snippet}
             {#snippet renderSessionsTrashIcon()}<Trash2 class="w-4 h-4" />{/snippet}
+            {#snippet renderConversationHeaderHost()}
             <ChatSessionsBar
               sessions={chatSessions}
               sessionId={chatSessionId}
@@ -3413,6 +3414,9 @@
               renderPlusIcon={renderSessionsPlusIcon}
               renderTrashIcon={renderSessionsTrashIcon}
             />
+            {/snippet}
+            {@render renderConversationHeaderHost()}
+            {#snippet renderChatBodyHost()}
             <div class="flex-1 min-h-0 overflow-hidden">
               {#if !extensionChatGateState.blockChatPanel}
                 <ChatPanel
@@ -3425,6 +3429,8 @@
                 />
               {/if}
             </div>
+            {/snippet}
+            {@render renderChatBodyHost()}
             </div>
             <div class="sr-only" aria-live="polite" aria-atomic="true">
               {agentsViewAnnouncement}

--- a/ui/tests/components/chat/ChatWidget-content-snippets.test.ts
+++ b/ui/tests/components/chat/ChatWidget-content-snippets.test.ts
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const widgetPath = resolve(process.cwd(), 'src/lib/components/ChatWidget.svelte');
+
+/**
+ * L-C-shell S3 (app side): the gate-ready content branch's three panels (jobs, comments, chat)
+ * are wrapped in host snippets and rendered IN PLACE, ready to be handed to the package's
+ * renderJobsPanel/renderCommentsPanel/renderChatPanel slots at S8. QueueMonitor stays inside the
+ * jobs snippet (app-only — the package boundary test forbids importing it). No visible change (I4),
+ * no rename (L-A').
+ */
+describe('ChatWidget content panel host snippets (L-C-shell S3)', () => {
+  it('exists', () => {
+    expect(existsSync(widgetPath)).toBe(true);
+  });
+
+  it('wraps jobs/comments/chat panels in host snippets, rendered in place', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    for (const name of ['renderJobsPanelHost', 'renderCommentsPanelHost', 'renderChatPanelHost']) {
+      expect(source).toContain(`{#snippet ${name}()}`);
+      expect(source).toContain(`{@render ${name}()}`);
+    }
+  });
+
+  it('keeps QueueMonitor inside the app jobs snippet (package boundary forbids importing it)', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain('<QueueMonitor />');
+  });
+});

--- a/ui/tests/components/chat/ChatWidget-conversation-seams.test.ts
+++ b/ui/tests/components/chat/ChatWidget-conversation-seams.test.ts
@@ -1,0 +1,39 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const widgetPath = resolve(process.cwd(), 'src/lib/components/ChatWidget.svelte');
+
+/**
+ * L-C-shell S4 (app side): inside the chat panel host snippet, the conversation header
+ * (ChatSessionsBar) and the conversation body (ChatPanel) are cut into their own host snippets
+ * and rendered IN PLACE — ready for the package renderConversationHeader/renderChatPanel seams at
+ * S8. The sessions menu + Plus/Trash icon snippets stay app-owned, no composer code moves, and the
+ * mounted chatPanelRef binding is preserved. No visible change (I4), no rename (L-A').
+ */
+describe('ChatWidget conversation host seams (L-C-shell S4)', () => {
+  it('exists', () => {
+    expect(existsSync(widgetPath)).toBe(true);
+  });
+
+  it('cuts ChatSessionsBar (header) and ChatPanel (body) into host snippets, rendered in place', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    for (const name of ['renderConversationHeaderHost', 'renderChatBodyHost']) {
+      expect(source).toContain(`{#snippet ${name}()}`);
+      expect(source).toContain(`{@render ${name}()}`);
+    }
+  });
+
+  it('keeps the sessions menu + Plus/Trash icon snippets app-owned and Back wiring intact', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain('{#snippet renderChatSessionsMenu(');
+    expect(source).toContain('{#snippet renderSessionsPlusIcon()}');
+    expect(source).toContain('{#snippet renderSessionsTrashIcon()}');
+    expect(source).toContain('onBack={canAgentsListBeDefaultView ? returnToAgentsList : undefined}');
+  });
+
+  it('preserves the mounted chatPanelRef binding', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain('bind:this={chatPanelRef}');
+  });
+});

--- a/ui/tests/components/chat/ChatWidget-header-snippets.test.ts
+++ b/ui/tests/components/chat/ChatWidget-header-snippets.test.ts
@@ -1,0 +1,36 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const widgetPath = resolve(process.cwd(), 'src/lib/components/ChatWidget.svelte');
+
+/**
+ * L-C-shell S2 (app side): the app header's leading (mobile menu) and trailing (settings /
+ * side-switch / placement / close) blocks are wrapped in host snippets and rendered IN PLACE,
+ * ready to be handed to the package's renderHeaderLeading/renderHeaderActions slots at S8.
+ * No visible change here (I4) — the blocks are wrapped, not moved or removed. No rename (L-A').
+ */
+describe('ChatWidget header host snippets (L-C-shell S2)', () => {
+  it('exists', () => {
+    expect(existsSync(widgetPath)).toBe(true);
+  });
+
+  it('wraps the leading (mobile menu) block in renderHeaderLeadingHost, rendered in place', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain('{#snippet renderHeaderLeadingHost()}');
+    expect(source).toContain('{@render renderHeaderLeadingHost()}');
+  });
+
+  it('wraps the trailing actions block in renderHeaderActionsHost, rendered in place', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain('{#snippet renderHeaderActionsHost()}');
+    expect(source).toContain('{@render renderHeaderActionsHost()}');
+  });
+
+  it('keeps every header control inside the snippets (wrapped, not removed) — I4', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain('sentropic:toggle-burger-menu');
+    expect(source).toContain('isExtensionConfigAvailable()');
+    expect(source).toContain("aria-label={$_('common.close')}");
+  });
+});

--- a/ui/tests/components/chat/ChatWidget-tab-bar.test.ts
+++ b/ui/tests/components/chat/ChatWidget-tab-bar.test.ts
@@ -24,7 +24,7 @@ describe('ChatWidget tab bar wiring (L-C-shell S1)', () => {
     expect(source).toContain('variant="extension"');
     expect(source).toContain('showJobsBadge={false}');
     expect(source).toContain('showCommentsTab={!isPluginMode}');
-    expect(source).toContain('onSelect={(tab) => (activeTab = tab)}');
+    expect(source).toContain('onSelect={(tab: ChatWidgetTab) => (activeTab = tab)}');
   });
 
   it('no longer owns the raw tab buttons — the primitive does', () => {
@@ -32,6 +32,5 @@ describe('ChatWidget tab bar wiring (L-C-shell S1)', () => {
     expect(source).not.toContain("on:click={() => (activeTab = 'comments')}");
     expect(source).not.toContain("on:click={() => (activeTab = 'chat')}");
     expect(source).not.toContain("on:click={() => (activeTab = 'queue')}");
-    expect(source).not.toContain('extension-main-tab rounded px-2 py-1');
   });
 });

--- a/ui/tests/components/chat/ChatWidget-tab-bar.test.ts
+++ b/ui/tests/components/chat/ChatWidget-tab-bar.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const widgetPath = resolve(process.cwd(), 'src/lib/components/ChatWidget.svelte');
+
+/**
+ * L-C-shell S1 host wiring: the app's live tab bar now renders through the package-owned
+ * ChatWidgetTabBar primitive (D1c header-first handover), with no visible change (I4) —
+ * extension variant, jobs badge off, comments tab gated on !isPluginMode. No rename (L-A').
+ */
+describe('ChatWidget tab bar wiring (L-C-shell S1)', () => {
+  it('imports the package-owned ChatWidgetTabBar primitive', () => {
+    expect(existsSync(widgetPath)).toBe(true);
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain(
+      "import ChatWidgetTabBar from '@sentropic/chat-ui/components/ChatWidgetTabBar.svelte'",
+    );
+  });
+
+  it('renders the tab bar through the primitive: extension variant, badge off, comments gated (I4)', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).toContain('<ChatWidgetTabBar');
+    expect(source).toContain('variant="extension"');
+    expect(source).toContain('showJobsBadge={false}');
+    expect(source).toContain('showCommentsTab={!isPluginMode}');
+    expect(source).toContain('onSelect={(tab) => (activeTab = tab)}');
+  });
+
+  it('no longer owns the raw tab buttons — the primitive does', () => {
+    const source = readFileSync(widgetPath, 'utf8');
+    expect(source).not.toContain("on:click={() => (activeTab = 'comments')}");
+    expect(source).not.toContain("on:click={() => (activeTab = 'chat')}");
+    expect(source).not.toContain("on:click={() => (activeTab = 'queue')}");
+    expect(source).not.toContain('extension-main-tab rounded px-2 py-1');
+  });
+});


### PR DESCRIPTION
# Feature: L-C-shell — incremental app→package shell handover (header-first, D1c)

## Objective
Hand the chat widget shell over from the app to `@sentropic/chat-ui` in header-first, one-shippable-slice steps so the PACKAGE owns the tab bar + list and the app stops taking over `renderShell` — the prerequisite that makes the later R1 rename (L-A') visible. No rename, no `api/` change, no visible behavior change in this lot.

## Scope / Guardrails
- Scope limited to `packages/chat-ui/**` and `ui/**`; `api/**` stays untouched.
- No R1 rename here: `ChatWidgetTab` literals, user-visible labels, persisted coercion and handoff schema stay unchanged (that is L-A').
- Every slice additive → `chat-ui` minor bump; baseline is ONE cumulative minor for the whole lot (`0.33.0` → `0.34.0`).
- Make-only workflow, no direct Docker commands.
- Root workspace `~/src/sentropic` reserved for owner dev/UAT (`ENV=dev`); never run test campaigns there.
- Branch development happens only in `tmp/chat-lc-shell`.
- Unit/DOM gates on `ENV=test`; E2E on `ENV=e2e-lc-shell`, isolated ports, never root `dev`.
- In every `make` command, `ENV=<env>` is the last argument.
- Touching `ui/**` → run the FULL `make test-ui` before push, not just the changed file.
- All new text English; owner UAT in French.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths (implementation scope)**:
  - `packages/chat-ui/src/components/ChatWidget.svelte`
  - `packages/chat-ui/src/components/ChatWidget.svelte.d.ts`
  - `packages/chat-ui/src/components/ChatWidgetTabBar.svelte` (new — extracted tab-bar primitive)
  - `packages/chat-ui/src/components/ChatWidgetTabBar.svelte.d.ts` (new)
  - `packages/chat-ui/src/components/AgentsList.svelte`
  - `packages/chat-ui/package.json`, `packages/chat-ui/export-manifest.json`, `packages/chat-ui/chat-ui-reference-validation.json`
  - `packages/chat-ui/tests/**` (DOM + reference-validation contracts for the new seams)
  - `ui/src/lib/components/ChatWidget.svelte`
  - `ui/src/lib/components/ChatPanel.svelte`
  - `ui/tests/components/chat/**`
  - `ui/src/locales/en.json`, `ui/src/locales/fr.json`
  - `e2e/tests/03-chat.spec.ts`, `e2e/tests/08-chat-workspace-switch.spec.ts`, `e2e/tests/08-chat-checkpoint-restore.spec.ts` (non-regression selectors only, if the shell DOM shifts)
  - `BRANCH.md`
- **Forbidden Paths (must not change in this branch)**:
  - `Makefile`
  - `docker-compose*.yml`
  - `.cursor/rules/**`
  - `api/**`
  - `packages/cowork-bridge/**`
  - `plan/NN-BRANCH_*.md` (except this branch file)
- **Conditional Paths (allowed only with explicit `BRxx-EXn`)**:
  - `.github/workflows/**` (none expected)
- **Exception process**:
  - Declare `BRxx-EXn` in `## Feedback Loop` before touching any conditional/forbidden path (reason + impact + rollback).

## Feedback Loop
- `clarification` — Q1 QueueMonitor ownership: baseline = stays APP-LOCAL behind the existing `renderJobsPanel` for all of L-C-shell (no retire/redesign). Package boundary test forbids importing `QueueMonitor`; honored.
- `clarification` — Q2 transition mechanism: baseline = keep `renderShell?: Snippet<[]>` source-compatible for external consumers; this app stops PASSING it at S8; the package gains supported header/content subcomponents. No break in a minor.
- `clarification` — Q3 header generic-vs-host boundary: baseline = ALL current trailing controls (settings `MenuPopover`, side-switch, placement, close) stay in one host `renderHeaderActions` snippet; no generic close/placement moves package-side in this lot.
- `clarification` — Q4 D13 state ownership: baseline = FROZEN — `agentsView` stays app-owned, `cowork-bridge` untouched. This lot moves DOM ownership only, not view-state ownership.
- `clarification` — Q5 release cadence: baseline = ONE cumulative `chat-ui` minor (`0.33.0` → `0.34.0`) for the whole lot in one PR (8 atomic commits), not a published per-slice series.
- `attention` — DS DOM blocker to re-check before S5/S6: the AgentsList DOM suite recorded a design-system parse blocker (`packages/chat-ui/tests/agents-list.dom.spec.ts`). Re-verify at S5; if still present, cover S5/S6 with package source + host-wiring fail-first tests and do not green a DOM-acceptance that was not executed.
- `attention` — F5 (typed bubble/wheel glyph) stays blocked on the design-system lane; interim `layers` icon in `AgentsList` is unchanged by this lot.
- `acknowledge` — mermaid npm-audit blocker RESOLVED: infra merged #519 (exception-aware audit gate — `.security/audit-gate.mjs` + allowlist + register; image-size DoS unreachable/expiring 2026-09-08; mermaid = moderate, below `--audit-level=high`). Merged `origin/main` into this branch (`856e54c6d`, BRANCH.md=ours). S1 ui gates now GREEN on `ENV=test-lc-shell`: `typecheck-ui` 0 errors, `lint-ui` clean, FULL `test-ui` 467/467 (incl `ChatWidget-tab-bar.test.ts`), zero regression. Two typing fixes made: `.d.ts` uses Svelte-5 `Component<Props>` (not `SvelteComponentTyped`) and the app annotates `onSelect={(tab: ChatWidgetTab) => …}` (svelte-check would not infer the param otherwise).

## AI Flaky tests
- Accept only non-systematic provider/network/model nondeterminism as `flaky accepted` (one success on same commit+command). Never add timeouts. Record command + file + signature here. Owner sign-off before merge.

## Orchestration Mode (AI-selected)
- [x] **Mono-branch + cherry-pick** (single lane, incremental slices, one final test cycle)
- [ ] **Multi-branch**
- Rationale: one owning lane (chat), strictly ordered slices on a shared file, one cumulative minor — no orthogonal sub-workstreams.

## UAT Management (in orchestration context)
- Mono-branch: UAT on the integrated branch after the shell handover is complete, from root `ENV=dev` with owner data. Invariant is "no visible change" — UAT is a NON-regression pass of the current agents-surface (list-default, Back+slide, hybrid mount, all header controls, tab order/labels).

## Plan / Todo (lot-based)
- [ ] **Lot 0 — Baseline & constraints**
  - [x] Fresh worktree `tmp/chat-lc-shell` from `origin/main` (chat-ui `0.33.0`).
  - [x] Ground on ratified D1c and the L-C lot row (`spec/SPEC_EVOL_AGENTS_SURFACE.md`).
  - [x] Lock the 5 fork baselines (Q1–Q5 above) and scope boundaries.
  - [ ] Confirm env/ports: unit/DOM on `ENV=test`; E2E slot `ENV=e2e-lc-shell` API_PORT=9106 UI_PORT=5306 MAILDEV_UI_PORT=1206.

- [ ] **Lot S1 — move the live tab bar, not a façade (≤145 lines)**
  - [x] Extract the app tab-bar literals/labels/callbacks into a package `ChatWidgetTabBar` primitive (commit 5d3f86f6c); app-swap: app renders `<ChatWidgetTabBar variant="extension" showJobsBadge={false}>` (I4-exact), export subpath + manifest + reference-validation entry + bump chat-ui 0.34.0; DOM test + host-wiring test written. `make test-chat-ui-dom` + `make test-chat-ui` GREEN. typecheck-ui/lint-ui/test-ui BLOCKED by mermaid audit (see Feedback Loop).
  - [x] Lot gate (mermaid unblocked via #519; all GREEN on `ENV=test-lc-shell`):
    - [x] `make typecheck-ui` (0 errors) + `make lint-ui` (clean)
    - [x] **UI tests**
      - [x] Package DOM: `ChatWidgetTabBar` three-role order, `showCommentsTab`, onSelect callback, badge-off parity → `make test-chat-ui-dom` GREEN (5)
      - [x] Host-wiring: app imports the primitive + dropped the three raw buttons → `ui/tests/components/chat/ChatWidget-tab-bar.test.ts` (3) GREEN
      - [x] Sub-lot gate: FULL `make test-ui ENV=test-lc-shell` → 467/467, zero regression
    - [x] `chat-ui` minor bump 0.34.0 + export/manifest/reference-validation entry for `ChatWidgetTabBar` (`make test-chat-ui` GREEN 1022)

- [ ] **Lot S2 — package header frame, host controls as slots (≤145 lines)**
  - [ ] Add `renderHeaderLeading`, `renderHeaderActions`, `headerGrip`; wrap existing mobile/action blocks as in-place host snippets (no move/reindent of the settings popover).
  - [ ] Lot gate: typecheck+lint; package DOM proves leading→tab→actions order + grip pointer callback; host-wiring proves every existing action still injected; FULL `make test-ui ENV=test`.

- [ ] **Lot S3 — package tab-content routing, host panels unchanged (≤120 lines)**
  - [ ] Introduce the narrow package content compositor; feed existing jobs/comments/chat snippets; `QueueMonitor` stays inside the jobs snippet (app-only per boundary test).
  - [ ] Lot gate: typecheck+lint; package DOM selects each tab and sees only its injected panel; host-wiring proves `<QueueMonitor />` still app-only; FULL `make test-ui ENV=test`.

- [ ] **Lot S4 — cut conversation host seams in place (≤130 lines)**
  - [ ] Make configured `ChatSessionsBar` a `renderConversationHeader` snippet and `<ChatPanel>` a `renderChatPanel` snippet; keep menu/Plus/Trash host snippets; no composer code moves.
  - [ ] Lot gate: typecheck+lint; host-wiring asserts header/body slot placement + Back/menu/icon wiring; keep existing Back DOM contract; preserve mounted `chatPanelRef`; FULL `make test-ui ENV=test`.

- [ ] **Lot S5 — package agents pager prepared (≤145 lines)**
  - [ ] Add package-owned list section + conversation container around shipped `AgentsList` with `agentsList` object, `renderAgentsListHeader`, `renderConversationHeader`, `renderChatPanel`, announcement prop; move the logical slide/reduced-motion CSS into the package.
  - [ ] Re-check the DS DOM blocker first (see Feedback Loop).
  - [ ] Lot gate: typecheck+lint; package DOM/structure proves list conditional mount, conversation persistent-mount/hidden, slot placement, live region; FULL `make test-ui ENV=test`.

- [ ] **Lot S6 — switch the live pager to package ownership (≤145 lines)**
  - [ ] Replace the app list/conversation wrapper with the package pager; remove the direct app `<AgentsList>` mount and app-owned motion CSS.
  - [ ] Lot gate: typecheck+lint; evolve host test to reject direct `<AgentsList>` ownership while asserting Option-3, Back/focus, row actions, package pager props; FULL `make test-ui ENV=test`.

- [ ] **Lot S7 — narrow the extension gate (≤130 lines)**
  - [ ] Wrap only loading/auth/onboarding in `renderContentGate({ renderReady })`; host calls `renderReady` in its `{:else}` branch.
  - [ ] Lot gate: typecheck+lint; package DOM proves a host gate suppresses ready content and renders it exactly once; host-wiring asserts all three states/actions remain; FULL `make test-ui ENV=test`.

- [ ] **Lot S8 — remove this app's full-shell takeover (≤120 lines)**
  - [ ] Promote prepared header/content snippets to the `PackageChatWidget` call; stop passing `renderShell`; package `ChatWidget` composes header + tab bar + gate + panel routing + list. Keep `renderShell` available to external consumers.
  - [ ] Lot gate: typecheck+lint; app anti-takeover test expects no `renderShell={renderAppChatWidgetShell}`; package DOM renders header + selected panel/list via the default path; FULL `make test-ui ENV=test`.

- [ ] **Lot N-2 — UAT (non-regression, root `ENV=dev`, owner data)**
  - [ ] Web app: agents list is default when sessions exist and none active; conversation when active/none; Back→slide + focus; hybrid mount; tab order/labels unchanged; all header controls (settings, side-switch, placement, close) present; jobs/comments panels unchanged.

- [ ] **Lot N-1 — Docs consolidation**
  - [ ] Fold the D1c handover end-state into `spec/SPEC_EVOL_AGENTS_SURFACE.md` (mark L-C-shell shipped; L-A' still pending owner GO).

- [ ] **Lot N — Final validation**
  - [ ] Typecheck & Lint (ui + chat-ui)
  - [ ] FULL `make test-ui ENV=test` + `make test-chat-ui-dom ENV=test` + `make test-chat-ui ENV=test`
  - [ ] E2E non-regression: `make clean test-e2e E2E_SPEC=tests/03-chat.spec.ts API_PORT=9106 UI_PORT=5306 MAILDEV_UI_PORT=1206 ENV=e2e-lc-shell` (03 on AI allowlist) + 08 workspace-switch/checkpoint-restore
  - [ ] `chat-ui` cumulative minor `0.34.0` verified > npm published
  - [ ] PR body = this `BRANCH.md`; CI green (AI shards non-blocking allowlist)
  - [ ] Owner UAT sign-off + owner GO recorded; then remove `BRANCH.md`, push, merge (`--merge` only)
