### PR TITLE
feat: add FocusLiveSession owner signature gate

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -93,4 +93,4 @@
   - [x] Make the in-memory adapter test-only and unexported; document the production durable atomic upsert/read-back primitive as a prerequisite for live use.
   - [x] Add getter/receipt/authentication/authorization/append-failure/racy-port adversarial regression coverage.
   - [x] Re-run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
-  - [ ] Push the existing draft branch without changing its draft state and update its follow-up note.
+  - [x] Push the existing draft branch without changing its draft state and update its follow-up note.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -96,10 +96,10 @@
   - [x] Re-run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
   - [x] Push the existing draft branch without changing its draft state and update its follow-up note.
 
-- [ ] **Lot 5 — Third independent adversarial signature-gate repair**
+- [x] **Lot 5 — Third independent adversarial signature-gate repair**
   - [x] Define the durable Track uniqueness key as canonical owner, workspace, and decision id, excluding idempotency.
   - [x] Replace the false-positive barrier race with a production-like atomic uniqueness regression.
   - [x] Make every external capture boundary exception-total and copy the opaque proof into an immutable call-boundary value.
   - [x] Add throwing-accessor and proof-mutation regressions with honest not-done results.
   - [x] Correct the stale public-package and live-driver documentation.
-  - [ ] Re-run the isolated Focus package test target, scope checks, and push the existing draft branch.
+  - [x] Re-run the isolated Focus package test target, scope checks, and push the existing draft branch.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -94,3 +94,11 @@
   - [x] Add getter/receipt/authentication/authorization/append-failure/racy-port adversarial regression coverage.
   - [x] Re-run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
   - [x] Push the existing draft branch without changing its draft state and update its follow-up note.
+
+- [ ] **Lot 5 — Third independent adversarial signature-gate repair**
+  - [x] Define the durable Track uniqueness key as canonical owner, workspace, and decision id, excluding idempotency.
+  - [x] Replace the false-positive barrier race with a production-like atomic uniqueness regression.
+  - [ ] Make every external capture boundary exception-total and copy the opaque proof into an immutable call-boundary value.
+  - [ ] Add throwing-accessor and proof-mutation regressions with honest not-done results.
+  - [ ] Correct the stale public-package and live-driver documentation.
+  - [ ] Re-run the isolated Focus package test target, scope checks, and push the existing draft branch.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -5,11 +5,11 @@
 - [ ] Return an honest not-done result whenever authentication, authorization, contract validation, ingest, or read-back confirmation is unavailable or fails.
 
 ## Scope / Guardrails
-- [ ] Scope is limited to the private `@sentropic/focus` live-write driver, its public exports, focused unit tests, package metadata, and this branch plan.
+- [ ] Scope is limited to the public `@sentropic/focus` live-write driver, its public exports, focused unit tests, package metadata, README, and this branch plan.
 - [ ] The driver accepts only a Track-native decision id; it does not accept, render, transform, or submit an h2a decision dossier.
-- [ ] Owner authentication and decision/workspace authorization are required injected gates; a relayer is recorded separately and can never become the attester.
+- [ ] Owner authentication, trusted relayer provenance, and decision/workspace authorization are required injected gates; a relayer is recorded separately and can never become the attester.
 - [ ] The Track ingest contract is pinned to an exact version and every successful write is confirmed by a persisted read-back attestation before success is returned.
-- [ ] The package remains private and no package publication, CLI prompt, UI, API endpoint, migration, or Track event-schema change is introduced.
+- [ ] The package remains public and no package publication command, CLI prompt, UI, API endpoint, migration, or Track event-schema change is introduced.
 - [ ] The h2a-to-Track dossier adapter, connector teardown, tenancy cache invalidation/freshness repair, durable agentRef repair, and V1 breadth remain held out of scope.
 - [ ] Make-only workflow and Docker-first execution apply; every Make command ends with `ENV=focus-sig-gate`.
 - [ ] Automated tests use `ENV=test-focus-sig-gate`, never `ENV=dev`.
@@ -22,6 +22,7 @@
   - `packages/focus/src/index.ts`
   - `packages/focus/tests/live.spec.ts`
   - `packages/focus/package.json`
+  - `packages/focus/README.md`
   - `BRANCH.md`
 - **Forbidden Paths (must not change in this branch)**:
   - `Makefile`
@@ -44,6 +45,7 @@
 - [ ] `BR-FOCUS-SIG-GATE-1` — OPEN. Production use remains gated: PR #416 tenancy resolution needs strict mode plus cache invalidation/TTL or fresh per-authorization resolution; this primitive neither claims nor implements that repair.
 - [ ] `BR-FOCUS-SIG-GATE-2` — OPEN. The h2a-to-Track dossier adapter/wire is not implemented or consumed; only already Track-native decisions can be submitted.
 - [ ] `BR-FOCUS-SIG-GATE-3` — OPEN. No locally installed `@sentropic/track/ingest` contract is yet proven to expose the required owner-attestation event; the driver stays port-injected and returns not-done without a matching pinned implementation.
+- [ ] `BR-FOCUS-SIG-GATE-4` — OPEN. Before any live use, a co-specified production Track adapter must persist the owner signature with a durable canonical-owner/workspace/decision unique constraint or upsert and transactionally read it back. The test-only in-memory Map is intentionally non-durable and is not a production adapter.
 - [x] `BR503-EX1` — `package-lock.json` workspace metadata is updated with `packages/focus/package.json`: required for Docker `npm ci` after the mandatory package patch bump; impact is only the matching workspace version; rollback is to revert both version fields together.
 
 ## AI Flaky tests
@@ -85,10 +87,10 @@
   - [ ] Verify the pushed branch CI and report exact command results, package version, commit SHAs, and PR URL.
 
 - [ ] **Lot 4 — Independent signature-gate review repair**
-  - [x] Replace mutable caller and port aliases with frozen scalar snapshots and a separately frozen port copy.
-  - [x] Runtime-validate the Track write receipt and make the package-owned contract version the sole accepted value.
-  - [x] Require atomic owner/decision uniqueness from Track ports and provide an in-memory reference adapter.
-  - [x] Add adversarial wrong-record, pre-ingest-denial, malformed-receipt, and concurrent-submit regression coverage.
-  - [x] Runtime-validate request object shape and relayer transport before the authentication boundary.
-  - [x] Run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
-  - [x] Push the existing draft branch without changing its draft state.
+  - [x] Capture every request, authentication, trusted-relayer, authorization, receipt, and persisted-read-back value exactly once into frozen snapshots before validation or reuse.
+  - [x] Accept only the boolean authorization result `true`; malformed truthy values are denied before append.
+  - [x] Remove caller-supplied relayer provenance, use normalized issuer+subject identity equality, and reject canonical owner-relayer collisions before authorization.
+  - [x] Make the in-memory adapter test-only and unexported; document the production durable atomic upsert/read-back primitive as a prerequisite for live use.
+  - [x] Add getter/receipt/authentication/authorization/append-failure/racy-port adversarial regression coverage.
+  - [x] Re-run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
+  - [ ] Push the existing draft branch without changing its draft state and update its follow-up note.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -106,7 +106,7 @@
 
 - [ ] **Lot 6 — Fourth independent adversarial signature-gate repair**
   - [x] Preserve trusted canonical issuer and subject values exactly, including case-sensitive opaque identity parts, across authorization, collision rejection, and durable uniqueness.
-  - [ ] Capture hostile opaque proofs from one structural snapshot and lock all affected port-failure paths with tests.
+  - [x] Capture hostile opaque proofs from one structural snapshot and lock all affected port-failure paths with tests.
   - [ ] Replace the synchronous race fake with a barrier async constraint-rejection driver regression; retain the production durable adapter as the only full exactly-once proof.
   - [ ] Regenerate root lock metadata and correct the public Focus README/version history.
   - [ ] Re-run isolated Focus package tests, scope checks, and push the existing draft branch without changing its draft state.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -18,6 +18,7 @@
 - **Allowed Paths (implementation scope)**:
   - `packages/focus/src/model.ts`
   - `packages/focus/src/live/index.ts`
+  - `packages/focus/src/live/in-memory.ts`
   - `packages/focus/src/index.ts`
   - `packages/focus/tests/live.spec.ts`
   - `packages/focus/package.json`
@@ -82,3 +83,10 @@
   - [x] Run `harness check scope` and `make scope-check` before every commit.
   - [ ] Create a draft PR against `main` using this plan as the source body; state the contract, held items, and `draft: independent build-review + owner UAT required before merge/live`.
   - [ ] Verify the pushed branch CI and report exact command results, package version, commit SHAs, and PR URL.
+
+- [ ] **Lot 4 — Independent signature-gate review repair**
+  - [ ] Replace mutable caller and port aliases with frozen scalar snapshots and a separately frozen port copy.
+  - [ ] Runtime-validate the Track write receipt and make the package-owned contract version the sole accepted value.
+  - [ ] Require atomic owner/decision uniqueness from Track ports and provide an in-memory reference adapter.
+  - [ ] Add adversarial wrong-record, pre-ingest-denial, malformed-receipt, and concurrent-submit regression coverage.
+  - [ ] Run focused and full Focus package tests in `ENV=test-focus-sig-gate`, then push the existing draft branch.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -63,8 +63,8 @@
 
 - [ ] **Lot 1 — Live signature contract and fail-closed driver**
   - [x] Add `FocusLiveSession` types for an own-principal owner act, distinct relayer provenance, Track-native decision target, exact ingest-contract version, idempotency key, duplicate semantics, persisted attestation, and honest not-done outcomes.
-  - [ ] Add the live driver port that authenticates the owner, authorizes the owner for the requested workspace and decision, rejects an owner/relayer identity substitution, requires the exact pinned Track ingest contract, submits the signature, and reads the attestation back.
-  - [ ] Export the live driver from the package root without changing the read-only CLI or Track-read binding.
+  - [x] Add the live driver port that authenticates the owner, authorizes the owner for the requested workspace and decision, rejects an owner/relayer identity substitution, requires the exact pinned Track ingest contract, submits the signature, and reads the attestation back.
+  - [x] Export the live driver from the package root without changing the read-only CLI or Track-read binding.
   - [ ] Lot gate: package typecheck and focused live-driver test command pass in `ENV=test-focus-sig-gate`.
 
 - [ ] **Lot 2 — Security and duplicate-result test lock**

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -109,4 +109,4 @@
   - [x] Capture hostile opaque proofs from one structural snapshot and lock all affected port-failure paths with tests.
   - [x] Replace the synchronous race fake with a barrier async constraint-rejection driver regression; retain the production durable adapter as the only full exactly-once proof.
   - [x] Regenerate root lock metadata and correct the public Focus README/version history.
-  - [ ] Re-run isolated Focus package tests, scope checks, and push the existing draft branch without changing its draft state.
+  - [x] Re-run isolated Focus package tests and scope checks; push the existing draft branch without changing its draft state.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -81,7 +81,7 @@
   - [x] Lot gate: focused package tests and package typecheck pass in `ENV=test-focus-sig-gate`.
 
 - [ ] **Lot 3 — Version, final verification, and draft review handoff**
-  - [x] Bump `packages/focus/package.json` from `0.3.0` to the next patch version after checking the published package version.
+  - [x] Bump `packages/focus/package.json` from `0.4.0` to `0.4.1` after checking the published package version.
   - [x] Run package typecheck, focused live tests, the available package test suite, and package build through Make in `ENV=test-focus-sig-gate`.
   - [x] Run `harness check scope` and `make scope-check` before every commit.
   - [ ] Create a draft PR against `main` using this plan as the source body; state the contract, held items, and `draft: independent build-review + owner UAT required before merge/live`.
@@ -108,5 +108,5 @@
   - [x] Preserve trusted canonical issuer and subject values exactly, including case-sensitive opaque identity parts, across authorization, collision rejection, and durable uniqueness.
   - [x] Capture hostile opaque proofs from one structural snapshot and lock all affected port-failure paths with tests.
   - [x] Replace the synchronous race fake with a barrier async constraint-rejection driver regression; retain the production durable adapter as the only full exactly-once proof.
-  - [ ] Regenerate root lock metadata and correct the public Focus README/version history.
+  - [x] Regenerate root lock metadata and correct the public Focus README/version history.
   - [ ] Re-run isolated Focus package tests, scope checks, and push the existing draft branch without changing its draft state.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -25,7 +25,6 @@
   - `packages/focus/README.md`
   - `BRANCH.md`
 - **Forbidden Paths (must not change in this branch)**:
-  - `Makefile`
   - `docker-compose*.yml`
   - `.cursor/rules/**`
   - `api/**`
@@ -35,6 +34,7 @@
   - `packages/focus/src/track/**`
   - `plan/**`
 - **Conditional Paths (allowed only with explicit exception when not already listed in Allowed Paths)**:
+  - `Makefile`
   - `package-lock.json`
   - `spec/**`
   - `.github/workflows/**`
@@ -47,6 +47,7 @@
 - [ ] `BR-FOCUS-SIG-GATE-3` — OPEN. No locally installed `@sentropic/track/ingest` contract is yet proven to expose the required owner-attestation event; the driver stays port-injected and returns not-done without a matching pinned implementation.
 - [ ] `BR-FOCUS-SIG-GATE-4` — OPEN. Before any live use, a co-specified production Track adapter must persist the owner signature with a durable canonical-owner/workspace/decision unique constraint or upsert and transactionally read it back. The test-only in-memory Map is intentionally non-durable and is not a production adapter.
 - [x] `BR503-EX1` — `package-lock.json` workspace metadata is updated with `packages/focus/package.json`: required for Docker `npm ci` after the mandatory package patch bump; impact is only the matching workspace version; rollback is to revert both version fields together.
+- [x] `BR503-EX2` — `Makefile` corrects the Focus package target comment from private to public: impact is documentation-only with no target behavior change; rollback is to revert that comment.
 
 ## AI Flaky tests
 - [ ] Not applicable: focused deterministic package unit tests only.
@@ -99,6 +100,6 @@
   - [x] Define the durable Track uniqueness key as canonical owner, workspace, and decision id, excluding idempotency.
   - [x] Replace the false-positive barrier race with a production-like atomic uniqueness regression.
   - [x] Make every external capture boundary exception-total and copy the opaque proof into an immutable call-boundary value.
-  - [ ] Add throwing-accessor and proof-mutation regressions with honest not-done results.
-  - [ ] Correct the stale public-package and live-driver documentation.
+  - [x] Add throwing-accessor and proof-mutation regressions with honest not-done results.
+  - [x] Correct the stale public-package and live-driver documentation.
   - [ ] Re-run the isolated Focus package test target, scope checks, and push the existing draft branch.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -62,7 +62,7 @@
   - [ ] Lot gate: `harness check scope` and `make scope-check` pass for `BRANCH.md` only.
 
 - [ ] **Lot 1 — Live signature contract and fail-closed driver**
-  - [ ] Add `FocusLiveSession` types for an own-principal owner act, distinct relayer provenance, Track-native decision target, exact ingest-contract version, idempotency key, duplicate semantics, persisted attestation, and honest not-done outcomes.
+  - [x] Add `FocusLiveSession` types for an own-principal owner act, distinct relayer provenance, Track-native decision target, exact ingest-contract version, idempotency key, duplicate semantics, persisted attestation, and honest not-done outcomes.
   - [ ] Add the live driver port that authenticates the owner, authorizes the owner for the requested workspace and decision, rejects an owner/relayer identity substitution, requires the exact pinned Track ingest contract, submits the signature, and reads the attestation back.
   - [ ] Export the live driver from the package root without changing the read-only CLI or Track-read binding.
   - [ ] Lot gate: package typecheck and focused live-driver test command pass in `ENV=test-focus-sig-gate`.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -103,3 +103,10 @@
   - [x] Add throwing-accessor and proof-mutation regressions with honest not-done results.
   - [x] Correct the stale public-package and live-driver documentation.
   - [x] Re-run the isolated Focus package test target, scope checks, and push the existing draft branch.
+
+- [ ] **Lot 6 — Fourth independent adversarial signature-gate repair**
+  - [x] Preserve trusted canonical issuer and subject values exactly, including case-sensitive opaque identity parts, across authorization, collision rejection, and durable uniqueness.
+  - [ ] Capture hostile opaque proofs from one structural snapshot and lock all affected port-failure paths with tests.
+  - [ ] Replace the synchronous race fake with a barrier async constraint-rejection driver regression; retain the production durable adapter as the only full exactly-once proof.
+  - [ ] Regenerate root lock metadata and correct the public Focus README/version history.
+  - [ ] Re-run isolated Focus package tests, scope checks, and push the existing draft branch without changing its draft state.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,41 +1,83 @@
-# Fix(sec): exception-aware npm-audit gate — unblock ui/api Docker builds
+# Feature: FocusLiveSession owner-signature gate
 
 ## Objective
-- [x] Lift the repo-wide `--audit-level=high` Docker gate that reds every ui/api build (blocks all ui lanes + PR CI).
-- [x] Root cause: `image-size` (GHSA-w3rx-r6r6-pgpr + GHSA-5p2g-fcmc-qvqq, DoS parsers) pulled transitively by `pptxgenjs@4.0.1` in the ROOT lockfile. `#517` (mermaid in `ui/package-lock.json`) is a NO-OP — the Docker build audits the ROOT lockfile; mermaid is only moderate anyway.
-- [x] No forward fix exists (`image-size <= 2.0.2` all vulnerable, `first_patched_version = null`), and the DoS is unreachable in sentropic → a targeted, expiring audit exception is the right unblock.
+- [ ] Provide the first live-write primitive for a Track-native decision: an owner-authenticated, authorized, version-pinned, idempotent Track attestation with verified persisted read-back.
+- [ ] Return an honest not-done result whenever authentication, authorization, contract validation, ingest, or read-back confirmation is unavailable or fails.
 
 ## Scope / Guardrails
-- [x] `.security/audit-gate.mjs` (new) + `.security/audit-allowlist.json` (new): exception-aware wrapper — fails on any HIGH/CRITICAL GHSA not allowlisted, and fails after `review_due`.
-- [x] `.security/vulnerability-register.yaml`: `false_positive` entry for the 2 GHSAs (human record).
-- [x] `api/Dockerfile` (base + production gates) + `ui/Dockerfile` (base gate): replace raw `npm audit` with the wrapper. `api/Dockerfile:99` (auth-idp/web sub-tree, no image-size) left as raw audit.
-- [x] No `package.json` / lockfile change (npm ci stays valid). mermaid override bump DEFERRED (needs a full lockfile regen; moderate/non-blocking) — fast-follow.
+- [ ] Scope is limited to the private `@sentropic/focus` live-write driver, its public exports, focused unit tests, package metadata, and this branch plan.
+- [ ] The driver accepts only a Track-native decision id; it does not accept, render, transform, or submit an h2a decision dossier.
+- [ ] Owner authentication and decision/workspace authorization are required injected gates; a relayer is recorded separately and can never become the attester.
+- [ ] The Track ingest contract is pinned to an exact version and every successful write is confirmed by a persisted read-back attestation before success is returned.
+- [ ] The package remains private and no package publication, CLI prompt, UI, API endpoint, migration, or Track event-schema change is introduced.
+- [ ] The h2a-to-Track dossier adapter, connector teardown, tenancy cache invalidation/freshness repair, durable agentRef repair, and V1 breadth remain held out of scope.
+- [ ] Make-only workflow and Docker-first execution apply; every Make command ends with `ENV=focus-sig-gate`.
+- [ ] Automated tests use `ENV=test-focus-sig-gate`, never `ENV=dev`.
 
 ## Branch Scope Boundaries (MANDATORY)
 - **Allowed Paths (implementation scope)**:
-  - `.security/audit-gate.mjs`, `.security/audit-allowlist.json`, `.security/vulnerability-register.yaml`
-  - `api/Dockerfile`, `ui/Dockerfile`, `BRANCH.md`
+  - `packages/focus/src/model.ts`
+  - `packages/focus/src/live/index.ts`
+  - `packages/focus/src/index.ts`
+  - `packages/focus/tests/live.spec.ts`
+  - `packages/focus/package.json`
+  - `BRANCH.md`
 - **Forbidden Paths (must not change in this branch)**:
-  - `Makefile`, `docker-compose*.yml`, `package.json`, `package-lock.json`, `api/src/**`, `ui/src/**`, `packages/**`
-- **Conditional Paths**: none.
+  - `Makefile`
+  - `docker-compose*.yml`
+  - `.cursor/rules/**`
+  - `api/**`
+  - `ui/**`
+  - `packages/cli/**`
+  - `packages/focus/src/cli/**`
+  - `packages/focus/src/track/**`
+  - `plan/**`
+- **Conditional Paths (allowed only with explicit exception when not already listed in Allowed Paths)**:
+  - `package-lock.json`
+  - `spec/**`
+  - `.github/workflows/**`
+- **Exception process**:
+  - [ ] Declare a `BR-FOCUS-SIG-EXn` item in `## Feedback Loop` with reason, impact, and rollback before changing any conditional or forbidden path.
 
 ## Feedback Loop
-- [x] `SEC-IMGSIZE-A` — RESOLVED. Option A (forward override) is IMPOSSIBLE: no patched image-size exists (`<= 2.0.2` vulnerable, `first_patched=null`, latest 2.0.2). Confirmed by cyber (gh api /advisories + npm registry) and infra (GitHub advisories). Conductor decision A/B/C: A preferred if a patch exists, else B (expiring exception), C (breaking pptxgenjs downgrade) REJECTED.
-- [x] `SEC-IMGSIZE-B` — Reachability NULL, double barrier (verified): (1) pptxgenjs@4.0.1 never imports image-size — dead declared dep (commented `FIXME: currently unused` consumer, `browser:{image-size:false}`); (2) sentropic passes no image bytes — no `addImage` in the repo, pptx surface = text/shape/table, backgrounds color-only. The CVSS 7.5 DoS on attacker-image parsing has no reachable path → `false_positive`.
-- [x] `SEC-IMGSIZE-VERIFY` — `make build-ui-image` green: `audit-gate: OK — only allowlisted HIGH/CRITICAL remain`, full ui build `Successfully built`.
-- [ ] `SEC-IMGSIZE-EXPIRY` — exception `review_due` 2026-09-08. Follow-up: upstream pptxgenjs issue to drop the dead image-size dependency, then remove the exception.
-- [ ] `SEC-IMGSIZE-MERMAID` — DEFERRED fast-follow: bump the `mermaid` root override `^11.15.0 -> ^11.16.1` (clears the moderate mermaid advisory) via a dedicated delete-lockfile regen. Moderate, non-blocking, out of this urgent unblock.
+- [ ] `BR-FOCUS-SIG-GATE-1` — OPEN. Production use remains gated: PR #416 tenancy resolution needs strict mode plus cache invalidation/TTL or fresh per-authorization resolution; this primitive neither claims nor implements that repair.
+- [ ] `BR-FOCUS-SIG-GATE-2` — OPEN. The h2a-to-Track dossier adapter/wire is not implemented or consumed; only already Track-native decisions can be submitted.
+- [ ] `BR-FOCUS-SIG-GATE-3` — OPEN. No locally installed `@sentropic/track/ingest` contract is yet proven to expose the required owner-attestation event; the driver stays port-injected and returns not-done without a matching pinned implementation.
 
 ## AI Flaky tests
-- Not applicable: security-gate + Dockerfile change only.
+- [ ] Not applicable: focused deterministic package unit tests only.
 
 ## Orchestration Mode (AI-selected)
-- [x] Mono-branch + cherry-pick.
-- [ ] Multi-branch.
-- Rationale: one atomic security-gate change; conductor holds the merge GO.
+- [x] **Mono-branch + cherry-pick**
+- [ ] **Multi-branch**
+- [ ] One coherent package primitive with sequential contract, implementation, and verification lots.
 
 ## Plan / Todo (lot-based)
-- [x] Lot 0 — RCA: gate = 4 Dockerfile lines audit the ROOT lockfile; #517 no-op; blocker = image-size HIGH.
-- [x] Lot 1 — Build the exception-aware wrapper + allowlist + register entry; wire the 3 real gates.
-- [x] Lot 2 — Verify via `make build-ui-image` (REGISTRY=local): gate passes, build green.
-- [ ] Lot 3 — Handover: draft PR; merge on conductor GO; report main-green to conductor + chat; open the pptxgenjs upstream follow-up.
+- [ ] **Lot 0 — Scope and executable contract plan**
+  - [x] Read `rules/MASTER.md`, `rules/workflow.md`, `rules/architecture.md`, and `rules/testing.md`.
+  - [x] Run `harness check branch` for `feat/focus-live-signature-gate`.
+  - [x] Inspect #503, the FocusSnapshot/Track-read boundary, package metadata, and the plan template.
+  - [x] Create this file from `plan/BRANCH_TEMPLATE.md` with allowed and forbidden paths.
+  - [ ] Commit the initial plan before implementation.
+  - [ ] Lot gate: `harness check scope` and `make scope-check` pass for `BRANCH.md` only.
+
+- [ ] **Lot 1 — Live signature contract and fail-closed driver**
+  - [ ] Add `FocusLiveSession` types for an own-principal owner act, distinct relayer provenance, Track-native decision target, exact ingest-contract version, idempotency key, duplicate semantics, persisted attestation, and honest not-done outcomes.
+  - [ ] Add the live driver port that authenticates the owner, authorizes the owner for the requested workspace and decision, rejects an owner/relayer identity substitution, requires the exact pinned Track ingest contract, submits the signature, and reads the attestation back.
+  - [ ] Export the live driver from the package root without changing the read-only CLI or Track-read binding.
+  - [ ] Lot gate: package typecheck and focused live-driver test command pass in `ENV=test-focus-sig-gate`.
+
+- [ ] **Lot 2 — Security and duplicate-result test lock**
+  - [ ] Add `packages/focus/tests/live.spec.ts` covering own-principal authentication required.
+  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that a relayer cannot forge the owner attestation and that relayer provenance is retained separately.
+  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that double submit with one idempotency key yields one persisted attestation and a duplicate result.
+  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that failed or mismatched read-back returns not-done, never a signature.
+  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that unauthorized workspace or decision is denied before ingest.
+  - [ ] Lot gate: focused package tests and package typecheck pass in `ENV=test-focus-sig-gate`.
+
+- [ ] **Lot 3 — Version, final verification, and draft review handoff**
+  - [ ] Bump `packages/focus/package.json` from `0.3.0` to the next patch version after checking the published package version.
+  - [ ] Run package typecheck, focused live tests, and the available package test suite through Make in `ENV=test-focus-sig-gate`.
+  - [ ] Run `harness check scope` and `make scope-check` before every commit.
+  - [ ] Create a draft PR against `main` using this plan as the source body; state the contract, held items, and `draft: independent build-review + owner UAT required before merge/live`.
+  - [ ] Verify the pushed branch CI and report exact command results, package version, commit SHAs, and PR URL.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -91,4 +91,4 @@
   - [x] Add adversarial wrong-record, pre-ingest-denial, malformed-receipt, and concurrent-submit regression coverage.
   - [x] Runtime-validate request object shape and relayer transport before the authentication boundary.
   - [x] Run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
-  - [ ] Push the existing draft branch without changing its draft state.
+  - [x] Push the existing draft branch without changing its draft state.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -45,7 +45,7 @@
 - [ ] `BR-FOCUS-SIG-GATE-1` — OPEN. Production use remains gated: PR #416 tenancy resolution needs strict mode plus cache invalidation/TTL or fresh per-authorization resolution; this primitive neither claims nor implements that repair.
 - [ ] `BR-FOCUS-SIG-GATE-2` — OPEN. The h2a-to-Track dossier adapter/wire is not implemented or consumed; only already Track-native decisions can be submitted.
 - [ ] `BR-FOCUS-SIG-GATE-3` — OPEN. No locally installed `@sentropic/track/ingest` contract is yet proven to expose the required owner-attestation event; the driver stays port-injected and returns not-done without a matching pinned implementation.
-- [ ] `BR-FOCUS-SIG-GATE-4` — OPEN. Before any live use, a co-specified production Track adapter must persist the owner signature with a durable canonical-owner/workspace/decision unique constraint or upsert and transactionally read it back. The test-only in-memory Map is intentionally non-durable and is not a production adapter.
+- [ ] `BR-FOCUS-SIG-GATE-4` — OPEN. Before any live use, a co-specified production Track adapter must persist the owner signature with a durable canonical-owner/workspace/decision unique constraint or upsert and transactionally read it back. Full exactly-once atomicity is proven only by that production durable adapter; an in-memory test can only verify the driver's constraint-duplicate handling.
 - [x] `BR503-EX1` — `package-lock.json` workspace metadata is updated with `packages/focus/package.json`: required for Docker `npm ci` after the mandatory package patch bump; impact is only the matching workspace version; rollback is to revert both version fields together.
 - [x] `BR503-EX2` — `Makefile` corrects the Focus package target comment from private to public: impact is documentation-only with no target behavior change; rollback is to revert that comment.
 
@@ -90,7 +90,7 @@
 - [ ] **Lot 4 — Independent signature-gate review repair**
   - [x] Capture every request, authentication, trusted-relayer, authorization, receipt, and persisted-read-back value exactly once into frozen snapshots before validation or reuse.
   - [x] Accept only the boolean authorization result `true`; malformed truthy values are denied before append.
-  - [x] Remove caller-supplied relayer provenance, use normalized issuer+subject identity equality, and reject canonical owner-relayer collisions before authorization.
+  - [x] Remove caller-supplied relayer provenance, use exact canonical issuer+subject identity equality, and reject canonical owner-relayer collisions before authorization.
   - [x] Make the in-memory adapter test-only and unexported; document the production durable atomic upsert/read-back primitive as a prerequisite for live use.
   - [x] Add getter/receipt/authentication/authorization/append-failure/racy-port adversarial regression coverage.
   - [x] Re-run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
@@ -98,7 +98,7 @@
 
 - [x] **Lot 5 — Third independent adversarial signature-gate repair**
   - [x] Define the durable Track uniqueness key as canonical owner, workspace, and decision id, excluding idempotency.
-  - [x] Replace the false-positive barrier race with a production-like atomic uniqueness regression.
+  - [x] Add a barrier race regression that verifies driver handling of a constraint duplicate without claiming an in-memory durability proof.
   - [x] Make every external capture boundary exception-total and copy the opaque proof into an immutable call-boundary value.
   - [x] Add throwing-accessor and proof-mutation regressions with honest not-done results.
   - [x] Correct the stale public-package and live-driver documentation.
@@ -107,6 +107,6 @@
 - [ ] **Lot 6 — Fourth independent adversarial signature-gate repair**
   - [x] Preserve trusted canonical issuer and subject values exactly, including case-sensitive opaque identity parts, across authorization, collision rejection, and durable uniqueness.
   - [x] Capture hostile opaque proofs from one structural snapshot and lock all affected port-failure paths with tests.
-  - [ ] Replace the synchronous race fake with a barrier async constraint-rejection driver regression; retain the production durable adapter as the only full exactly-once proof.
+  - [x] Replace the synchronous race fake with a barrier async constraint-rejection driver regression; retain the production durable adapter as the only full exactly-once proof.
   - [ ] Regenerate root lock metadata and correct the public Focus README/version history.
   - [ ] Re-run isolated Focus package tests, scope checks, and push the existing draft branch without changing its draft state.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -37,12 +37,13 @@
   - `spec/**`
   - `.github/workflows/**`
 - **Exception process**:
-  - [ ] Declare a `BR-FOCUS-SIG-EXn` item in `## Feedback Loop` with reason, impact, and rollback before changing any conditional or forbidden path.
+  - [ ] Declare a `BR503-EXn` item in `## Feedback Loop` with reason, impact, and rollback before changing any conditional or forbidden path.
 
 ## Feedback Loop
 - [ ] `BR-FOCUS-SIG-GATE-1` — OPEN. Production use remains gated: PR #416 tenancy resolution needs strict mode plus cache invalidation/TTL or fresh per-authorization resolution; this primitive neither claims nor implements that repair.
 - [ ] `BR-FOCUS-SIG-GATE-2` — OPEN. The h2a-to-Track dossier adapter/wire is not implemented or consumed; only already Track-native decisions can be submitted.
 - [ ] `BR-FOCUS-SIG-GATE-3` — OPEN. No locally installed `@sentropic/track/ingest` contract is yet proven to expose the required owner-attestation event; the driver stays port-injected and returns not-done without a matching pinned implementation.
+- [x] `BR503-EX1` — `package-lock.json` workspace metadata is updated with `packages/focus/package.json`: required for Docker `npm ci` after the mandatory package patch bump; impact is only the matching workspace version; rollback is to revert both version fields together.
 
 ## AI Flaky tests
 - [ ] Not applicable: focused deterministic package unit tests only.
@@ -53,31 +54,31 @@
 - [ ] One coherent package primitive with sequential contract, implementation, and verification lots.
 
 ## Plan / Todo (lot-based)
-- [ ] **Lot 0 — Scope and executable contract plan**
+- [x] **Lot 0 — Scope and executable contract plan**
   - [x] Read `rules/MASTER.md`, `rules/workflow.md`, `rules/architecture.md`, and `rules/testing.md`.
   - [x] Run `harness check branch` for `feat/focus-live-signature-gate`.
   - [x] Inspect #503, the FocusSnapshot/Track-read boundary, package metadata, and the plan template.
   - [x] Create this file from `plan/BRANCH_TEMPLATE.md` with allowed and forbidden paths.
-  - [ ] Commit the initial plan before implementation.
-  - [ ] Lot gate: `harness check scope` and `make scope-check` pass for `BRANCH.md` only.
+  - [x] Commit the initial plan before implementation.
+  - [x] Lot gate: `harness check scope` and `make scope-check` pass for `BRANCH.md` only.
 
-- [ ] **Lot 1 — Live signature contract and fail-closed driver**
+- [x] **Lot 1 — Live signature contract and fail-closed driver**
   - [x] Add `FocusLiveSession` types for an own-principal owner act, distinct relayer provenance, Track-native decision target, exact ingest-contract version, idempotency key, duplicate semantics, persisted attestation, and honest not-done outcomes.
   - [x] Add the live driver port that authenticates the owner, authorizes the owner for the requested workspace and decision, rejects an owner/relayer identity substitution, requires the exact pinned Track ingest contract, submits the signature, and reads the attestation back.
   - [x] Export the live driver from the package root without changing the read-only CLI or Track-read binding.
   - [x] Lot gate: package typecheck and focused live-driver test command pass in `ENV=test-focus-sig-gate`.
 
-- [ ] **Lot 2 — Security and duplicate-result test lock**
+- [x] **Lot 2 — Security and duplicate-result test lock**
   - [x] Add `packages/focus/tests/live.spec.ts` covering own-principal authentication required.
   - [x] Add `packages/focus/tests/live.spec.ts` coverage that a relayer cannot forge the owner attestation and that relayer provenance is retained separately.
   - [x] Add `packages/focus/tests/live.spec.ts` coverage that double submit with one idempotency key yields one persisted attestation and a duplicate result.
   - [x] Add `packages/focus/tests/live.spec.ts` coverage that failed or mismatched read-back returns not-done, never a signature.
   - [x] Add `packages/focus/tests/live.spec.ts` coverage that unauthorized workspace or decision is denied before ingest.
-  - [ ] Lot gate: focused package tests and package typecheck pass in `ENV=test-focus-sig-gate`.
+  - [x] Lot gate: focused package tests and package typecheck pass in `ENV=test-focus-sig-gate`.
 
 - [ ] **Lot 3 — Version, final verification, and draft review handoff**
-  - [ ] Bump `packages/focus/package.json` from `0.3.0` to the next patch version after checking the published package version.
-  - [ ] Run package typecheck, focused live tests, and the available package test suite through Make in `ENV=test-focus-sig-gate`.
-  - [ ] Run `harness check scope` and `make scope-check` before every commit.
+  - [x] Bump `packages/focus/package.json` from `0.3.0` to the next patch version after checking the published package version.
+  - [x] Run package typecheck, focused live tests, the available package test suite, and package build through Make in `ENV=test-focus-sig-gate`.
+  - [x] Run `harness check scope` and `make scope-check` before every commit.
   - [ ] Create a draft PR against `main` using this plan as the source body; state the contract, held items, and `draft: independent build-review + owner UAT required before merge/live`.
   - [ ] Verify the pushed branch CI and report exact command results, package version, commit SHAs, and PR URL.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -98,7 +98,7 @@
 - [ ] **Lot 5 — Third independent adversarial signature-gate repair**
   - [x] Define the durable Track uniqueness key as canonical owner, workspace, and decision id, excluding idempotency.
   - [x] Replace the false-positive barrier race with a production-like atomic uniqueness regression.
-  - [ ] Make every external capture boundary exception-total and copy the opaque proof into an immutable call-boundary value.
+  - [x] Make every external capture boundary exception-total and copy the opaque proof into an immutable call-boundary value.
   - [ ] Add throwing-accessor and proof-mutation regressions with honest not-done results.
   - [ ] Correct the stale public-package and live-driver documentation.
   - [ ] Re-run the isolated Focus package test target, scope checks, and push the existing draft branch.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -65,14 +65,14 @@
   - [x] Add `FocusLiveSession` types for an own-principal owner act, distinct relayer provenance, Track-native decision target, exact ingest-contract version, idempotency key, duplicate semantics, persisted attestation, and honest not-done outcomes.
   - [x] Add the live driver port that authenticates the owner, authorizes the owner for the requested workspace and decision, rejects an owner/relayer identity substitution, requires the exact pinned Track ingest contract, submits the signature, and reads the attestation back.
   - [x] Export the live driver from the package root without changing the read-only CLI or Track-read binding.
-  - [ ] Lot gate: package typecheck and focused live-driver test command pass in `ENV=test-focus-sig-gate`.
+  - [x] Lot gate: package typecheck and focused live-driver test command pass in `ENV=test-focus-sig-gate`.
 
 - [ ] **Lot 2 — Security and duplicate-result test lock**
-  - [ ] Add `packages/focus/tests/live.spec.ts` covering own-principal authentication required.
-  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that a relayer cannot forge the owner attestation and that relayer provenance is retained separately.
-  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that double submit with one idempotency key yields one persisted attestation and a duplicate result.
-  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that failed or mismatched read-back returns not-done, never a signature.
-  - [ ] Add `packages/focus/tests/live.spec.ts` coverage that unauthorized workspace or decision is denied before ingest.
+  - [x] Add `packages/focus/tests/live.spec.ts` covering own-principal authentication required.
+  - [x] Add `packages/focus/tests/live.spec.ts` coverage that a relayer cannot forge the owner attestation and that relayer provenance is retained separately.
+  - [x] Add `packages/focus/tests/live.spec.ts` coverage that double submit with one idempotency key yields one persisted attestation and a duplicate result.
+  - [x] Add `packages/focus/tests/live.spec.ts` coverage that failed or mismatched read-back returns not-done, never a signature.
+  - [x] Add `packages/focus/tests/live.spec.ts` coverage that unauthorized workspace or decision is denied before ingest.
   - [ ] Lot gate: focused package tests and package typecheck pass in `ENV=test-focus-sig-gate`.
 
 - [ ] **Lot 3 — Version, final verification, and draft review handoff**

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -85,8 +85,10 @@
   - [ ] Verify the pushed branch CI and report exact command results, package version, commit SHAs, and PR URL.
 
 - [ ] **Lot 4 — Independent signature-gate review repair**
-  - [ ] Replace mutable caller and port aliases with frozen scalar snapshots and a separately frozen port copy.
-  - [ ] Runtime-validate the Track write receipt and make the package-owned contract version the sole accepted value.
-  - [ ] Require atomic owner/decision uniqueness from Track ports and provide an in-memory reference adapter.
-  - [ ] Add adversarial wrong-record, pre-ingest-denial, malformed-receipt, and concurrent-submit regression coverage.
-  - [ ] Run focused and full Focus package tests in `ENV=test-focus-sig-gate`, then push the existing draft branch.
+  - [x] Replace mutable caller and port aliases with frozen scalar snapshots and a separately frozen port copy.
+  - [x] Runtime-validate the Track write receipt and make the package-owned contract version the sole accepted value.
+  - [x] Require atomic owner/decision uniqueness from Track ports and provide an in-memory reference adapter.
+  - [x] Add adversarial wrong-record, pre-ingest-denial, malformed-receipt, and concurrent-submit regression coverage.
+  - [x] Runtime-validate request object shape and relayer transport before the authentication boundary.
+  - [x] Run focused and full Focus package tests in `ENV=test-focus-sig-gate`.
+  - [ ] Push the existing draft branch without changing its draft state.

--- a/Makefile
+++ b/Makefile
@@ -1194,7 +1194,7 @@ pack-harness: build-harness ## Validate @sentropic/harness npm package contents 
 # --- @sentropic/focus (BR-FOCUS-EX (Makefile): focus gained its first real runtime dep
 #     @sentropic/track, so it builds via the WORKSPACE node_modules — the install-internal-packages
 #     + `npx --offline tsc/vitest` pattern used by chat-core/comments — NOT the isolated zero-dep
-#     temp-toolset (which cannot resolve @sentropic/track + its transitive deps). Private, pure-TS
+#     temp-toolset (which cannot resolve @sentropic/track + its transitive deps). Public, pure-TS
 #     render-core + the /track read binding; node test env. install-internal-packages installs the
 #     packages/focus workspace (incl. @sentropic/track@0.17.0) into node_modules from the lockfile.) ---
 .PHONY: typecheck-focus test-focus build-focus pack-focus publish-focus publish-focus-token

--- a/package-lock.json
+++ b/package-lock.json
@@ -17716,7 +17716,7 @@
     },
     "packages/focus": {
       "name": "@sentropic/focus",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@sentropic/track": "^0.17.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17215,7 +17215,7 @@
       }
     },
     "node_modules/zlibjs": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
       "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3198,7 +3198,7 @@
       }
     },
     "node_modules/@pinojs/redact": {
-      "version": "0.4.0",
+      "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17716,7 +17716,7 @@
     },
     "packages/focus": {
       "name": "@sentropic/focus",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@sentropic/track": "^0.17.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17716,7 +17716,7 @@
     },
     "packages/focus": {
       "name": "@sentropic/focus",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@sentropic/track": "^0.17.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3198,7 +3198,7 @@
       }
     },
     "node_modules/@pinojs/redact": {
-      "version": "0.4.1",
+      "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
       "license": "MIT"
@@ -17215,7 +17215,7 @@
       }
     },
     "node_modules/zlibjs": {
-      "version": "0.3.2",
+      "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/zlibjs/-/zlibjs-0.3.1.tgz",
       "integrity": "sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==",
       "license": "MIT",

--- a/packages/focus/README.md
+++ b/packages/focus/README.md
@@ -9,7 +9,7 @@ This is a **public published package** (`@sentropic/focus`). Its public API is i
 small and hosts must provide their own authentication, relayer-provenance, authorization, and
 durable Track adapters for live use.
 
-## Scope — Focus-M1 L1 (`feat/focus-render-core`)
+## Scope — Focus-M1 L2 + live signature driver (`feat/focus-live-signature-gate`)
 
 - The **concrete `DecisionDossierDocument` model** — the decision-dossier is the *first* focus
   type, not a generic Focus platform. Node families: `prose`, `question` (q + recommended
@@ -18,12 +18,17 @@ durable Track adapters for live use.
   `targetRef`.
 - The **three deterministic renderers**: `renderTerminal`, `renderMd`, `renderHtml` — **HTML is
   mandatory**. Each takes a document and returns a `string`.
-- A local **`DecisionDossierView`-shaped fixture type** + `toDecisionDossierDocument(view)` mapper.
-  L2 (`feat/focus-track-read`) rebinds the same mapper to the real `@sentropic/track/read`.
+- The **`@sentropic/focus/track` binding** maps the real `@sentropic/track/read`
+  `DecisionDossierView` + amendment trace with `toDecisionDossierDocument(view)`.
+- The fail-closed **`FocusLiveSession` owner-signature driver** accepts only an authenticated,
+  authorized own-principal signature for an existing Track-native decision. A co-specified
+  production Track adapter with a durable canonical-owner/workspace/decision unique
+  constraint or upsert and transactional read-back is required before any live use; the
+  in-memory adapter is test-only and cannot establish exactly-once durability.
 
 The **read-only FocusSnapshot** split remains: affordances render as **disabled metadata only**
-(no live commands). A fail-closed `FocusLiveSession` owner-signature driver is now available to
-hosts that inject their own authentication, relayer-provenance, authorization, and durable Track adapters.
+(no live commands). The live driver requires host-injected authentication, relayer provenance,
+authorization, and the durable Track adapter described above.
 
 ## Injection + sanitize hooks (no bundled markdown/diagram engine)
 
@@ -39,14 +44,10 @@ in HTML, indented text in the terminal.
 ## Usage
 
 ```ts
-import {
-  toDecisionDossierDocument,
-  renderTerminal,
-  renderMd,
-  renderHtml,
-} from "@sentropic/focus";
+import { renderTerminal, renderMd, renderHtml } from "@sentropic/focus";
+import { toDecisionDossierDocument } from "@sentropic/focus/track";
 
-const doc = toDecisionDossierDocument(view); // view = DecisionDossierView fixture (L1) / track read (L2)
+const doc = toDecisionDossierDocument(view); // view = real Track DecisionDossierView
 
 const text = renderTerminal(doc);
 const md = renderMd(doc);

--- a/packages/focus/README.md
+++ b/packages/focus/README.md
@@ -21,8 +21,9 @@ durable Track adapters for live use.
 - A local **`DecisionDossierView`-shaped fixture type** + `toDecisionDossierDocument(view)` mapper.
   L2 (`feat/focus-track-read`) rebinds the same mapper to the real `@sentropic/track/read`.
 
-This is the **read-only FocusSnapshot** split: affordances render as **disabled metadata only**
-(no live commands). Live drivers (`FocusLiveSession`) are deferred to later lots.
+The **read-only FocusSnapshot** split remains: affordances render as **disabled metadata only**
+(no live commands). A fail-closed `FocusLiveSession` owner-signature driver is now available to
+hosts that inject their own authentication, relayer-provenance, authorization, and durable Track adapters.
 
 ## Injection + sanitize hooks (no bundled markdown/diagram engine)
 

--- a/packages/focus/README.md
+++ b/packages/focus/README.md
@@ -5,9 +5,9 @@ A **focused-session document runtime** — the read-only **FocusSnapshot** rende
 to orient/steer it (decide being one modality among orient / amend / comment). See
 `spec/SPEC_VOL_FOCUS.md`.
 
-This package is **private** (`"private": true`) and **app-local-first**: it is not yet published.
-It is extracted to `@sentropic/focus` on npm only once a real external consumer wires it
-(repo real-consumption rule).
+This is a **public published package** (`@sentropic/focus`). Its public API is intentionally
+small and hosts must provide their own authentication, relayer-provenance, authorization, and
+durable Track adapters for live use.
 
 ## Scope — Focus-M1 L1 (`feat/focus-render-core`)
 

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sentropic/focus",
-  "version": "0.3.0",
-  "description": "Focused-session document runtime (FocusSnapshot): the concrete decision-dossier document model + deterministic terminal/MD/HTML renderers + a /track read binding over @sentropic/track/read + a /cli read-only driver (stp focus). Read-only snapshot render-core; markdown injected by the host, HTML sanitized by the host. (Focus-M1 L3)",
+  "version": "0.3.1",
+  "description": "Focused-session document runtime: read-only FocusSnapshot renderers plus the fail-closed FocusLiveSession owner-signature driver for Track-native decisions. Markdown is injected by the host and HTML is sanitized by the host.",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/focus",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Focused-session document runtime: read-only FocusSnapshot renderers plus the fail-closed FocusLiveSession owner-signature driver for Track-native decisions. Markdown is injected by the host and HTML is sanitized by the host.",
   "type": "module",
   "license": "MIT",

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/focus",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Focused-session document runtime: read-only FocusSnapshot renderers plus the fail-closed FocusLiveSession owner-signature driver for Track-native decisions. Markdown is injected by the host and HTML is sanitized by the host.",
   "type": "module",
   "license": "MIT",

--- a/packages/focus/package.json
+++ b/packages/focus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/focus",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Focused-session document runtime: read-only FocusSnapshot renderers plus the fail-closed FocusLiveSession owner-signature driver for Track-native decisions. Markdown is injected by the host and HTML is sanitized by the host.",
   "type": "module",
   "license": "MIT",

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -12,6 +12,7 @@ export type {
   Affordance,
   AmendmentStep,
   AmendmentTraceNode,
+  AuthenticatedOwnPrincipal,
   ComprehensionEvidence,
   DecisionDossierDocument,
   DiagramNode,
@@ -19,6 +20,11 @@ export type {
   FocusNode,
   FocusProvenance,
   FocusRef,
+  FocusLiveSession,
+  OwnerSignatureAttestation,
+  OwnerSignatureNotDoneReason,
+  OwnerSignatureRequest,
+  OwnerSignatureResult,
   OptionAnnotationState,
   OptionNode,
   OptionSetNode,
@@ -27,7 +33,13 @@ export type {
   ProseNode,
   QuestionNode,
   QuestionValidationState,
+  OwnPrincipalAuthentication,
+  PersistedOwnerSignature,
+  RelayerProvenance,
   TargetRef,
+  TrackNativeDecisionTarget,
+  TrackOwnerSignatureWrite,
+  TrackOwnerSignatureWriteResult,
 } from "./model.js";
 
 export type {

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -58,6 +58,7 @@ export type { TerminalRenderOptions } from "./render/terminal.js";
 export { renderMd } from "./render/md.js";
 export { renderHtml } from "./render/html.js";
 export { FocusLiveSessionDriver } from "./live/index.js";
+export { InMemoryTrackOwnerSignaturePort } from "./live/in-memory.js";
 export type {
   FocusLiveSessionDependencies,
   OwnPrincipalAuthenticator,

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -24,6 +24,7 @@ export type {
   FocusLiveSession,
   FocusOwnerSignatureContractVersion,
   OwnerSignatureAttestation,
+  OwnerSignatureDurableUniquenessKey,
   OwnerSignatureIdentity,
   OwnerSignatureNotDoneReason,
   OwnerSignatureRequest,

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -1,11 +1,13 @@
 /**
- * @sentropic/focus (Focus-M1 L2) — the FocusSnapshot render-core.
+ * @sentropic/focus (Focus-M1 L2) — the FocusSnapshot render-core and shipped fail-closed
+ * `FocusLiveSession` owner-signature live driver.
  *
  * Public API: the concrete decision-dossier document model, the three deterministic renderers
- * (terminal / MD / HTML — read-only snapshot), and the host render hooks (markdown injection +
- * HTML sanitization). The `/track` subpath (`@sentropic/focus/track`) binds the model to the REAL
- * `@sentropic/track/read` `DecisionDossierView` + `amendmentTrace` (L2 replaced L1's local
- * `DecisionDossierViewFixture` type + mapper).
+ * (terminal / MD / HTML — read-only snapshot), the host render hooks (markdown injection + HTML
+ * sanitization), and the `FocusLiveSession` owner-signature driver. Live activation remains gated
+ * on a real durable Track adapter and owner UAT. The `/track` subpath (`@sentropic/focus/track`)
+ * binds the model to the REAL `@sentropic/track/read` `DecisionDossierView` + `amendmentTrace`
+ * (L2 replaced L1's local `DecisionDossierViewFixture` type + mapper).
  */
 
 export type {

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -53,3 +53,10 @@ export { renderTerminal } from "./render/terminal.js";
 export type { TerminalRenderOptions } from "./render/terminal.js";
 export { renderMd } from "./render/md.js";
 export { renderHtml } from "./render/html.js";
+export { FocusLiveSessionDriver } from "./live/index.js";
+export type {
+  FocusLiveSessionDependencies,
+  OwnPrincipalAuthenticator,
+  OwnerSignatureAuthorizer,
+  TrackOwnerSignaturePort,
+} from "./live/index.js";

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -21,7 +21,9 @@ export type {
   FocusProvenance,
   FocusRef,
   FocusLiveSession,
+  FocusOwnerSignatureContractVersion,
   OwnerSignatureAttestation,
+  OwnerSignatureIdentity,
   OwnerSignatureNotDoneReason,
   OwnerSignatureRequest,
   OwnerSignatureResult,
@@ -41,6 +43,8 @@ export type {
   TrackOwnerSignatureWrite,
   TrackOwnerSignatureWriteResult,
 } from "./model.js";
+
+export { FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION } from "./model.js";
 
 export type {
   HtmlRenderHooks,

--- a/packages/focus/src/index.ts
+++ b/packages/focus/src/index.ts
@@ -13,6 +13,7 @@ export type {
   AmendmentStep,
   AmendmentTraceNode,
   AuthenticatedOwnPrincipal,
+  CanonicalPrincipalIdentity,
   ComprehensionEvidence,
   DecisionDossierDocument,
   DiagramNode,
@@ -58,10 +59,10 @@ export type { TerminalRenderOptions } from "./render/terminal.js";
 export { renderMd } from "./render/md.js";
 export { renderHtml } from "./render/html.js";
 export { FocusLiveSessionDriver } from "./live/index.js";
-export { InMemoryTrackOwnerSignaturePort } from "./live/in-memory.js";
 export type {
   FocusLiveSessionDependencies,
   OwnPrincipalAuthenticator,
   OwnerSignatureAuthorizer,
   TrackOwnerSignaturePort,
+  TrustedRelayerProvenancePort,
 } from "./live/index.js";

--- a/packages/focus/src/live/in-memory.ts
+++ b/packages/focus/src/live/in-memory.ts
@@ -1,0 +1,64 @@
+import {
+  FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+  type OwnerSignatureIdentity,
+  type PersistedOwnerSignature,
+  type TrackOwnerSignatureWrite,
+  type TrackOwnerSignatureWriteResult,
+} from "../model.js";
+import type { TrackOwnerSignaturePort } from "./index.js";
+
+const identityKey = (identity: OwnerSignatureIdentity): string =>
+  `${identity.ownerPrincipalId}\u0000${identity.target.workspace}\u0000${identity.target.decisionId}`;
+
+const copyPersisted = (write: TrackOwnerSignatureWrite, recordId: string): PersistedOwnerSignature =>
+  Object.freeze({
+    contractVersion: write.contractVersion,
+    target: Object.freeze({ workspace: write.target.workspace, decisionId: write.target.decisionId }),
+    attestation: Object.freeze({
+      attester: Object.freeze({
+        principalId: write.attestation.attester.principalId,
+        authenticatedAt: write.attestation.attester.authenticatedAt,
+      }),
+    }),
+    relayer: Object.freeze({ transport: write.relayer.transport, relayerId: write.relayer.relayerId }),
+    idempotencyKey: write.idempotencyKey,
+    recordId,
+  });
+
+/**
+ * Reference Track adapter for tests and local hosts. Its synchronous map check-and-set is one
+ * JavaScript critical section: concurrent callers cannot observe an empty identity between the
+ * check and insert. Durable adapters must provide the same guarantee with an upsert/constraint.
+ */
+export class InMemoryTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
+  readonly contractVersion = FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION;
+
+  private readonly records = new Map<string, PersistedOwnerSignature>();
+  private nextRecord = 1;
+  appendAttempts = 0;
+
+  get recordCount(): number {
+    return this.records.size;
+  }
+
+  appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult> {
+    this.appendAttempts += 1;
+    const key = identityKey({
+      ownerPrincipalId: input.attestation.attester.principalId,
+      target: input.target,
+    });
+    const existing = this.records.get(key);
+    if (existing !== undefined) return Promise.resolve({ status: "duplicate", recordId: existing.recordId });
+
+    const persisted = copyPersisted(input, `owner-signature-${this.nextRecord}`);
+    this.nextRecord += 1;
+    this.records.set(key, persisted);
+    return Promise.resolve({ status: "written", recordId: persisted.recordId });
+  }
+
+  readOwnerSignature(
+    input: OwnerSignatureIdentity & { readonly idempotencyKey: string },
+  ): Promise<PersistedOwnerSignature | undefined> {
+    return Promise.resolve(this.records.get(identityKey(input)));
+  }
+}

--- a/packages/focus/src/live/in-memory.ts
+++ b/packages/focus/src/live/in-memory.ts
@@ -69,7 +69,7 @@ export class TestOnlyInMemoryTrackOwnerSignaturePort implements TrackOwnerSignat
   }
 
   readOwnerSignature(
-    input: OwnerSignatureIdentity & { readonly idempotencyKey: string },
+    input: OwnerSignatureIdentity,
   ): Promise<PersistedOwnerSignature | undefined> {
     this.readAttempts += 1;
     return Promise.resolve(this.records.get(identityKey(input)));

--- a/packages/focus/src/live/in-memory.ts
+++ b/packages/focus/src/live/in-memory.ts
@@ -8,7 +8,7 @@ import {
 import type { TrackOwnerSignaturePort } from "./index.js";
 
 const identityKey = (identity: OwnerSignatureIdentity): string =>
-  `${identity.ownerPrincipalId}\u0000${identity.target.workspace}\u0000${identity.target.decisionId}`;
+  `${identity.ownerCanonicalIdentity.issuer}\u0000${identity.ownerCanonicalIdentity.subject}\u0000${identity.target.workspace}\u0000${identity.target.decisionId}`;
 
 const copyPersisted = (write: TrackOwnerSignatureWrite, recordId: string): PersistedOwnerSignature =>
   Object.freeze({
@@ -17,25 +17,37 @@ const copyPersisted = (write: TrackOwnerSignatureWrite, recordId: string): Persi
     attestation: Object.freeze({
       attester: Object.freeze({
         principalId: write.attestation.attester.principalId,
+        canonicalIdentity: Object.freeze({
+          issuer: write.attestation.attester.canonicalIdentity.issuer,
+          subject: write.attestation.attester.canonicalIdentity.subject,
+        }),
         authenticatedAt: write.attestation.attester.authenticatedAt,
       }),
     }),
-    relayer: Object.freeze({ transport: write.relayer.transport, relayerId: write.relayer.relayerId }),
+    relayer: Object.freeze({
+      transport: write.relayer.transport,
+      relayerId: write.relayer.relayerId,
+      canonicalIdentity: Object.freeze({
+        issuer: write.relayer.canonicalIdentity.issuer,
+        subject: write.relayer.canonicalIdentity.subject,
+      }),
+    }),
     idempotencyKey: write.idempotencyKey,
     recordId,
   });
 
 /**
- * Reference Track adapter for tests and local hosts. Its synchronous map check-and-set is one
- * JavaScript critical section: concurrent callers cannot observe an empty identity between the
- * check and insert. Durable adapters must provide the same guarantee with an upsert/constraint.
+ * TEST-ONLY, non-durable reference adapter. This process-local Map is not a Track persistence
+ * implementation and must never be wired into a live host. It gives unit tests a deterministic
+ * synchronous critical section; production needs the durable atomic port contract.
  */
-export class InMemoryTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
+export class TestOnlyInMemoryTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
   readonly contractVersion = FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION;
 
   private readonly records = new Map<string, PersistedOwnerSignature>();
   private nextRecord = 1;
   appendAttempts = 0;
+  readAttempts = 0;
 
   get recordCount(): number {
     return this.records.size;
@@ -44,7 +56,7 @@ export class InMemoryTrackOwnerSignaturePort implements TrackOwnerSignaturePort 
   appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult> {
     this.appendAttempts += 1;
     const key = identityKey({
-      ownerPrincipalId: input.attestation.attester.principalId,
+      ownerCanonicalIdentity: input.attestation.attester.canonicalIdentity,
       target: input.target,
     });
     const existing = this.records.get(key);
@@ -59,6 +71,7 @@ export class InMemoryTrackOwnerSignaturePort implements TrackOwnerSignaturePort 
   readOwnerSignature(
     input: OwnerSignatureIdentity & { readonly idempotencyKey: string },
   ): Promise<PersistedOwnerSignature | undefined> {
+    this.readAttempts += 1;
     return Promise.resolve(this.records.get(identityKey(input)));
   }
 }

--- a/packages/focus/src/live/in-memory.ts
+++ b/packages/focus/src/live/in-memory.ts
@@ -38,8 +38,9 @@ const copyPersisted = (write: TrackOwnerSignatureWrite, recordId: string): Persi
 
 /**
  * TEST-ONLY, non-durable reference adapter. This process-local Map is not a Track persistence
- * implementation and must never be wired into a live host. It gives unit tests a deterministic
- * synchronous critical section; production needs the durable atomic port contract.
+ * implementation and must never be wired into a live host. It only gives unit tests deterministic
+ * duplicate behavior; it cannot prove durable exactly-once atomicity. Only the co-specified
+ * production Track adapter's durable unique constraint/upsert proves that property before live use.
  */
 export class TestOnlyInMemoryTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
   readonly contractVersion = FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION;

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -1,5 +1,6 @@
 import type {
   AuthenticatedOwnPrincipal,
+  CanonicalPrincipalIdentity,
   FocusOwnerSignatureContractVersion,
   FocusLiveSession,
   OwnerSignatureIdentity,
@@ -27,6 +28,14 @@ export interface OwnerSignatureAuthorizer {
 }
 
 /**
+ * Trusted host-owned transport provenance. It is deliberately separate from the caller request:
+ * callers must never assert the identity recorded as the relayer.
+ */
+export interface TrustedRelayerProvenancePort {
+  getRelayerProvenance(): Promise<RelayerProvenance>;
+}
+
+/**
  * The co-specified Track ingest/read-back contract required for a real owner signature.
  * Current `@sentropic/track/ingest@1.2.0` does not implement this shape, so production wiring
  * must supply a future pinned adapter instead of weakening attester/relayer provenance.
@@ -34,9 +43,11 @@ export interface OwnerSignatureAuthorizer {
 export interface TrackOwnerSignaturePort {
   readonly contractVersion: FocusOwnerSignatureContractVersion;
   /**
-   * Atomically create or return the record unique on `{ ownerPrincipalId, workspace, decisionId }`.
-   * Implementations MUST enforce that uniqueness in their durable store (for example with an
-   * upsert or unique constraint); a process-local read-then-insert is not a valid implementation.
+   * Atomically create or return the record unique on canonical
+   * `{ owner issuer+subject, workspace, decisionId }`. Production implementations MUST enforce
+   * that uniqueness with a durable database constraint/upsert and transactionally read the
+   * persisted attestation back. Process-local locking or a check-then-insert sequence is not a
+   * valid implementation: the driver deliberately relies on this port-level contract.
    */
   appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult>;
   readOwnerSignature(
@@ -44,14 +55,16 @@ export interface TrackOwnerSignaturePort {
   ): Promise<PersistedOwnerSignature | undefined>;
 }
 
-/** Dependencies owned by the host that knows its own-principal and tenancy policy. */
+/** Dependencies owned by the host that knows its own-principal, transport, and tenancy policy. */
 export interface FocusLiveSessionDependencies {
   readonly ownPrincipal: OwnPrincipalAuthenticator;
+  readonly relayerProvenance: TrustedRelayerProvenancePort;
   readonly authorizer: OwnerSignatureAuthorizer;
   readonly track: TrackOwnerSignaturePort;
 }
 
 type RelayerTransport = RelayerProvenance["transport"];
+type ReceiptStatus = TrackOwnerSignatureWriteResult["status"];
 
 const hasText = (value: unknown): value is string => typeof value === "string" && value.trim().length > 0;
 
@@ -61,49 +74,169 @@ const isObject = (value: unknown): value is Record<string, unknown> =>
 const isRelayerTransport = (value: unknown): value is RelayerTransport =>
   value === "cli" || value === "http" || value === "mcp-stdio" || value === "internal";
 
+const isReceiptStatus = (value: unknown): value is ReceiptStatus => value === "written" || value === "duplicate";
+
 const copyText = (value: string): string => `${value}`;
 
-const isRequestWellFormed = (request: OwnerSignatureRequest): boolean =>
-  isObject(request) &&
-  isObject(request.target) &&
-  isObject(request.authentication) &&
-  isObject(request.relayer) &&
-  request.authentication.kind === "own-principal" &&
-  hasText(request.target.workspace) &&
-  hasText(request.target.decisionId) &&
-  hasText(request.idempotencyKey) &&
-  hasText(request.relayer.relayerId) &&
-  isRelayerTransport(request.relayer.transport);
+const normalizeIdentityPart = (value: string): string => value.trim().toLocaleLowerCase("en-US");
 
 interface RequestSignatureScalars {
   readonly workspace: string;
   readonly decisionId: string;
-  readonly relayerTransport: RelayerTransport;
-  readonly relayerId: string;
+  readonly authenticationProof: unknown;
   readonly idempotencyKey: string;
   readonly contractVersion: FocusOwnerSignatureContractVersion;
 }
 
-interface ConfirmedSignatureScalars extends RequestSignatureScalars {
+interface OwnerSignatureScalars {
   readonly ownerPrincipalId: string;
-  readonly authenticatedAt: string;
+  readonly ownerAuthenticatedAt: string;
+  readonly ownerCanonicalIdentity: CanonicalPrincipalIdentity;
+}
+
+interface RelayerSignatureScalars {
+  readonly relayerTransport: RelayerTransport;
+  readonly relayerId: string;
+  readonly relayerCanonicalIdentity: CanonicalPrincipalIdentity;
+}
+
+interface ConfirmedSignatureScalars
+  extends Omit<RequestSignatureScalars, "authenticationProof">,
+    OwnerSignatureScalars,
+    RelayerSignatureScalars {
   readonly recordId: string;
 }
+
+interface ReceiptScalars {
+  readonly status: ReceiptStatus;
+  readonly recordId: string;
+}
+
+const captureCanonicalIdentity = (value: unknown): CanonicalPrincipalIdentity | undefined => {
+  if (!isObject(value)) return undefined;
+
+  const scalarSnapshot = Object.freeze({ issuer: value.issuer, subject: value.subject });
+  if (!hasText(scalarSnapshot.issuer) || !hasText(scalarSnapshot.subject)) return undefined;
+
+  return Object.freeze({
+    issuer: normalizeIdentityPart(scalarSnapshot.issuer),
+    subject: normalizeIdentityPart(scalarSnapshot.subject),
+  });
+};
+
+/** Capture every caller field once, then validate only the frozen scalar snapshot. */
+const captureRequest = (value: unknown): RequestSignatureScalars | undefined => {
+  if (!isObject(value)) return undefined;
+
+  const requestBoundary = Object.freeze({
+    target: value.target,
+    authentication: value.authentication,
+    idempotencyKey: value.idempotencyKey,
+  });
+  if (!isObject(requestBoundary.target) || !isObject(requestBoundary.authentication)) return undefined;
+
+  const scalarSnapshot = Object.freeze({
+    workspace: requestBoundary.target.workspace,
+    decisionId: requestBoundary.target.decisionId,
+    authenticationKind: requestBoundary.authentication.kind,
+    authenticationProof: requestBoundary.authentication.proof,
+    idempotencyKey: requestBoundary.idempotencyKey,
+  });
+  if (
+    scalarSnapshot.authenticationKind !== "own-principal" ||
+    !hasText(scalarSnapshot.workspace) ||
+    !hasText(scalarSnapshot.decisionId) ||
+    !hasText(scalarSnapshot.idempotencyKey)
+  ) {
+    return undefined;
+  }
+
+  return Object.freeze({
+    workspace: copyText(scalarSnapshot.workspace),
+    decisionId: copyText(scalarSnapshot.decisionId),
+    authenticationProof: scalarSnapshot.authenticationProof,
+    idempotencyKey: copyText(scalarSnapshot.idempotencyKey),
+    contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+  });
+};
+
+/** Capture a runtime authentication result once; null, arrays, and malformed shapes are invalid. */
+const captureAuthenticatedOwner = (value: unknown): OwnerSignatureScalars | undefined => {
+  if (!isObject(value)) return undefined;
+
+  const scalarSnapshot = Object.freeze({
+    principalId: value.principalId,
+    authenticatedAt: value.authenticatedAt,
+    canonicalIdentity: value.canonicalIdentity,
+  });
+  if (!hasText(scalarSnapshot.principalId) || !hasText(scalarSnapshot.authenticatedAt)) return undefined;
+
+  const canonicalIdentity = captureCanonicalIdentity(scalarSnapshot.canonicalIdentity);
+  if (canonicalIdentity === undefined) return undefined;
+
+  return Object.freeze({
+    ownerPrincipalId: copyText(scalarSnapshot.principalId),
+    ownerAuthenticatedAt: copyText(scalarSnapshot.authenticatedAt),
+    ownerCanonicalIdentity: canonicalIdentity,
+  });
+};
+
+/** Capture trusted relayer provenance once; callers cannot supply this value. */
+const captureRelayerProvenance = (value: unknown): RelayerSignatureScalars | undefined => {
+  if (!isObject(value)) return undefined;
+
+  const scalarSnapshot = Object.freeze({
+    transport: value.transport,
+    relayerId: value.relayerId,
+    canonicalIdentity: value.canonicalIdentity,
+  });
+  if (!isRelayerTransport(scalarSnapshot.transport) || !hasText(scalarSnapshot.relayerId)) return undefined;
+
+  const canonicalIdentity = captureCanonicalIdentity(scalarSnapshot.canonicalIdentity);
+  if (canonicalIdentity === undefined) return undefined;
+
+  return Object.freeze({
+    relayerTransport: scalarSnapshot.transport,
+    relayerId: copyText(scalarSnapshot.relayerId),
+    relayerCanonicalIdentity: canonicalIdentity,
+  });
+};
+
+/** Capture a port-owned receipt once; no receipt property is ever consulted after this boundary. */
+const captureReceipt = (value: unknown): ReceiptScalars | undefined => {
+  if (!isObject(value)) return undefined;
+
+  const scalarSnapshot = Object.freeze({ status: value.status, recordId: value.recordId });
+  if (!isReceiptStatus(scalarSnapshot.status) || !hasText(scalarSnapshot.recordId)) return undefined;
+
+  return Object.freeze({ status: scalarSnapshot.status, recordId: copyText(scalarSnapshot.recordId) });
+};
 
 const freezeTarget = (snapshot: Pick<RequestSignatureScalars, "workspace" | "decisionId">): TrackNativeDecisionTarget =>
   Object.freeze({ workspace: snapshot.workspace, decisionId: snapshot.decisionId });
 
-const freezeAttester = (
-  snapshot: Pick<ConfirmedSignatureScalars, "ownerPrincipalId" | "authenticatedAt">,
-): AuthenticatedOwnPrincipal =>
-  Object.freeze({ principalId: snapshot.ownerPrincipalId, authenticatedAt: snapshot.authenticatedAt });
+const freezeCanonicalIdentity = (identity: CanonicalPrincipalIdentity): CanonicalPrincipalIdentity =>
+  Object.freeze({ issuer: identity.issuer, subject: identity.subject });
 
-const freezeRelayer = (
-  snapshot: Pick<RequestSignatureScalars, "relayerTransport" | "relayerId">,
-) => Object.freeze({ transport: snapshot.relayerTransport, relayerId: snapshot.relayerId });
+const freezeAttester = (snapshot: OwnerSignatureScalars): AuthenticatedOwnPrincipal =>
+  Object.freeze({
+    principalId: snapshot.ownerPrincipalId,
+    canonicalIdentity: freezeCanonicalIdentity(snapshot.ownerCanonicalIdentity),
+    authenticatedAt: snapshot.ownerAuthenticatedAt,
+  });
+
+const freezeRelayer = (snapshot: RelayerSignatureScalars): RelayerProvenance =>
+  Object.freeze({
+    transport: snapshot.relayerTransport,
+    relayerId: snapshot.relayerId,
+    canonicalIdentity: freezeCanonicalIdentity(snapshot.relayerCanonicalIdentity),
+  });
+
+const freezeAuthentication = (snapshot: RequestSignatureScalars): OwnerSignatureRequest["authentication"] =>
+  Object.freeze({ kind: "own-principal", proof: snapshot.authenticationProof });
 
 const freezePortWrite = (
-  snapshot: RequestSignatureScalars & Pick<ConfirmedSignatureScalars, "ownerPrincipalId" | "authenticatedAt">,
+  snapshot: RequestSignatureScalars & OwnerSignatureScalars & RelayerSignatureScalars,
 ): TrackOwnerSignatureWrite =>
   Object.freeze({
     contractVersion: snapshot.contractVersion,
@@ -113,126 +246,224 @@ const freezePortWrite = (
     idempotencyKey: snapshot.idempotencyKey,
   });
 
-/** Runtime validation is required because an injected port can violate its TypeScript declaration. */
-const isWrittenReceipt = (value: unknown): value is TrackOwnerSignatureWriteResult =>
-  isObject(value) &&
-  (value.status === "written" || value.status === "duplicate") &&
-  typeof value.recordId === "string" &&
-  hasText(value.recordId);
+const freezeIdentity = (
+  snapshot: OwnerSignatureScalars & Pick<RequestSignatureScalars, "workspace" | "decisionId">,
+): OwnerSignatureIdentity =>
+  Object.freeze({
+    ownerCanonicalIdentity: freezeCanonicalIdentity(snapshot.ownerCanonicalIdentity),
+    target: freezeTarget(snapshot),
+  });
 
-const confirms = (
-  persisted: unknown,
-  snapshot: ConfirmedSignatureScalars,
-): boolean =>
-  isObject(persisted) &&
-  isObject(persisted.target) &&
-  isObject(persisted.attestation) &&
-  isObject(persisted.attestation.attester) &&
-  isObject(persisted.relayer) &&
-  persisted.recordId === snapshot.recordId &&
-  persisted.contractVersion === snapshot.contractVersion &&
-  persisted.target.workspace === snapshot.workspace &&
-  persisted.target.decisionId === snapshot.decisionId &&
-  persisted.idempotencyKey === snapshot.idempotencyKey &&
-  persisted.attestation.attester.principalId === snapshot.ownerPrincipalId &&
-  persisted.attestation.attester.authenticatedAt === snapshot.authenticatedAt &&
-  persisted.relayer.transport === snapshot.relayerTransport &&
-  persisted.relayer.relayerId === snapshot.relayerId;
+const canonicalIdentityEquals = (left: CanonicalPrincipalIdentity, right: CanonicalPrincipalIdentity): boolean =>
+  left.issuer === right.issuer && left.subject === right.subject;
+
+/** Capture every field of an untrusted persisted record before validating the read-back. */
+const capturePersistedSignature = (value: unknown): ConfirmedSignatureScalars | undefined => {
+  if (!isObject(value)) return undefined;
+
+  const recordBoundary = Object.freeze({
+    recordId: value.recordId,
+    contractVersion: value.contractVersion,
+    target: value.target,
+    attestation: value.attestation,
+    relayer: value.relayer,
+    idempotencyKey: value.idempotencyKey,
+  });
+  if (
+    !isObject(recordBoundary.target) ||
+    !isObject(recordBoundary.attestation) ||
+    !isObject(recordBoundary.relayer)
+  ) {
+    return undefined;
+  }
+
+  const attestationBoundary = Object.freeze({ attester: recordBoundary.attestation.attester });
+  if (!isObject(attestationBoundary.attester)) return undefined;
+
+  const scalarSnapshot = Object.freeze({
+    recordId: recordBoundary.recordId,
+    contractVersion: recordBoundary.contractVersion,
+    workspace: recordBoundary.target.workspace,
+    decisionId: recordBoundary.target.decisionId,
+    idempotencyKey: recordBoundary.idempotencyKey,
+    ownerPrincipalId: attestationBoundary.attester.principalId,
+    ownerAuthenticatedAt: attestationBoundary.attester.authenticatedAt,
+    ownerCanonicalIdentity: attestationBoundary.attester.canonicalIdentity,
+    relayerTransport: recordBoundary.relayer.transport,
+    relayerId: recordBoundary.relayer.relayerId,
+    relayerCanonicalIdentity: recordBoundary.relayer.canonicalIdentity,
+  });
+  if (
+    scalarSnapshot.contractVersion !== FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION ||
+    !hasText(scalarSnapshot.recordId) ||
+    !hasText(scalarSnapshot.workspace) ||
+    !hasText(scalarSnapshot.decisionId) ||
+    !hasText(scalarSnapshot.idempotencyKey) ||
+    !hasText(scalarSnapshot.ownerPrincipalId) ||
+    !hasText(scalarSnapshot.ownerAuthenticatedAt) ||
+    !isRelayerTransport(scalarSnapshot.relayerTransport) ||
+    !hasText(scalarSnapshot.relayerId)
+  ) {
+    return undefined;
+  }
+
+  const ownerCanonicalIdentity = captureCanonicalIdentity(scalarSnapshot.ownerCanonicalIdentity);
+  const relayerCanonicalIdentity = captureCanonicalIdentity(scalarSnapshot.relayerCanonicalIdentity);
+  if (ownerCanonicalIdentity === undefined || relayerCanonicalIdentity === undefined) return undefined;
+
+  return Object.freeze({
+    contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+    workspace: copyText(scalarSnapshot.workspace),
+    decisionId: copyText(scalarSnapshot.decisionId),
+    idempotencyKey: copyText(scalarSnapshot.idempotencyKey),
+    ownerPrincipalId: copyText(scalarSnapshot.ownerPrincipalId),
+    ownerAuthenticatedAt: copyText(scalarSnapshot.ownerAuthenticatedAt),
+    ownerCanonicalIdentity,
+    relayerTransport: scalarSnapshot.relayerTransport,
+    relayerId: copyText(scalarSnapshot.relayerId),
+    relayerCanonicalIdentity,
+    recordId: copyText(scalarSnapshot.recordId),
+  });
+};
+
+const confirms = (persisted: ConfirmedSignatureScalars, expected: ConfirmedSignatureScalars): boolean =>
+  persisted.recordId === expected.recordId &&
+  persisted.contractVersion === expected.contractVersion &&
+  persisted.workspace === expected.workspace &&
+  persisted.decisionId === expected.decisionId &&
+  persisted.idempotencyKey === expected.idempotencyKey &&
+  persisted.ownerPrincipalId === expected.ownerPrincipalId &&
+  persisted.ownerAuthenticatedAt === expected.ownerAuthenticatedAt &&
+  canonicalIdentityEquals(persisted.ownerCanonicalIdentity, expected.ownerCanonicalIdentity) &&
+  persisted.relayerTransport === expected.relayerTransport &&
+  persisted.relayerId === expected.relayerId &&
+  canonicalIdentityEquals(persisted.relayerCanonicalIdentity, expected.relayerCanonicalIdentity);
+
+const freezePersistedSignature = (snapshot: ConfirmedSignatureScalars): PersistedOwnerSignature =>
+  Object.freeze({
+    contractVersion: snapshot.contractVersion,
+    target: freezeTarget(snapshot),
+    attestation: Object.freeze({ attester: freezeAttester(snapshot) }),
+    relayer: freezeRelayer(snapshot),
+    idempotencyKey: snapshot.idempotencyKey,
+    recordId: snapshot.recordId,
+  });
 
 /**
  * Fail-closed live driver for owner acceptance of an existing Track-native decision.
  * A write receipt alone never means signed: only matching persisted read-back returns `signed`.
  */
 export class FocusLiveSessionDriver implements FocusLiveSession {
-  constructor(private readonly dependencies: FocusLiveSessionDependencies) {}
+  private readonly ownPrincipal: OwnPrincipalAuthenticator;
+  private readonly relayerProvenance: TrustedRelayerProvenancePort;
+  private readonly authorizer: OwnerSignatureAuthorizer;
+  private readonly track: TrackOwnerSignaturePort;
+
+  constructor(dependencies: FocusLiveSessionDependencies) {
+    this.ownPrincipal = dependencies.ownPrincipal;
+    this.relayerProvenance = dependencies.relayerProvenance;
+    this.authorizer = dependencies.authorizer;
+    this.track = dependencies.track;
+  }
 
   async sign(request: OwnerSignatureRequest): Promise<OwnerSignatureResult> {
-    if (!isRequestWellFormed(request)) {
-      return { status: "not-done", reason: "invalid-signature-request" };
-    }
+    const requestSnapshot = captureRequest(request);
+    if (requestSnapshot === undefined) return { status: "not-done", reason: "invalid-signature-request" };
 
-    // Copy all caller-controlled primitives before authentication can yield to another actor.
-    const requestSnapshot: RequestSignatureScalars = Object.freeze({
-      workspace: copyText(request.target.workspace),
-      decisionId: copyText(request.target.decisionId),
-      relayerTransport: request.relayer.transport,
-      relayerId: copyText(request.relayer.relayerId),
-      idempotencyKey: copyText(request.idempotencyKey),
-      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
-    });
     const authenticationRequest: OwnerSignatureRequest = Object.freeze({
       target: freezeTarget(requestSnapshot),
-      authentication: request.authentication,
-      relayer: freezeRelayer(requestSnapshot),
+      authentication: freezeAuthentication(requestSnapshot),
       idempotencyKey: requestSnapshot.idempotencyKey,
     });
 
-    let owner: AuthenticatedOwnPrincipal | undefined;
+    let authenticationResult: unknown;
     try {
-      owner = await this.dependencies.ownPrincipal.authenticate(authenticationRequest);
+      const authenticate = this.ownPrincipal.authenticate;
+      authenticationResult = await authenticate.call(this.ownPrincipal, authenticationRequest);
     } catch {
       return { status: "not-done", reason: "owner-authentication-invalid" };
     }
-    if (owner === undefined) {
+    if (authenticationResult === undefined) {
       return { status: "not-done", reason: "owner-authentication-required" };
     }
-    if (!hasText(owner.principalId) || !hasText(owner.authenticatedAt)) {
-      return { status: "not-done", reason: "owner-authentication-invalid" };
+
+    const ownerSnapshot = captureAuthenticatedOwner(authenticationResult);
+    if (ownerSnapshot === undefined) return { status: "not-done", reason: "owner-authentication-invalid" };
+
+    let relayerResult: unknown;
+    try {
+      const getRelayerProvenance = this.relayerProvenance.getRelayerProvenance;
+      relayerResult = await getRelayerProvenance.call(this.relayerProvenance);
+    } catch {
+      return { status: "not-done", reason: "relayer-provenance-invalid" };
     }
-    const ownerSnapshot = Object.freeze({
-      ownerPrincipalId: copyText(owner.principalId),
-      authenticatedAt: copyText(owner.authenticatedAt),
-    });
-    if (ownerSnapshot.ownerPrincipalId === requestSnapshot.relayerId) {
+    const relayerSnapshot = captureRelayerProvenance(relayerResult);
+    if (relayerSnapshot === undefined) return { status: "not-done", reason: "relayer-provenance-invalid" };
+
+    if (canonicalIdentityEquals(ownerSnapshot.ownerCanonicalIdentity, relayerSnapshot.relayerCanonicalIdentity)) {
       return { status: "not-done", reason: "attester-relayer-conflict" };
     }
 
     const authorizationOwner = freezeAttester(ownerSnapshot);
     const authorizationTarget = freezeTarget(requestSnapshot);
-
+    let authorizationResult: unknown;
     try {
-      const authorized = await this.dependencies.authorizer.authorize(
+      const authorize = this.authorizer.authorize;
+      authorizationResult = await authorize.call(
+        this.authorizer,
         Object.freeze({ owner: authorizationOwner, target: authorizationTarget }),
       );
-      if (!authorized) return { status: "not-done", reason: "authorization-denied" };
     } catch {
       return { status: "not-done", reason: "authorization-denied" };
     }
+    const authorizationSnapshot = Object.freeze({ authorized: authorizationResult });
+    if (authorizationSnapshot.authorized !== true) {
+      return { status: "not-done", reason: "authorization-denied" };
+    }
 
-    if (this.dependencies.track.contractVersion !== FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION) {
+    const trackContractSnapshot = Object.freeze({ contractVersion: this.track.contractVersion });
+    if (trackContractSnapshot.contractVersion !== FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION) {
       return { status: "not-done", reason: "track-contract-mismatch" };
     }
 
-    const write = freezePortWrite(Object.freeze({ ...requestSnapshot, ...ownerSnapshot }));
+    const write = freezePortWrite(Object.freeze({ ...requestSnapshot, ...ownerSnapshot, ...relayerSnapshot }));
 
-    let receipt: unknown;
+    let receiptResult: unknown;
     try {
-      receipt = await this.dependencies.track.appendOwnerSignature(write);
+      const appendOwnerSignature = this.track.appendOwnerSignature;
+      receiptResult = await appendOwnerSignature.call(this.track, write);
     } catch {
       return { status: "not-done", reason: "track-write-failed" };
     }
-    if (!isWrittenReceipt(receipt)) return { status: "not-done", reason: "track-write-failed" };
+    const receiptSnapshot = captureReceipt(receiptResult);
+    if (receiptSnapshot === undefined) return { status: "not-done", reason: "track-write-failed" };
 
     const confirmationSnapshot: ConfirmedSignatureScalars = Object.freeze({
       ...requestSnapshot,
       ...ownerSnapshot,
-      recordId: copyText(receipt.recordId),
+      ...relayerSnapshot,
+      recordId: receiptSnapshot.recordId,
     });
 
+    let persistedResult: unknown;
     try {
-      const persisted = await this.dependencies.track.readOwnerSignature(
-        Object.freeze({
-          ownerPrincipalId: confirmationSnapshot.ownerPrincipalId,
-          target: freezeTarget(confirmationSnapshot),
-          idempotencyKey: confirmationSnapshot.idempotencyKey,
-        }),
+      const readOwnerSignature = this.track.readOwnerSignature;
+      persistedResult = await readOwnerSignature.call(
+        this.track,
+        Object.freeze({ ...freezeIdentity(confirmationSnapshot), idempotencyKey: confirmationSnapshot.idempotencyKey }),
       );
-      if (persisted === undefined || !confirms(persisted, confirmationSnapshot)) {
-        return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
-      }
-      return { status: "signed", duplicate: receipt.status === "duplicate", persisted };
     } catch {
       return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
     }
+    const persistedSnapshot = capturePersistedSignature(persistedResult);
+    if (persistedSnapshot === undefined || !confirms(persistedSnapshot, confirmationSnapshot)) {
+      return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
+    }
+
+    return {
+      status: "signed",
+      duplicate: receiptSnapshot.status === "duplicate",
+      persisted: freezePersistedSignature(persistedSnapshot),
+    };
   }
 }

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -82,10 +82,89 @@ const copyText = (value: string): string => `${value}`;
 
 const normalizeIdentityPart = (value: string): string => value.trim().toLocaleLowerCase("en-US");
 
+const captureBoundary = <T>(capture: () => T | undefined): T | undefined => {
+  try {
+    return capture();
+  } catch {
+    return undefined;
+  }
+};
+
+type ImmutableProofPrimitive = undefined | null | boolean | number | string | bigint | symbol;
+interface ImmutableProofArray extends ReadonlyArray<ImmutableProof> {}
+interface ImmutableProofObject {
+  readonly [key: string]: ImmutableProof;
+}
+type ImmutableProof = ImmutableProofPrimitive | ImmutableProofArray | ImmutableProofObject;
+
+interface ImmutableProofCapture {
+  readonly value: ImmutableProof;
+}
+
+/**
+ * Reduce opaque proof input to a frozen, JSON-shaped value tree (plus immutable primitives).
+ * Unsupported, cyclic, accessor-throwing, or proxy-throwing values are rejected before auth.
+ */
+const copyImmutableProof = (
+  value: unknown,
+  ancestors: ReadonlySet<object>,
+): ImmutableProofCapture | undefined => {
+  if (
+    value === undefined ||
+    value === null ||
+    typeof value === "boolean" ||
+    typeof value === "number" ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    typeof value === "symbol"
+  ) {
+    return { value };
+  }
+  if (typeof value !== "object") return undefined;
+  if (ancestors.has(value)) return undefined;
+
+  const nextAncestors = new Set(ancestors);
+  nextAncestors.add(value);
+
+  if (Array.isArray(value)) {
+    const length = value.length;
+    if (Reflect.ownKeys(value).length !== length + 1) return undefined;
+
+    const copy: ImmutableProof[] = [];
+    for (let index = 0; index < length; index += 1) {
+      if (!Object.hasOwn(value, index)) return undefined;
+      const item = copyImmutableProof(value[index], nextAncestors);
+      if (item === undefined) return undefined;
+      copy.push(item.value);
+    }
+    return { value: Object.freeze(copy) };
+  }
+
+  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) return undefined;
+  const keys = Object.keys(value);
+  if (Reflect.ownKeys(value).length !== keys.length) return undefined;
+
+  const copy: Record<string, ImmutableProof> = Object.create(null) as Record<string, ImmutableProof>;
+  for (const key of keys) {
+    const item = copyImmutableProof((value as Record<string, unknown>)[key], nextAncestors);
+    if (item === undefined) return undefined;
+    Object.defineProperty(copy, key, {
+      configurable: false,
+      enumerable: true,
+      value: item.value,
+      writable: false,
+    });
+  }
+  return { value: Object.freeze(copy) };
+};
+
+const captureImmutableProof = (value: unknown): ImmutableProofCapture | undefined =>
+  captureBoundary(() => copyImmutableProof(value, new Set<object>()));
+
 interface RequestSignatureScalars {
   readonly workspace: string;
   readonly decisionId: string;
-  readonly authenticationProof: unknown;
+  readonly authenticationProof: ImmutableProof;
   readonly idempotencyKey: string;
   readonly contractVersion: FocusOwnerSignatureContractVersion;
 }
@@ -114,7 +193,7 @@ interface ReceiptScalars {
   readonly recordId: string;
 }
 
-const captureCanonicalIdentity = (value: unknown): CanonicalPrincipalIdentity | undefined => {
+const captureCanonicalIdentityUnsafe = (value: unknown): CanonicalPrincipalIdentity | undefined => {
   if (!isObject(value)) return undefined;
 
   const scalarSnapshot = Object.freeze({ issuer: value.issuer, subject: value.subject });
@@ -126,8 +205,11 @@ const captureCanonicalIdentity = (value: unknown): CanonicalPrincipalIdentity | 
   });
 };
 
+const captureCanonicalIdentity = (value: unknown): CanonicalPrincipalIdentity | undefined =>
+  captureBoundary(() => captureCanonicalIdentityUnsafe(value));
+
 /** Capture every caller field once, then validate only the frozen scalar snapshot. */
-const captureRequest = (value: unknown): RequestSignatureScalars | undefined => {
+const captureRequestUnsafe = (value: unknown): RequestSignatureScalars | undefined => {
   if (!isObject(value)) return undefined;
 
   const requestBoundary = Object.freeze({
@@ -144,11 +226,13 @@ const captureRequest = (value: unknown): RequestSignatureScalars | undefined => 
     authenticationProof: requestBoundary.authentication.proof,
     idempotencyKey: requestBoundary.idempotencyKey,
   });
+  const proofSnapshot = captureImmutableProof(scalarSnapshot.authenticationProof);
   if (
     scalarSnapshot.authenticationKind !== "own-principal" ||
     !hasText(scalarSnapshot.workspace) ||
     !hasText(scalarSnapshot.decisionId) ||
-    !hasText(scalarSnapshot.idempotencyKey)
+    !hasText(scalarSnapshot.idempotencyKey) ||
+    proofSnapshot === undefined
   ) {
     return undefined;
   }
@@ -156,14 +240,17 @@ const captureRequest = (value: unknown): RequestSignatureScalars | undefined => 
   return Object.freeze({
     workspace: copyText(scalarSnapshot.workspace),
     decisionId: copyText(scalarSnapshot.decisionId),
-    authenticationProof: scalarSnapshot.authenticationProof,
+    authenticationProof: proofSnapshot.value,
     idempotencyKey: copyText(scalarSnapshot.idempotencyKey),
     contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
   });
 };
 
+const captureRequest = (value: unknown): RequestSignatureScalars | undefined =>
+  captureBoundary(() => captureRequestUnsafe(value));
+
 /** Capture a runtime authentication result once; null, arrays, and malformed shapes are invalid. */
-const captureAuthenticatedOwner = (value: unknown): OwnerSignatureScalars | undefined => {
+const captureAuthenticatedOwnerUnsafe = (value: unknown): OwnerSignatureScalars | undefined => {
   if (!isObject(value)) return undefined;
 
   const scalarSnapshot = Object.freeze({
@@ -183,8 +270,11 @@ const captureAuthenticatedOwner = (value: unknown): OwnerSignatureScalars | unde
   });
 };
 
+const captureAuthenticatedOwner = (value: unknown): OwnerSignatureScalars | undefined =>
+  captureBoundary(() => captureAuthenticatedOwnerUnsafe(value));
+
 /** Capture trusted relayer provenance once; callers cannot supply this value. */
-const captureRelayerProvenance = (value: unknown): RelayerSignatureScalars | undefined => {
+const captureRelayerProvenanceUnsafe = (value: unknown): RelayerSignatureScalars | undefined => {
   if (!isObject(value)) return undefined;
 
   const scalarSnapshot = Object.freeze({
@@ -204,8 +294,11 @@ const captureRelayerProvenance = (value: unknown): RelayerSignatureScalars | und
   });
 };
 
+const captureRelayerProvenance = (value: unknown): RelayerSignatureScalars | undefined =>
+  captureBoundary(() => captureRelayerProvenanceUnsafe(value));
+
 /** Capture a port-owned receipt once; no receipt property is ever consulted after this boundary. */
-const captureReceipt = (value: unknown): ReceiptScalars | undefined => {
+const captureReceiptUnsafe = (value: unknown): ReceiptScalars | undefined => {
   if (!isObject(value)) return undefined;
 
   const scalarSnapshot = Object.freeze({ status: value.status, recordId: value.recordId });
@@ -213,6 +306,9 @@ const captureReceipt = (value: unknown): ReceiptScalars | undefined => {
 
   return Object.freeze({ status: scalarSnapshot.status, recordId: copyText(scalarSnapshot.recordId) });
 };
+
+const captureReceipt = (value: unknown): ReceiptScalars | undefined =>
+  captureBoundary(() => captureReceiptUnsafe(value));
 
 const freezeTarget = (snapshot: Pick<RequestSignatureScalars, "workspace" | "decisionId">): TrackNativeDecisionTarget =>
   Object.freeze({ workspace: snapshot.workspace, decisionId: snapshot.decisionId });
@@ -260,7 +356,7 @@ const canonicalIdentityEquals = (left: CanonicalPrincipalIdentity, right: Canoni
   left.issuer === right.issuer && left.subject === right.subject;
 
 /** Capture every field of an untrusted persisted record before validating the read-back. */
-const capturePersistedSignature = (value: unknown): ConfirmedSignatureScalars | undefined => {
+const capturePersistedSignatureUnsafe = (value: unknown): ConfirmedSignatureScalars | undefined => {
   if (!isObject(value)) return undefined;
 
   const recordBoundary = Object.freeze({
@@ -271,11 +367,7 @@ const capturePersistedSignature = (value: unknown): ConfirmedSignatureScalars | 
     relayer: value.relayer,
     idempotencyKey: value.idempotencyKey,
   });
-  if (
-    !isObject(recordBoundary.target) ||
-    !isObject(recordBoundary.attestation) ||
-    !isObject(recordBoundary.relayer)
-  ) {
+  if (!isObject(recordBoundary.target) || !isObject(recordBoundary.attestation) || !isObject(recordBoundary.relayer)) {
     return undefined;
   }
 
@@ -327,6 +419,9 @@ const capturePersistedSignature = (value: unknown): ConfirmedSignatureScalars | 
     recordId: copyText(scalarSnapshot.recordId),
   });
 };
+
+const capturePersistedSignature = (value: unknown): ConfirmedSignatureScalars | undefined =>
+  captureBoundary(() => capturePersistedSignatureUnsafe(value));
 
 const confirms = (
   persisted: ConfirmedSignatureScalars,
@@ -427,7 +522,13 @@ export class FocusLiveSessionDriver implements FocusLiveSession {
       return { status: "not-done", reason: "authorization-denied" };
     }
 
-    const trackContractSnapshot = Object.freeze({ contractVersion: this.track.contractVersion });
+    let trackContractVersion: unknown;
+    try {
+      trackContractVersion = this.track.contractVersion;
+    } catch {
+      return { status: "not-done", reason: "track-write-failed" };
+    }
+    const trackContractSnapshot = Object.freeze({ contractVersion: trackContractVersion });
     if (trackContractSnapshot.contractVersion !== FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION) {
       return { status: "not-done", reason: "track-contract-mismatch" };
     }

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -1,0 +1,138 @@
+import type {
+  AuthenticatedOwnPrincipal,
+  FocusLiveSession,
+  OwnerSignatureRequest,
+  OwnerSignatureResult,
+  PersistedOwnerSignature,
+  TrackNativeDecisionTarget,
+  TrackOwnerSignatureWrite,
+  TrackOwnerSignatureWriteResult,
+} from "../model.js";
+
+/** The trusted integration boundary for own-principal authentication. */
+export interface OwnPrincipalAuthenticator {
+  authenticate(input: OwnerSignatureRequest): Promise<AuthenticatedOwnPrincipal | undefined>;
+}
+
+/** The trusted integration boundary for decision and workspace authorization. */
+export interface OwnerSignatureAuthorizer {
+  authorize(input: {
+    readonly owner: AuthenticatedOwnPrincipal;
+    readonly target: TrackNativeDecisionTarget;
+  }): Promise<boolean>;
+}
+
+/**
+ * The co-specified Track ingest/read-back contract required for a real owner signature.
+ * Current `@sentropic/track/ingest@1.2.0` does not implement this shape, so production wiring
+ * must supply a future pinned adapter instead of weakening attester/relayer provenance.
+ */
+export interface TrackOwnerSignaturePort {
+  readonly contractVersion: string;
+  appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult>;
+  readOwnerSignature(input: {
+    readonly target: TrackNativeDecisionTarget;
+    readonly idempotencyKey: string;
+  }): Promise<PersistedOwnerSignature | undefined>;
+}
+
+/** Dependencies owned by the host that knows its own-principal and tenancy policy. */
+export interface FocusLiveSessionDependencies {
+  readonly ownPrincipal: OwnPrincipalAuthenticator;
+  readonly authorizer: OwnerSignatureAuthorizer;
+  readonly track: TrackOwnerSignaturePort;
+  /** Exact Track signature-ingest contract version accepted by this host. */
+  readonly expectedTrackContractVersion: string;
+}
+
+const hasText = (value: string): boolean => value.trim().length > 0;
+
+const isRequestWellFormed = (request: OwnerSignatureRequest): boolean =>
+  hasText(request.target.workspace) &&
+  hasText(request.target.decisionId) &&
+  hasText(request.idempotencyKey) &&
+  hasText(request.relayer.relayerId);
+
+const confirms = (
+  persisted: PersistedOwnerSignature,
+  write: TrackOwnerSignatureWrite,
+  recordId: string,
+): boolean =>
+  persisted.recordId === recordId &&
+  persisted.contractVersion === write.contractVersion &&
+  persisted.target.workspace === write.target.workspace &&
+  persisted.target.decisionId === write.target.decisionId &&
+  persisted.idempotencyKey === write.idempotencyKey &&
+  persisted.attestation.attester.principalId === write.attestation.attester.principalId &&
+  persisted.attestation.attester.authenticatedAt === write.attestation.attester.authenticatedAt &&
+  persisted.relayer.transport === write.relayer.transport &&
+  persisted.relayer.relayerId === write.relayer.relayerId;
+
+/**
+ * Fail-closed live driver for owner acceptance of an existing Track-native decision.
+ * A write receipt alone never means signed: only matching persisted read-back returns `signed`.
+ */
+export class FocusLiveSessionDriver implements FocusLiveSession {
+  constructor(private readonly dependencies: FocusLiveSessionDependencies) {}
+
+  async sign(request: OwnerSignatureRequest): Promise<OwnerSignatureResult> {
+    if (!isRequestWellFormed(request)) {
+      return { status: "not-done", reason: "invalid-signature-request" };
+    }
+
+    let owner: AuthenticatedOwnPrincipal | undefined;
+    try {
+      owner = await this.dependencies.ownPrincipal.authenticate(request);
+    } catch {
+      return { status: "not-done", reason: "owner-authentication-invalid" };
+    }
+    if (owner === undefined) {
+      return { status: "not-done", reason: "owner-authentication-required" };
+    }
+    if (!hasText(owner.principalId) || !hasText(owner.authenticatedAt)) {
+      return { status: "not-done", reason: "owner-authentication-invalid" };
+    }
+    if (owner.principalId === request.relayer.relayerId) {
+      return { status: "not-done", reason: "attester-relayer-conflict" };
+    }
+
+    try {
+      const authorized = await this.dependencies.authorizer.authorize({ owner, target: request.target });
+      if (!authorized) return { status: "not-done", reason: "authorization-denied" };
+    } catch {
+      return { status: "not-done", reason: "authorization-denied" };
+    }
+
+    if (this.dependencies.track.contractVersion !== this.dependencies.expectedTrackContractVersion) {
+      return { status: "not-done", reason: "track-contract-mismatch" };
+    }
+
+    const write: TrackOwnerSignatureWrite = {
+      contractVersion: this.dependencies.expectedTrackContractVersion,
+      target: request.target,
+      attestation: { attester: owner },
+      relayer: request.relayer,
+      idempotencyKey: request.idempotencyKey,
+    };
+
+    let receipt: TrackOwnerSignatureWriteResult;
+    try {
+      receipt = await this.dependencies.track.appendOwnerSignature(write);
+    } catch {
+      return { status: "not-done", reason: "track-write-failed" };
+    }
+
+    try {
+      const persisted = await this.dependencies.track.readOwnerSignature({
+        target: request.target,
+        idempotencyKey: request.idempotencyKey,
+      });
+      if (persisted === undefined || !confirms(persisted, write, receipt.recordId)) {
+        return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
+      }
+      return { status: "signed", duplicate: receipt.status === "duplicate", persisted };
+    } catch {
+      return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
+    }
+  }
+}

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -1,6 +1,8 @@
 import type {
   AuthenticatedOwnPrincipal,
+  FocusOwnerSignatureContractVersion,
   FocusLiveSession,
+  OwnerSignatureIdentity,
   OwnerSignatureRequest,
   OwnerSignatureResult,
   PersistedOwnerSignature,
@@ -8,6 +10,7 @@ import type {
   TrackOwnerSignatureWrite,
   TrackOwnerSignatureWriteResult,
 } from "../model.js";
+import { FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION } from "../model.js";
 
 /** The trusted integration boundary for own-principal authentication. */
 export interface OwnPrincipalAuthenticator {
@@ -28,12 +31,16 @@ export interface OwnerSignatureAuthorizer {
  * must supply a future pinned adapter instead of weakening attester/relayer provenance.
  */
 export interface TrackOwnerSignaturePort {
-  readonly contractVersion: string;
+  readonly contractVersion: FocusOwnerSignatureContractVersion;
+  /**
+   * Atomically create or return the record unique on `{ ownerPrincipalId, workspace, decisionId }`.
+   * Implementations MUST enforce that uniqueness in their durable store (for example with an
+   * upsert or unique constraint); a process-local read-then-insert is not a valid implementation.
+   */
   appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult>;
-  readOwnerSignature(input: {
-    readonly target: TrackNativeDecisionTarget;
-    readonly idempotencyKey: string;
-  }): Promise<PersistedOwnerSignature | undefined>;
+  readOwnerSignature(
+    input: OwnerSignatureIdentity & { readonly idempotencyKey: string },
+  ): Promise<PersistedOwnerSignature | undefined>;
 }
 
 /** Dependencies owned by the host that knows its own-principal and tenancy policy. */
@@ -41,11 +48,11 @@ export interface FocusLiveSessionDependencies {
   readonly ownPrincipal: OwnPrincipalAuthenticator;
   readonly authorizer: OwnerSignatureAuthorizer;
   readonly track: TrackOwnerSignaturePort;
-  /** Exact Track signature-ingest contract version accepted by this host. */
-  readonly expectedTrackContractVersion: string;
 }
 
 const hasText = (value: string): boolean => value.trim().length > 0;
+
+const copyText = (value: string): string => `${value}`;
 
 const isRequestWellFormed = (request: OwnerSignatureRequest): boolean =>
   hasText(request.target.workspace) &&
@@ -53,20 +60,72 @@ const isRequestWellFormed = (request: OwnerSignatureRequest): boolean =>
   hasText(request.idempotencyKey) &&
   hasText(request.relayer.relayerId);
 
+interface RequestSignatureScalars {
+  readonly workspace: string;
+  readonly decisionId: string;
+  readonly relayerTransport: "cli" | "http" | "mcp-stdio" | "internal";
+  readonly relayerId: string;
+  readonly idempotencyKey: string;
+  readonly contractVersion: FocusOwnerSignatureContractVersion;
+}
+
+interface ConfirmedSignatureScalars extends RequestSignatureScalars {
+  readonly ownerPrincipalId: string;
+  readonly authenticatedAt: string;
+  readonly recordId: string;
+}
+
+const freezeTarget = (snapshot: Pick<RequestSignatureScalars, "workspace" | "decisionId">): TrackNativeDecisionTarget =>
+  Object.freeze({ workspace: snapshot.workspace, decisionId: snapshot.decisionId });
+
+const freezeAttester = (
+  snapshot: Pick<ConfirmedSignatureScalars, "ownerPrincipalId" | "authenticatedAt">,
+): AuthenticatedOwnPrincipal =>
+  Object.freeze({ principalId: snapshot.ownerPrincipalId, authenticatedAt: snapshot.authenticatedAt });
+
+const freezeRelayer = (
+  snapshot: Pick<RequestSignatureScalars, "relayerTransport" | "relayerId">,
+) => Object.freeze({ transport: snapshot.relayerTransport, relayerId: snapshot.relayerId });
+
+const freezePortWrite = (
+  snapshot: RequestSignatureScalars & Pick<ConfirmedSignatureScalars, "ownerPrincipalId" | "authenticatedAt">,
+): TrackOwnerSignatureWrite =>
+  Object.freeze({
+    contractVersion: snapshot.contractVersion,
+    target: freezeTarget(snapshot),
+    attestation: Object.freeze({ attester: freezeAttester(snapshot) }),
+    relayer: freezeRelayer(snapshot),
+    idempotencyKey: snapshot.idempotencyKey,
+  });
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+/** Runtime validation is required because an injected port can violate its TypeScript declaration. */
+const isWrittenReceipt = (value: unknown): value is TrackOwnerSignatureWriteResult =>
+  isObject(value) &&
+  (value.status === "written" || value.status === "duplicate") &&
+  typeof value.recordId === "string" &&
+  hasText(value.recordId);
+
 const confirms = (
-  persisted: PersistedOwnerSignature,
-  write: TrackOwnerSignatureWrite,
-  recordId: string,
+  persisted: unknown,
+  snapshot: ConfirmedSignatureScalars,
 ): boolean =>
-  persisted.recordId === recordId &&
-  persisted.contractVersion === write.contractVersion &&
-  persisted.target.workspace === write.target.workspace &&
-  persisted.target.decisionId === write.target.decisionId &&
-  persisted.idempotencyKey === write.idempotencyKey &&
-  persisted.attestation.attester.principalId === write.attestation.attester.principalId &&
-  persisted.attestation.attester.authenticatedAt === write.attestation.attester.authenticatedAt &&
-  persisted.relayer.transport === write.relayer.transport &&
-  persisted.relayer.relayerId === write.relayer.relayerId;
+  isObject(persisted) &&
+  isObject(persisted.target) &&
+  isObject(persisted.attestation) &&
+  isObject(persisted.attestation.attester) &&
+  isObject(persisted.relayer) &&
+  persisted.recordId === snapshot.recordId &&
+  persisted.contractVersion === snapshot.contractVersion &&
+  persisted.target.workspace === snapshot.workspace &&
+  persisted.target.decisionId === snapshot.decisionId &&
+  persisted.idempotencyKey === snapshot.idempotencyKey &&
+  persisted.attestation.attester.principalId === snapshot.ownerPrincipalId &&
+  persisted.attestation.attester.authenticatedAt === snapshot.authenticatedAt &&
+  persisted.relayer.transport === snapshot.relayerTransport &&
+  persisted.relayer.relayerId === snapshot.relayerId;
 
 /**
  * Fail-closed live driver for owner acceptance of an existing Track-native decision.
@@ -80,9 +139,25 @@ export class FocusLiveSessionDriver implements FocusLiveSession {
       return { status: "not-done", reason: "invalid-signature-request" };
     }
 
+    // Copy all caller-controlled primitives before authentication can yield to another actor.
+    const requestSnapshot: RequestSignatureScalars = Object.freeze({
+      workspace: copyText(request.target.workspace),
+      decisionId: copyText(request.target.decisionId),
+      relayerTransport: request.relayer.transport,
+      relayerId: copyText(request.relayer.relayerId),
+      idempotencyKey: copyText(request.idempotencyKey),
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+    });
+    const authenticationRequest: OwnerSignatureRequest = Object.freeze({
+      target: freezeTarget(requestSnapshot),
+      authentication: request.authentication,
+      relayer: freezeRelayer(requestSnapshot),
+      idempotencyKey: requestSnapshot.idempotencyKey,
+    });
+
     let owner: AuthenticatedOwnPrincipal | undefined;
     try {
-      owner = await this.dependencies.ownPrincipal.authenticate(request);
+      owner = await this.dependencies.ownPrincipal.authenticate(authenticationRequest);
     } catch {
       return { status: "not-done", reason: "owner-authentication-invalid" };
     }
@@ -92,42 +167,55 @@ export class FocusLiveSessionDriver implements FocusLiveSession {
     if (!hasText(owner.principalId) || !hasText(owner.authenticatedAt)) {
       return { status: "not-done", reason: "owner-authentication-invalid" };
     }
-    if (owner.principalId === request.relayer.relayerId) {
+    const ownerSnapshot = Object.freeze({
+      ownerPrincipalId: copyText(owner.principalId),
+      authenticatedAt: copyText(owner.authenticatedAt),
+    });
+    if (ownerSnapshot.ownerPrincipalId === requestSnapshot.relayerId) {
       return { status: "not-done", reason: "attester-relayer-conflict" };
     }
 
+    const authorizationOwner = freezeAttester(ownerSnapshot);
+    const authorizationTarget = freezeTarget(requestSnapshot);
+
     try {
-      const authorized = await this.dependencies.authorizer.authorize({ owner, target: request.target });
+      const authorized = await this.dependencies.authorizer.authorize(
+        Object.freeze({ owner: authorizationOwner, target: authorizationTarget }),
+      );
       if (!authorized) return { status: "not-done", reason: "authorization-denied" };
     } catch {
       return { status: "not-done", reason: "authorization-denied" };
     }
 
-    if (this.dependencies.track.contractVersion !== this.dependencies.expectedTrackContractVersion) {
+    if (this.dependencies.track.contractVersion !== FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION) {
       return { status: "not-done", reason: "track-contract-mismatch" };
     }
 
-    const write: TrackOwnerSignatureWrite = {
-      contractVersion: this.dependencies.expectedTrackContractVersion,
-      target: request.target,
-      attestation: { attester: owner },
-      relayer: request.relayer,
-      idempotencyKey: request.idempotencyKey,
-    };
+    const write = freezePortWrite(Object.freeze({ ...requestSnapshot, ...ownerSnapshot }));
 
-    let receipt: TrackOwnerSignatureWriteResult;
+    let receipt: unknown;
     try {
       receipt = await this.dependencies.track.appendOwnerSignature(write);
     } catch {
       return { status: "not-done", reason: "track-write-failed" };
     }
+    if (!isWrittenReceipt(receipt)) return { status: "not-done", reason: "track-write-failed" };
+
+    const confirmationSnapshot: ConfirmedSignatureScalars = Object.freeze({
+      ...requestSnapshot,
+      ...ownerSnapshot,
+      recordId: copyText(receipt.recordId),
+    });
 
     try {
-      const persisted = await this.dependencies.track.readOwnerSignature({
-        target: request.target,
-        idempotencyKey: request.idempotencyKey,
-      });
-      if (persisted === undefined || !confirms(persisted, write, receipt.recordId)) {
+      const persisted = await this.dependencies.track.readOwnerSignature(
+        Object.freeze({
+          ownerPrincipalId: confirmationSnapshot.ownerPrincipalId,
+          target: freezeTarget(confirmationSnapshot),
+          idempotencyKey: confirmationSnapshot.idempotencyKey,
+        }),
+      );
+      if (persisted === undefined || !confirms(persisted, confirmationSnapshot)) {
         return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
       }
       return { status: "signed", duplicate: receipt.status === "duplicate", persisted };

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -6,6 +6,7 @@ import type {
   OwnerSignatureRequest,
   OwnerSignatureResult,
   PersistedOwnerSignature,
+  RelayerProvenance,
   TrackNativeDecisionTarget,
   TrackOwnerSignatureWrite,
   TrackOwnerSignatureWriteResult,
@@ -50,20 +51,34 @@ export interface FocusLiveSessionDependencies {
   readonly track: TrackOwnerSignaturePort;
 }
 
-const hasText = (value: string): boolean => value.trim().length > 0;
+type RelayerTransport = RelayerProvenance["transport"];
+
+const hasText = (value: unknown): value is string => typeof value === "string" && value.trim().length > 0;
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const isRelayerTransport = (value: unknown): value is RelayerTransport =>
+  value === "cli" || value === "http" || value === "mcp-stdio" || value === "internal";
 
 const copyText = (value: string): string => `${value}`;
 
 const isRequestWellFormed = (request: OwnerSignatureRequest): boolean =>
+  isObject(request) &&
+  isObject(request.target) &&
+  isObject(request.authentication) &&
+  isObject(request.relayer) &&
+  request.authentication.kind === "own-principal" &&
   hasText(request.target.workspace) &&
   hasText(request.target.decisionId) &&
   hasText(request.idempotencyKey) &&
-  hasText(request.relayer.relayerId);
+  hasText(request.relayer.relayerId) &&
+  isRelayerTransport(request.relayer.transport);
 
 interface RequestSignatureScalars {
   readonly workspace: string;
   readonly decisionId: string;
-  readonly relayerTransport: "cli" | "http" | "mcp-stdio" | "internal";
+  readonly relayerTransport: RelayerTransport;
   readonly relayerId: string;
   readonly idempotencyKey: string;
   readonly contractVersion: FocusOwnerSignatureContractVersion;
@@ -97,9 +112,6 @@ const freezePortWrite = (
     relayer: freezeRelayer(snapshot),
     idempotencyKey: snapshot.idempotencyKey,
   });
-
-const isObject = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value);
 
 /** Runtime validation is required because an injected port can violate its TypeScript declaration. */
 const isWrittenReceipt = (value: unknown): value is TrackOwnerSignatureWriteResult =>

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -3,6 +3,7 @@ import type {
   CanonicalPrincipalIdentity,
   FocusOwnerSignatureContractVersion,
   FocusLiveSession,
+  OwnerSignatureDurableUniquenessKey,
   OwnerSignatureIdentity,
   OwnerSignatureRequest,
   OwnerSignatureResult,
@@ -43,16 +44,17 @@ export interface TrustedRelayerProvenancePort {
 export interface TrackOwnerSignaturePort {
   readonly contractVersion: FocusOwnerSignatureContractVersion;
   /**
-   * Atomically create or return the record unique on canonical
-   * `{ owner issuer+subject, workspace, decisionId }`. Production implementations MUST enforce
-   * that uniqueness with a durable database constraint/upsert and transactionally read the
-   * persisted attestation back. Process-local locking or a check-then-insert sequence is not a
-   * valid implementation: the driver deliberately relies on this port-level contract.
+   * Atomically create or return the record unique on the
+   * `OwnerSignatureDurableUniquenessKey` `{ canonical owner issuer+subject, workspace,
+   * decisionId }`. `idempotencyKey` is intentionally excluded: it only identifies an identical
+   * retry and never authorizes a second durable owner signature. Production implementations MUST
+   * enforce this uniqueness with a durable database constraint/upsert and transactionally read
+   * the persisted attestation back. Process-local locking or a check-then-insert sequence is not
+   * a valid implementation: the driver deliberately relies on this port-level contract.
    */
   appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult>;
-  readOwnerSignature(
-    input: OwnerSignatureIdentity & { readonly idempotencyKey: string },
-  ): Promise<PersistedOwnerSignature | undefined>;
+  /** Read the canonical durable record by the same uniqueness key, never by idempotency key. */
+  readOwnerSignature(input: OwnerSignatureDurableUniquenessKey): Promise<PersistedOwnerSignature | undefined>;
 }
 
 /** Dependencies owned by the host that knows its own-principal, transport, and tenancy policy. */
@@ -326,12 +328,16 @@ const capturePersistedSignature = (value: unknown): ConfirmedSignatureScalars | 
   });
 };
 
-const confirms = (persisted: ConfirmedSignatureScalars, expected: ConfirmedSignatureScalars): boolean =>
+const confirms = (
+  persisted: ConfirmedSignatureScalars,
+  expected: ConfirmedSignatureScalars,
+  requireMatchingIdempotencyKey: boolean,
+): boolean =>
   persisted.recordId === expected.recordId &&
   persisted.contractVersion === expected.contractVersion &&
   persisted.workspace === expected.workspace &&
   persisted.decisionId === expected.decisionId &&
-  persisted.idempotencyKey === expected.idempotencyKey &&
+  (!requireMatchingIdempotencyKey || persisted.idempotencyKey === expected.idempotencyKey) &&
   persisted.ownerPrincipalId === expected.ownerPrincipalId &&
   persisted.ownerAuthenticatedAt === expected.ownerAuthenticatedAt &&
   canonicalIdentityEquals(persisted.ownerCanonicalIdentity, expected.ownerCanonicalIdentity) &&
@@ -448,15 +454,15 @@ export class FocusLiveSessionDriver implements FocusLiveSession {
     let persistedResult: unknown;
     try {
       const readOwnerSignature = this.track.readOwnerSignature;
-      persistedResult = await readOwnerSignature.call(
-        this.track,
-        Object.freeze({ ...freezeIdentity(confirmationSnapshot), idempotencyKey: confirmationSnapshot.idempotencyKey }),
-      );
+      persistedResult = await readOwnerSignature.call(this.track, freezeIdentity(confirmationSnapshot));
     } catch {
       return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
     }
     const persistedSnapshot = capturePersistedSignature(persistedResult);
-    if (persistedSnapshot === undefined || !confirms(persistedSnapshot, confirmationSnapshot)) {
+    if (
+      persistedSnapshot === undefined ||
+      !confirms(persistedSnapshot, confirmationSnapshot, receiptSnapshot.status === "written")
+    ) {
       return { status: "not-done", reason: "persisted-attestation-not-confirmed" };
     }
 

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -80,8 +80,6 @@ const isReceiptStatus = (value: unknown): value is ReceiptStatus => value === "w
 
 const copyText = (value: string): string => `${value}`;
 
-const normalizeIdentityPart = (value: string): string => value.trim().toLocaleLowerCase("en-US");
-
 const captureBoundary = <T>(capture: () => T | undefined): T | undefined => {
   try {
     return capture();
@@ -200,8 +198,10 @@ const captureCanonicalIdentityUnsafe = (value: unknown): CanonicalPrincipalIdent
   if (!hasText(scalarSnapshot.issuer) || !hasText(scalarSnapshot.subject)) return undefined;
 
   return Object.freeze({
-    issuer: normalizeIdentityPart(scalarSnapshot.issuer),
-    subject: normalizeIdentityPart(scalarSnapshot.subject),
+    // Trusted boundaries supply canonical opaque identities. Do not recanonicalize case-sensitive
+    // issuer paths or subjects here: exact values are the authorization and uniqueness identity.
+    issuer: copyText(scalarSnapshot.issuer),
+    subject: copyText(scalarSnapshot.subject),
   });
 };
 

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -147,6 +147,7 @@ const copyImmutableProof = (
 
   const copy: Record<string, ImmutableProof> = Object.create(null) as Record<string, ImmutableProof>;
   for (const key of structuralSnapshot.ownKeys) {
+    if (typeof key !== "string") return undefined;
     const descriptor = Object.getOwnPropertyDescriptor(value, key);
     if (descriptor === undefined || !descriptor.enumerable) return undefined;
     const item = copyImmutableProof((value as Record<string, unknown>)[key], nextAncestors);

--- a/packages/focus/src/live/index.ts
+++ b/packages/focus/src/live/index.ts
@@ -138,12 +138,17 @@ const copyImmutableProof = (
     return { value: Object.freeze(copy) };
   }
 
-  if (Object.getPrototypeOf(value) !== Object.prototype && Object.getPrototypeOf(value) !== null) return undefined;
-  const keys = Object.keys(value);
-  if (Reflect.ownKeys(value).length !== keys.length) return undefined;
+  const structuralSnapshot = Object.freeze({
+    prototype: Object.getPrototypeOf(value),
+    ownKeys: Object.freeze([...Reflect.ownKeys(value)]),
+  });
+  if (structuralSnapshot.prototype !== Object.prototype && structuralSnapshot.prototype !== null) return undefined;
+  if (structuralSnapshot.ownKeys.some((key) => typeof key !== "string")) return undefined;
 
   const copy: Record<string, ImmutableProof> = Object.create(null) as Record<string, ImmutableProof>;
-  for (const key of keys) {
+  for (const key of structuralSnapshot.ownKeys) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (descriptor === undefined || !descriptor.enumerable) return undefined;
     const item = copyImmutableProof((value as Record<string, unknown>)[key], nextAncestors);
     if (item === undefined) return undefined;
     Object.defineProperty(copy, key, {

--- a/packages/focus/src/model.ts
+++ b/packages/focus/src/model.ts
@@ -185,9 +185,16 @@ export interface OwnPrincipalAuthentication {
   readonly proof: unknown;
 }
 
+/** A normalized, issuer-scoped identity supplied by a trusted authentication boundary. */
+export interface CanonicalPrincipalIdentity {
+  readonly issuer: string;
+  readonly subject: string;
+}
+
 /** The authenticated owner identity returned by the trusted own-principal adapter. */
 export interface AuthenticatedOwnPrincipal {
   readonly principalId: string;
+  readonly canonicalIdentity: CanonicalPrincipalIdentity;
   readonly authenticatedAt: string;
 }
 
@@ -195,6 +202,7 @@ export interface AuthenticatedOwnPrincipal {
 export interface RelayerProvenance {
   readonly transport: "cli" | "http" | "mcp-stdio" | "internal";
   readonly relayerId: string;
+  readonly canonicalIdentity: CanonicalPrincipalIdentity;
 }
 
 /** The authenticated owner act that the Track signature contract must persist. */
@@ -206,7 +214,6 @@ export interface OwnerSignatureAttestation {
 export interface OwnerSignatureRequest {
   readonly target: TrackNativeDecisionTarget;
   readonly authentication: OwnPrincipalAuthentication;
-  readonly relayer: RelayerProvenance;
   readonly idempotencyKey: string;
 }
 
@@ -229,7 +236,11 @@ export interface PersistedOwnerSignature extends TrackOwnerSignatureWrite {
  * given Track-native decision once, irrespective of transport retries or idempotency keys.
  */
 export interface OwnerSignatureIdentity {
-  readonly ownerPrincipalId: string;
+  /**
+   * The normalized issuer+subject identity of the authenticated owner. This is the identity
+   * used for the durable unique constraint, never a caller-supplied display identifier.
+   */
+  readonly ownerCanonicalIdentity: CanonicalPrincipalIdentity;
   readonly target: TrackNativeDecisionTarget;
 }
 
@@ -243,6 +254,7 @@ export type OwnerSignatureNotDoneReason =
   | "invalid-signature-request"
   | "owner-authentication-required"
   | "owner-authentication-invalid"
+  | "relayer-provenance-invalid"
   | "authorization-denied"
   | "attester-relayer-conflict"
   | "track-contract-mismatch"

--- a/packages/focus/src/model.ts
+++ b/packages/focus/src/model.ts
@@ -6,8 +6,9 @@
  * whose primary outcome modality is a decision). It is intentionally CONCRETE, not a generic
  * "Focus platform": the model stays decision-dossier-shaped until a 2nd modality is real.
  *
- * This is the read-only FocusSnapshot split: affordances render as DISABLED metadata only
- * (no live commands). Live drivers (FocusLiveSession) are deferred (L3+).
+ * This remains the read-only FocusSnapshot split: affordances render as DISABLED metadata only
+ * (no snapshot live commands). The shipped fail-closed `FocusLiveSession` owner-signature live
+ * driver activates only with a real durable Track adapter and owner UAT.
  */
 
 /**

--- a/packages/focus/src/model.ts
+++ b/packages/focus/src/model.ts
@@ -185,7 +185,7 @@ export interface OwnPrincipalAuthentication {
   readonly proof: unknown;
 }
 
-/** A normalized, issuer-scoped identity supplied by a trusted authentication boundary. */
+/** An exact canonical, issuer-scoped identity supplied by a trusted authentication boundary. */
 export interface CanonicalPrincipalIdentity {
   readonly issuer: string;
   readonly subject: string;
@@ -238,7 +238,7 @@ export interface PersistedOwnerSignature extends TrackOwnerSignatureWrite {
  */
 export interface OwnerSignatureIdentity {
   /**
-   * The normalized issuer+subject identity of the authenticated owner. This is the identity
+   * The exact canonical issuer+subject identity of the authenticated owner. This is the identity
    * used for the durable unique constraint, never a caller-supplied display identifier.
    */
   readonly ownerCanonicalIdentity: CanonicalPrincipalIdentity;

--- a/packages/focus/src/model.ts
+++ b/packages/focus/src/model.ts
@@ -173,6 +173,12 @@ export interface TrackNativeDecisionTarget {
   readonly decisionId: FocusRef;
 }
 
+/** The sole Track owner-signature contract accepted and emitted by this package. */
+export const FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION = "track-owner-signature/1.0.0" as const;
+
+/** A package-owned, closed contract version: callers cannot compose an arbitrary version. */
+export type FocusOwnerSignatureContractVersion = typeof FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION;
+
 /** Opaque proof that only an own-principal authentication adapter may verify. */
 export interface OwnPrincipalAuthentication {
   readonly kind: "own-principal";
@@ -206,7 +212,7 @@ export interface OwnerSignatureRequest {
 
 /** Exact, versioned write shape submitted to a Track owner-signature adapter. */
 export interface TrackOwnerSignatureWrite {
-  readonly contractVersion: string;
+  readonly contractVersion: FocusOwnerSignatureContractVersion;
   readonly target: TrackNativeDecisionTarget;
   readonly attestation: OwnerSignatureAttestation;
   readonly relayer: RelayerProvenance;
@@ -216,6 +222,15 @@ export interface TrackOwnerSignatureWrite {
 /** Persisted read-back record required before an owner signature may be reported. */
 export interface PersistedOwnerSignature extends TrackOwnerSignatureWrite {
   readonly recordId: string;
+}
+
+/**
+ * The atomic uniqueness identity for a persisted owner acceptance. One owner may attest to a
+ * given Track-native decision once, irrespective of transport retries or idempotency keys.
+ */
+export interface OwnerSignatureIdentity {
+  readonly ownerPrincipalId: string;
+  readonly target: TrackNativeDecisionTarget;
 }
 
 /** The Track adapter must say whether an idempotency replay created or reused a record. */

--- a/packages/focus/src/model.ts
+++ b/packages/focus/src/model.ts
@@ -232,8 +232,9 @@ export interface PersistedOwnerSignature extends TrackOwnerSignatureWrite {
 }
 
 /**
- * The atomic uniqueness identity for a persisted owner acceptance. One owner may attest to a
- * given Track-native decision once, irrespective of transport retries or idempotency keys.
+ * The atomic durable-uniqueness key for a persisted owner acceptance. One canonical owner may
+ * attest to a given Track-native decision once, irrespective of transport retries or
+ * idempotency keys.
  */
 export interface OwnerSignatureIdentity {
   /**
@@ -243,6 +244,12 @@ export interface OwnerSignatureIdentity {
   readonly ownerCanonicalIdentity: CanonicalPrincipalIdentity;
   readonly target: TrackNativeDecisionTarget;
 }
+
+/**
+ * The Track port's durable uniqueness key: canonical owner + workspace + decision id only.
+ * `idempotencyKey` deliberately does not belong to this key.
+ */
+export type OwnerSignatureDurableUniquenessKey = OwnerSignatureIdentity;
 
 /** The Track adapter must say whether an idempotency replay created or reused a record. */
 export type TrackOwnerSignatureWriteResult =

--- a/packages/focus/src/model.ts
+++ b/packages/focus/src/model.ts
@@ -166,3 +166,87 @@ export interface DecisionDossierDocument {
   readonly provenance: FocusProvenance;
   readonly amendmentTrace: readonly AmendmentStep[];
 }
+
+/** A Track-native decision location. h2a dossiers are intentionally not accepted here. */
+export interface TrackNativeDecisionTarget {
+  readonly workspace: string;
+  readonly decisionId: FocusRef;
+}
+
+/** Opaque proof that only an own-principal authentication adapter may verify. */
+export interface OwnPrincipalAuthentication {
+  readonly kind: "own-principal";
+  readonly proof: unknown;
+}
+
+/** The authenticated owner identity returned by the trusted own-principal adapter. */
+export interface AuthenticatedOwnPrincipal {
+  readonly principalId: string;
+  readonly authenticatedAt: string;
+}
+
+/** Transport provenance is a relayer record, never the owner attester. */
+export interface RelayerProvenance {
+  readonly transport: "cli" | "http" | "mcp-stdio" | "internal";
+  readonly relayerId: string;
+}
+
+/** The authenticated owner act that the Track signature contract must persist. */
+export interface OwnerSignatureAttestation {
+  readonly attester: AuthenticatedOwnPrincipal;
+}
+
+/** A request to accept one existing Track-native decision. */
+export interface OwnerSignatureRequest {
+  readonly target: TrackNativeDecisionTarget;
+  readonly authentication: OwnPrincipalAuthentication;
+  readonly relayer: RelayerProvenance;
+  readonly idempotencyKey: string;
+}
+
+/** Exact, versioned write shape submitted to a Track owner-signature adapter. */
+export interface TrackOwnerSignatureWrite {
+  readonly contractVersion: string;
+  readonly target: TrackNativeDecisionTarget;
+  readonly attestation: OwnerSignatureAttestation;
+  readonly relayer: RelayerProvenance;
+  readonly idempotencyKey: string;
+}
+
+/** Persisted read-back record required before an owner signature may be reported. */
+export interface PersistedOwnerSignature extends TrackOwnerSignatureWrite {
+  readonly recordId: string;
+}
+
+/** The Track adapter must say whether an idempotency replay created or reused a record. */
+export type TrackOwnerSignatureWriteResult =
+  | { readonly status: "written"; readonly recordId: string }
+  | { readonly status: "duplicate"; readonly recordId: string };
+
+/** Explicit honest-not-done outcomes; none represent an owner signature. */
+export type OwnerSignatureNotDoneReason =
+  | "invalid-signature-request"
+  | "owner-authentication-required"
+  | "owner-authentication-invalid"
+  | "authorization-denied"
+  | "attester-relayer-conflict"
+  | "track-contract-mismatch"
+  | "track-write-failed"
+  | "persisted-attestation-not-confirmed";
+
+/** A live attempt either returns verified persisted evidence or an honest not-done result. */
+export type OwnerSignatureResult =
+  | {
+      readonly status: "signed";
+      readonly duplicate: boolean;
+      readonly persisted: PersistedOwnerSignature;
+    }
+  | {
+      readonly status: "not-done";
+      readonly reason: OwnerSignatureNotDoneReason;
+    };
+
+/** The live write surface; a snapshot never implements this contract. */
+export interface FocusLiveSession {
+  sign(request: OwnerSignatureRequest): Promise<OwnerSignatureResult>;
+}

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -117,10 +117,12 @@ const expectNoIngest = async (
 };
 
 /**
- * Production-like test adapter: both writers cross the barrier, then one synchronous section
- * models a database unique constraint/upsert on canonical owner + workspace + decision only.
+ * In-memory race test double: both writers observe the uniqueness gap before the barrier, then
+ * an insert constraint returns `duplicate` to the loser. This tests the driver's response to a
+ * constraint rejection; a Map cannot prove durable exactly-once behavior. Only the co-specified
+ * production Track adapter, with its durable constraint/upsert, proves that property before live use.
  */
-class BarrierSynchronizedDurableAtomicTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
+class BarrierAsyncConstraintTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
   readonly contractVersion = FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION;
 
   private readonly records = new Map<string, PersistedOwnerSignature>();
@@ -142,17 +144,26 @@ class BarrierSynchronizedDurableAtomicTrackOwnerSignaturePort implements TrackOw
 
   async appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult> {
     this.appendAttempts += 1;
+    const key = this.key(input.attestation.attester.canonicalIdentity, input.target);
+    const observed = this.records.get(key);
     this.waiting += 1;
     if (this.waiting === 2) this.releaseBarrier?.();
     await this.barrier;
 
-    const key = this.key(input.attestation.attester.canonicalIdentity, input.target);
+    if (observed !== undefined) {
+      this.receiptStatuses.push("duplicate");
+      return { status: "duplicate", recordId: observed.recordId };
+    }
+
+    return this.insertWithConstraint(input, key);
+  }
+
+  private insertWithConstraint(input: TrackOwnerSignatureWrite, key: string): TrackOwnerSignatureWriteResult {
     const existing = this.records.get(key);
     if (existing !== undefined) {
       this.receiptStatuses.push("duplicate");
       return { status: "duplicate", recordId: existing.recordId };
     }
-
     const persisted = persistedFromWrite(input, `racy-owner-signature-${this.appendAttempts}`);
     this.records.set(key, persisted);
     this.receiptStatuses.push("written");
@@ -913,9 +924,9 @@ describe("FocusLiveSession owner-signature gate", () => {
     });
   });
 
-  it("returns one duplicate from a barrier-synchronized durable atomic owner-decision write", async () => {
-    const atomicPort = new BarrierSynchronizedDurableAtomicTrackOwnerSignaturePort();
-    const live = makeLive(atomicPort);
+  it("returns one duplicate when an async barrier race reaches the insert constraint", async () => {
+    const constrainedPort = new BarrierAsyncConstraintTrackOwnerSignaturePort();
+    const live = makeLive(constrainedPort);
     const [first, second] = await Promise.all([
       live.sign({ ...REQUEST, idempotencyKey: "race-key-one" }),
       live.sign({ ...REQUEST, idempotencyKey: "race-key-two" }),
@@ -923,13 +934,13 @@ describe("FocusLiveSession owner-signature gate", () => {
 
     expect([first, second].filter((result) => result.status === "signed" && !result.duplicate)).toHaveLength(1);
     expect([first, second].filter((result) => result.status === "signed" && result.duplicate)).toHaveLength(1);
-    expect(atomicPort.appendAttempts).toBe(2);
-    expect(atomicPort.recordCount).toBe(1);
-    expect(atomicPort.receiptStatuses.filter((status) => status === "written")).toHaveLength(1);
-    expect(atomicPort.receiptStatuses.filter((status) => status === "duplicate")).toHaveLength(1);
+    expect(constrainedPort.appendAttempts).toBe(2);
+    expect(constrainedPort.recordCount).toBe(1);
+    expect(constrainedPort.receiptStatuses.filter((status) => status === "written")).toHaveLength(1);
+    expect(constrainedPort.receiptStatuses.filter((status) => status === "duplicate")).toHaveLength(1);
   });
 
-  it("uses the test-only adapter's synchronous atomic owner-decision uniqueness for same-key replay", async () => {
+  it("returns a duplicate for a sequentially observed same-key replay in the test-only adapter", async () => {
     const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     const live = makeLive(store);
     const [first, second] = await Promise.all([live.sign(REQUEST), live.sign(REQUEST)]);

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "vitest";
+
+import { FocusLiveSessionDriver } from "../src/index.js";
+import type {
+  AuthenticatedOwnPrincipal,
+  OwnerSignatureRequest,
+  PersistedOwnerSignature,
+  TrackOwnerSignaturePort,
+  TrackOwnerSignatureWrite,
+} from "../src/index.js";
+
+const CONTRACT = "track-owner-signature/1.0.0";
+const OWNER: AuthenticatedOwnPrincipal = {
+  principalId: "owner-verified",
+  authenticatedAt: "2026-08-08T12:00:00.000Z",
+};
+const REQUEST: OwnerSignatureRequest = {
+  target: { workspace: "focus", decisionId: "decision-track-native" },
+  authentication: { kind: "own-principal", proof: { session: "verified" } },
+  relayer: { transport: "http", relayerId: "signature-gateway" },
+  idempotencyKey: "focus-signature:decision-track-native:owner-verified",
+};
+
+const keyOf = (input: { target: OwnerSignatureRequest["target"]; idempotencyKey: string }): string =>
+  `${input.target.workspace}:${input.target.decisionId}:${input.idempotencyKey}`;
+
+function makeTrack(options: { contractVersion?: string; readError?: Error } = {}) {
+  const records = new Map<string, PersistedOwnerSignature>();
+  let writes = 0;
+  const track: TrackOwnerSignaturePort = {
+    contractVersion: options.contractVersion ?? CONTRACT,
+    async appendOwnerSignature(write: TrackOwnerSignatureWrite) {
+      writes += 1;
+      const key = keyOf(write);
+      const existing = records.get(key);
+      if (existing !== undefined) return { status: "duplicate", recordId: existing.recordId } as const;
+      const persisted = { ...write, recordId: `signature-${records.size + 1}` };
+      records.set(key, persisted);
+      return { status: "written", recordId: persisted.recordId } as const;
+    },
+    async readOwnerSignature(input) {
+      if (options.readError !== undefined) throw options.readError;
+      return records.get(keyOf(input));
+    },
+  };
+  return { track, records, writeCount: () => writes };
+}
+
+function makeLive(
+  track: TrackOwnerSignaturePort,
+  owner: AuthenticatedOwnPrincipal | null = OWNER,
+  authorize: (request: OwnerSignatureRequest) => boolean = () => true,
+) {
+  return new FocusLiveSessionDriver({
+    ownPrincipal: { authenticate: async () => owner ?? undefined },
+    authorizer: { authorize: async ({ target }) => authorize({ ...REQUEST, target }) },
+    track,
+    expectedTrackContractVersion: CONTRACT,
+  });
+}
+
+describe("FocusLiveSession owner-signature gate", () => {
+  it("returns not-done and does not write when own-principal authentication is required", async () => {
+    const store = makeTrack();
+    const result = await makeLive(store.track, null).sign(REQUEST);
+
+    expect(result).toEqual({ status: "not-done", reason: "owner-authentication-required" });
+    expect(store.writeCount()).toBe(0);
+  });
+
+  it("records the authenticated owner as attester and rejects an identity-colliding relayer", async () => {
+    const store = makeTrack();
+    const signed = await makeLive(store.track).sign({
+      ...REQUEST,
+      relayer: { transport: "http", relayerId: "relayer-claiming-owner" },
+    });
+
+    expect(signed.status).toBe("signed");
+    if (signed.status === "signed") {
+      expect(signed.persisted.attestation.attester.principalId).toBe(OWNER.principalId);
+      expect(signed.persisted.relayer.relayerId).toBe("relayer-claiming-owner");
+    }
+    const forged = await makeLive(store.track).sign({
+      ...REQUEST,
+      idempotencyKey: "different-key",
+      relayer: { transport: "http", relayerId: OWNER.principalId },
+    });
+    expect(forged).toEqual({ status: "not-done", reason: "attester-relayer-conflict" });
+  });
+
+  it("persists one record and reports duplicate on idempotent double-submit", async () => {
+    const store = makeTrack();
+    const live = makeLive(store.track);
+
+    const first = await live.sign(REQUEST);
+    const second = await live.sign(REQUEST);
+
+    expect(first.status).toBe("signed");
+    expect(second).toMatchObject({ status: "signed", duplicate: true });
+    expect(store.records).toHaveLength(1);
+    expect(store.writeCount()).toBe(2);
+  });
+
+  it("returns not-done after a successful write whose persisted read-back fails", async () => {
+    const store = makeTrack({ readError: new Error("read unavailable") });
+    const result = await makeLive(store.track).sign(REQUEST);
+
+    expect(result).toEqual({ status: "not-done", reason: "persisted-attestation-not-confirmed" });
+    expect(store.records).toHaveLength(1);
+  });
+
+  it.each([
+    ["workspace", { ...REQUEST, target: { ...REQUEST.target, workspace: "other-workspace" } }],
+    ["decision", { ...REQUEST, target: { ...REQUEST.target, decisionId: "other-decision" } }],
+  ])("denies an unauthorized %s before Track ingest", async (_scope, request) => {
+    const store = makeTrack();
+    const result = await makeLive(
+      store.track,
+      OWNER,
+      (candidate) => candidate.target.workspace === REQUEST.target.workspace && candidate.target.decisionId === REQUEST.target.decisionId,
+    ).sign(request);
+
+    expect(result).toEqual({ status: "not-done", reason: "authorization-denied" });
+    expect(store.writeCount()).toBe(0);
+  });
+
+  it("returns not-done when the supplied Track signature contract is not the pinned version", async () => {
+    const store = makeTrack({ contractVersion: "track-owner-signature/2.0.0" });
+    const result = await makeLive(store.track).sign(REQUEST);
+
+    expect(result).toEqual({ status: "not-done", reason: "track-contract-mismatch" });
+    expect(store.writeCount()).toBe(0);
+  });
+});

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -657,6 +657,34 @@ describe("FocusLiveSession owner-signature gate", () => {
     expect(store.recordCount).toBe(0);
   });
 
+  it("rejects a hostile proof proxy from a single structural snapshot before authentication", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    let prototypeReads = 0;
+    let ownKeysReads = 0;
+    const proof = new Proxy(
+      { session: "verified" },
+      {
+        getPrototypeOf() {
+          prototypeReads += 1;
+          return prototypeReads === 1 ? Date.prototype : Object.prototype;
+        },
+        ownKeys() {
+          ownKeysReads += 1;
+          return ownKeysReads === 1 ? ["session"] : ["other"];
+        },
+      },
+    );
+
+    await expectNoIngest(
+      makeLive(store),
+      store,
+      { ...REQUEST, authentication: { kind: "own-principal", proof } },
+      "invalid-signature-request",
+    );
+    expect(prototypeReads).toBe(1);
+    expect(ownKeysReads).toBe(1);
+  });
+
   it("captures a getter-backed request field once, so its changed second value cannot enter the signed write", async () => {
     const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     let idempotencyKeyReads = 0;
@@ -707,6 +735,42 @@ describe("FocusLiveSession owner-signature gate", () => {
     });
     expect(statusReads).toBe(1);
     expect(recordIdReads).toBe(1);
+  });
+
+  it("does not ingest when the relayer provenance port rejects", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+
+    await expectNoIngest(
+      makeLive(store, {
+        getRelayerProvenance: async () => {
+          throw new Error("relayer provenance unavailable");
+        },
+      }),
+      store,
+      REQUEST,
+      "relayer-provenance-invalid",
+    );
+  });
+
+  it("returns not-done when the persisted read port rejects after a write", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    let readCalls = 0;
+    const track: TrackOwnerSignaturePort = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      appendOwnerSignature: (input) => store.appendOwnerSignature(input),
+      async readOwnerSignature() {
+        readCalls += 1;
+        throw new Error("persisted read unavailable");
+      },
+    };
+
+    await expect(makeLive(track).sign(REQUEST)).resolves.toEqual({
+      status: "not-done",
+      reason: "persisted-attestation-not-confirmed",
+    });
+    expect(readCalls).toBe(1);
+    expect(store.appendAttempts).toBe(1);
+    expect(store.recordCount).toBe(1);
   });
 
   it("gives the port immutable request, owner, and trusted relayer copies", async () => {

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -355,6 +355,101 @@ describe("FocusLiveSession owner-signature gate", () => {
     );
   });
 
+  it.each([
+    [
+      "request target",
+      () =>
+        ({
+          get target() {
+            throw new Error("request target unavailable");
+          },
+          authentication: REQUEST.authentication,
+          idempotencyKey: REQUEST.idempotencyKey,
+        }) as OwnerSignatureRequest,
+    ],
+    [
+      "target workspace",
+      () =>
+        ({
+          target: {
+            get workspace() {
+              throw new Error("workspace unavailable");
+            },
+            decisionId: REQUEST.target.decisionId,
+          } as TrackNativeDecisionTarget,
+          authentication: REQUEST.authentication,
+          idempotencyKey: REQUEST.idempotencyKey,
+        }) as OwnerSignatureRequest,
+    ],
+    [
+      "target decision id",
+      () =>
+        ({
+          target: {
+            workspace: REQUEST.target.workspace,
+            get decisionId() {
+              throw new Error("decision unavailable");
+            },
+          } as TrackNativeDecisionTarget,
+          authentication: REQUEST.authentication,
+          idempotencyKey: REQUEST.idempotencyKey,
+        }) as OwnerSignatureRequest,
+    ],
+    [
+      "authentication",
+      () =>
+        ({
+          target: REQUEST.target,
+          get authentication() {
+            throw new Error("authentication unavailable");
+          },
+          idempotencyKey: REQUEST.idempotencyKey,
+        }) as OwnerSignatureRequest,
+    ],
+    [
+      "authentication kind",
+      () =>
+        ({
+          target: REQUEST.target,
+          authentication: {
+            get kind() {
+              throw new Error("authentication kind unavailable");
+            },
+            proof: REQUEST.authentication.proof,
+          } as OwnerSignatureRequest["authentication"],
+          idempotencyKey: REQUEST.idempotencyKey,
+        }) as OwnerSignatureRequest,
+    ],
+    [
+      "authentication proof",
+      () =>
+        ({
+          target: REQUEST.target,
+          authentication: {
+            kind: "own-principal",
+            get proof() {
+              throw new Error("authentication proof unavailable");
+            },
+          } as OwnerSignatureRequest["authentication"],
+          idempotencyKey: REQUEST.idempotencyKey,
+        }) as OwnerSignatureRequest,
+    ],
+    [
+      "idempotency key",
+      () =>
+        ({
+          target: REQUEST.target,
+          authentication: REQUEST.authentication,
+          get idempotencyKey() {
+            throw new Error("idempotency key unavailable");
+          },
+        }) as OwnerSignatureRequest,
+    ],
+  ])("fails closed without ingest when the %s accessor throws", async (_label, requestFactory) => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(store), store, requestFactory(), "invalid-signature-request");
+  });
+
   it("captures a getter-backed request field once, so its changed second value cannot enter the signed write", async () => {
     const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     let idempotencyKeyReads = 0;

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -551,6 +551,112 @@ describe("FocusLiveSession owner-signature gate", () => {
     await expectNoIngest(makeLive(track), store, REQUEST, "track-write-failed");
   });
 
+  it.each([
+    [
+      "status",
+      {
+        get status() {
+          throw new Error("receipt status unavailable");
+        },
+        recordId: "throwing-receipt",
+      },
+    ],
+    [
+      "record id",
+      {
+        status: "written",
+        get recordId() {
+          throw new Error("receipt record unavailable");
+        },
+      },
+    ],
+  ])("returns track-write-failed when receipt %s access throws", async (_label, receipt) => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    let appendCalls = 0;
+    let readCalls = 0;
+    const track: TrackOwnerSignaturePort = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      async appendOwnerSignature() {
+        appendCalls += 1;
+        return receipt as TrackOwnerSignatureWriteResult;
+      },
+      async readOwnerSignature(identity) {
+        readCalls += 1;
+        return store.readOwnerSignature(identity);
+      },
+    };
+
+    await expect(makeLive(track).sign(REQUEST)).resolves.toEqual({ status: "not-done", reason: "track-write-failed" });
+    expect(appendCalls).toBe(1);
+    expect(readCalls).toBe(0);
+    expect(store.recordCount).toBe(0);
+  });
+
+  it.each([
+    ["record id", (record: PersistedOwnerSignature) => asPersisted({ ...record, get recordId() { throw new Error("record unavailable"); } })],
+    ["target workspace", (record: PersistedOwnerSignature) => asPersisted({ ...record, target: { get workspace() { throw new Error("workspace unavailable"); }, decisionId: record.target.decisionId } })],
+    ["attester principal", (record: PersistedOwnerSignature) => asPersisted({ ...record, attestation: { attester: { ...record.attestation.attester, get principalId() { throw new Error("owner unavailable"); } } } })],
+    ["relayer transport", (record: PersistedOwnerSignature) => asPersisted({ ...record, relayer: { ...record.relayer, get transport() { throw new Error("transport unavailable"); } } })],
+    ["idempotency key", (record: PersistedOwnerSignature) => asPersisted({ ...record, get idempotencyKey() { throw new Error("idempotency unavailable"); } })],
+  ])("returns persisted-attestation-not-confirmed when persisted %s access throws", async (_label, change) => {
+    let write: TrackOwnerSignatureWrite | undefined;
+    let appendCalls = 0;
+    let readCalls = 0;
+    const track: TrackOwnerSignaturePort = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      async appendOwnerSignature(input) {
+        appendCalls += 1;
+        write = input;
+        return { status: "written", recordId: "throwing-persisted" };
+      },
+      async readOwnerSignature() {
+        readCalls += 1;
+        if (write === undefined) throw new Error("expected append before read");
+        return change(persistedFromWrite(write, "throwing-persisted"));
+      },
+    };
+
+    await expect(makeLive(track).sign(REQUEST)).resolves.toEqual({
+      status: "not-done",
+      reason: "persisted-attestation-not-confirmed",
+    });
+    expect(appendCalls).toBe(1);
+    expect(readCalls).toBe(1);
+  });
+
+  it("does not authenticate a caller-mutated proof referent after the call boundary", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    const proof = { session: "invalid" };
+    let startAuthentication: (() => void) | undefined;
+    let resumeAuthentication: (() => void) | undefined;
+    let capturedProof: unknown;
+    const authenticationStarted = new Promise<void>((resolve) => {
+      startAuthentication = resolve;
+    });
+    const authenticationResumed = new Promise<void>((resolve) => {
+      resumeAuthentication = resolve;
+    });
+    const live = makeLive(store, {
+      authenticate: async (input) => {
+        capturedProof = input.authentication.proof;
+        startAuthentication?.();
+        await authenticationResumed;
+        return (input.authentication.proof as { readonly session: string }).session === "valid" ? OWNER : undefined;
+      },
+    });
+
+    const pending = live.sign({ ...REQUEST, authentication: { kind: "own-principal", proof } });
+    await authenticationStarted;
+    proof.session = "valid";
+    resumeAuthentication?.();
+
+    await expect(pending).resolves.toEqual({ status: "not-done", reason: "owner-authentication-required" });
+    expect(capturedProof).not.toBe(proof);
+    expect(Object.isFrozen(capturedProof)).toBe(true);
+    expect(store.appendAttempts).toBe(0);
+    expect(store.recordCount).toBe(0);
+  });
+
   it("captures a getter-backed request field once, so its changed second value cannot enter the signed write", async () => {
     const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     let idempotencyKeyReads = 0;

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -11,6 +11,7 @@ import type {
   PersistedOwnerSignature,
   TrackNativeDecisionTarget,
   TrackOwnerSignaturePort,
+  TrackOwnerSignatureWrite,
   TrackOwnerSignatureWriteResult,
 } from "../src/index.js";
 
@@ -180,6 +181,76 @@ describe("FocusLiveSession owner-signature gate", () => {
       readOwnerSignature: (identity) => contractStore.readOwnerSignature(identity),
     };
     await expectNoIngest(makeLive(wrongContract), contractStore, REQUEST, "track-contract-mismatch");
+  });
+
+  it("snapshots caller values and gives the port a separate deeply frozen copy", async () => {
+    const store = new InMemoryTrackOwnerSignaturePort();
+    let authorizedTarget: TrackNativeDecisionTarget | undefined;
+    let submitted: TrackOwnerSignatureWrite | undefined;
+    let mutationRejected = false;
+    const track: TrackOwnerSignaturePort = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      appendOwnerSignature(input) {
+        submitted = input;
+        try {
+          (input.target as { workspace: string }).workspace = "port-mutated";
+        } catch {
+          mutationRejected = true;
+        }
+        return store.appendOwnerSignature(input);
+      },
+      readOwnerSignature: (identity) => store.readOwnerSignature(identity),
+    };
+    const live = makeLive(track, {
+      authorize: ({ target }) => {
+        authorizedTarget = target;
+        return true;
+      },
+    });
+    const mutableRequest: {
+      target: { workspace: string; decisionId: string };
+      authentication: OwnerSignatureRequest["authentication"];
+      relayer: { transport: OwnerSignatureRequest["relayer"]["transport"]; relayerId: string };
+      idempotencyKey: string;
+    } = {
+      target: { ...REQUEST.target },
+      authentication: REQUEST.authentication,
+      relayer: { ...REQUEST.relayer },
+      idempotencyKey: REQUEST.idempotencyKey,
+    };
+
+    const pending = live.sign(mutableRequest);
+    mutableRequest.target.workspace = "caller-mutated";
+    mutableRequest.relayer.relayerId = "caller-mutated";
+    mutableRequest.idempotencyKey = "caller-mutated";
+    const result = await pending;
+
+    expect(result.status).toBe("signed");
+    expect(mutationRejected).toBe(true);
+    expect(submitted).toBeDefined();
+    if (submitted === undefined || authorizedTarget === undefined) throw new Error("expected captured port boundaries");
+    expect(Object.isFrozen(submitted.target)).toBe(true);
+    expect(Object.isFrozen(submitted.attestation)).toBe(true);
+    expect(Object.isFrozen(submitted.attestation.attester)).toBe(true);
+    expect(Object.isFrozen(submitted.relayer)).toBe(true);
+    expect(Object.isFrozen(authorizedTarget)).toBe(true);
+    expect(submitted.target).not.toBe(authorizedTarget);
+    expect(result).toMatchObject({
+      status: "signed",
+      persisted: { target: REQUEST.target, relayer: REQUEST.relayer, idempotencyKey: REQUEST.idempotencyKey },
+    });
+  });
+
+  it("uses the reference adapter's atomic owner-decision uniqueness for concurrent double-submit", async () => {
+    const store = new InMemoryTrackOwnerSignaturePort();
+    const live = makeLive(store);
+    const [first, second] = await Promise.all([live.sign(REQUEST), live.sign(REQUEST)]);
+
+    expect(first).toMatchObject({ status: "signed" });
+    expect(second).toMatchObject({ status: "signed" });
+    expect([first, second].filter((result) => result.status === "signed" && result.duplicate)).toHaveLength(1);
+    expect(store.appendAttempts).toBe(2);
+    expect(store.recordCount).toBe(1);
   });
 
 });

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -9,7 +9,9 @@ import type {
   AuthenticatedOwnPrincipal,
   OwnerSignatureRequest,
   PersistedOwnerSignature,
+  TrackNativeDecisionTarget,
   TrackOwnerSignaturePort,
+  TrackOwnerSignatureWriteResult,
 } from "../src/index.js";
 
 const OWNER: AuthenticatedOwnPrincipal = {
@@ -62,6 +64,17 @@ const makeWrongReadBackPort = (
   return { store, track };
 };
 
+const expectNoIngest = async (
+  live: FocusLiveSessionDriver,
+  store: InMemoryTrackOwnerSignaturePort,
+  request: OwnerSignatureRequest,
+  reason: string,
+) => {
+  await expect(live.sign(request)).resolves.toEqual({ status: "not-done", reason });
+  expect(store.appendAttempts).toBe(0);
+  expect(store.recordCount).toBe(0);
+};
+
 describe("FocusLiveSession owner-signature gate", () => {
   it("records the authenticated owner as attester and retains distinct relayer provenance", async () => {
     const store = new InMemoryTrackOwnerSignaturePort();
@@ -105,6 +118,68 @@ describe("FocusLiveSession owner-signature gate", () => {
       reason: "persisted-attestation-not-confirmed",
     });
     expect(store.recordCount).toBe(1);
+  });
+
+  it.each([
+    ["undefined receipt", undefined],
+    ["failed receipt", { status: "failed", recordId: "not-a-success" }],
+    ["blank record id", { status: "written", recordId: "   " }],
+    ["missing record id", { status: "duplicate" }],
+  ])("rejects a runtime-invalid %s without reading or persisting", async (_label, receipt) => {
+    const store = new InMemoryTrackOwnerSignaturePort();
+    let appendCalls = 0;
+    let readCalls = 0;
+    const track = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      async appendOwnerSignature(): Promise<TrackOwnerSignatureWriteResult> {
+        appendCalls += 1;
+        return receipt as TrackOwnerSignatureWriteResult;
+      },
+      async readOwnerSignature(identity: Parameters<TrackOwnerSignaturePort["readOwnerSignature"]>[0]) {
+        readCalls += 1;
+        return store.readOwnerSignature(identity);
+      },
+    } as TrackOwnerSignaturePort;
+
+    await expect(makeLive(track).sign(REQUEST)).resolves.toEqual({ status: "not-done", reason: "track-write-failed" });
+    expect(appendCalls).toBe(1);
+    expect(readCalls).toBe(0);
+    expect(store.appendAttempts).toBe(0);
+    expect(store.recordCount).toBe(0);
+  });
+
+  it("does not ingest for every pre-ingest denial", async () => {
+    const invalidRequest = { ...REQUEST, idempotencyKey: " " };
+    const relayerCollision = { ...REQUEST, relayer: { ...REQUEST.relayer, relayerId: OWNER.principalId } };
+
+    const invalid = new InMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(invalid), invalid, invalidRequest, "invalid-signature-request");
+
+    const authenticationRequired = new InMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(authenticationRequired, { owner: null }), authenticationRequired, REQUEST, "owner-authentication-required");
+
+    const authenticationInvalid = new InMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(authenticationInvalid, { owner: { ...OWNER, principalId: "" } }), authenticationInvalid, REQUEST, "owner-authentication-invalid");
+
+    const authenticationRejected = new InMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(authenticationRejected, { authenticate: async () => { throw new Error("rejected"); } }), authenticationRejected, REQUEST, "owner-authentication-invalid");
+
+    const collision = new InMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(collision), collision, relayerCollision, "attester-relayer-conflict");
+
+    const authorizationRejected = new InMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(authorizationRejected, { authorize: () => false }), authorizationRejected, REQUEST, "authorization-denied");
+
+    const authorizationError = new InMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(makeLive(authorizationError, { authorize: () => { throw new Error("denied"); } }), authorizationError, REQUEST, "authorization-denied");
+
+    const contractStore = new InMemoryTrackOwnerSignaturePort();
+    const wrongContract: TrackOwnerSignaturePort = {
+      contractVersion: "track-owner-signature/2.0.0" as never,
+      appendOwnerSignature: (input) => contractStore.appendOwnerSignature(input),
+      readOwnerSignature: (identity) => contractStore.readOwnerSignature(identity),
+    };
+    await expectNoIngest(makeLive(wrongContract), contractStore, REQUEST, "track-contract-mismatch");
   });
 
 });

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -450,6 +450,107 @@ describe("FocusLiveSession owner-signature gate", () => {
     await expectNoIngest(makeLive(store), store, requestFactory(), "invalid-signature-request");
   });
 
+  it.each([
+    [
+      "principal id",
+      {
+        get principalId() {
+          throw new Error("principal unavailable");
+        },
+        authenticatedAt: OWNER.authenticatedAt,
+        canonicalIdentity: OWNER.canonicalIdentity,
+      },
+    ],
+    [
+      "authentication time",
+      {
+        principalId: OWNER.principalId,
+        get authenticatedAt() {
+          throw new Error("authentication time unavailable");
+        },
+        canonicalIdentity: OWNER.canonicalIdentity,
+      },
+    ],
+    [
+      "canonical identity",
+      {
+        principalId: OWNER.principalId,
+        authenticatedAt: OWNER.authenticatedAt,
+        canonicalIdentity: {
+          get issuer() {
+            throw new Error("owner issuer unavailable");
+          },
+          subject: OWNER.canonicalIdentity.subject,
+        },
+      },
+    ],
+  ])("fails closed without ingest when authenticated-owner %s access throws", async (_label, owner) => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(
+      makeLive(store, { authenticate: () => owner }),
+      store,
+      REQUEST,
+      "owner-authentication-invalid",
+    );
+  });
+
+  it.each([
+    [
+      "transport",
+      {
+        get transport() {
+          throw new Error("relayer transport unavailable");
+        },
+        relayerId: RELAYER.relayerId,
+        canonicalIdentity: RELAYER.canonicalIdentity,
+      },
+    ],
+    [
+      "relayer id",
+      {
+        transport: RELAYER.transport,
+        get relayerId() {
+          throw new Error("relayer id unavailable");
+        },
+        canonicalIdentity: RELAYER.canonicalIdentity,
+      },
+    ],
+    [
+      "canonical identity",
+      {
+        transport: RELAYER.transport,
+        relayerId: RELAYER.relayerId,
+        canonicalIdentity: {
+          issuer: RELAYER.canonicalIdentity.issuer,
+          get subject() {
+            throw new Error("relayer subject unavailable");
+          },
+        },
+      },
+    ],
+  ])("fails closed without ingest when relayer %s access throws", async (_label, relayer) => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(
+      makeLive(store, { getRelayerProvenance: () => relayer }),
+      store,
+      REQUEST,
+      "relayer-provenance-invalid",
+    );
+  });
+
+  it("fails closed without ingest when the Track contract version accessor throws", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    const track: TrackOwnerSignaturePort = {
+      get contractVersion() {
+        throw new Error("Track contract unavailable");
+      },
+      appendOwnerSignature: (input) => store.appendOwnerSignature(input),
+      readOwnerSignature: (identity) => store.readOwnerSignature(identity),
+    };
+
+    await expectNoIngest(makeLive(track), store, REQUEST, "track-write-failed");
+  });
+
   it("captures a getter-backed request field once, so its changed second value cannot enter the signed write", async () => {
     const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     let idempotencyKeyReads = 0;

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -762,12 +762,12 @@ describe("FocusLiveSession owner-signature gate", () => {
     });
   });
 
-  it("rejects an owner-relayer canonical collision before authorization or append", async () => {
+  it("rejects an owner-relayer exact canonical collision before authorization or append", async () => {
     const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     let authorizationCalls = 0;
     const collidingOwner: AuthenticatedOwnPrincipal = {
       ...OWNER,
-      canonicalIdentity: { issuer: "HTTPS://AUTH.EXAMPLE", subject: "RELAY@EXAMPLE.COM" },
+      canonicalIdentity: { issuer: "https://auth.example", subject: "relay@example.com" },
     };
     const collidingRelayer: RelayerProvenance = {
       ...RELAYER,
@@ -786,6 +786,48 @@ describe("FocusLiveSession owner-signature gate", () => {
     ).resolves.toEqual({ status: "not-done", reason: "attester-relayer-conflict" });
     expect(authorizationCalls).toBe(0);
     expect(store.appendAttempts).toBe(0);
+  });
+
+  it("keeps case-sensitive canonical identities distinct for authorization and durable uniqueness", async () => {
+    const upperCaseIdentity: AuthenticatedOwnPrincipal = {
+      ...OWNER,
+      canonicalIdentity: { issuer: "https://idp.example/Realm", subject: "Owner-A" },
+    };
+    const lowerCaseIdentity: AuthenticatedOwnPrincipal = {
+      ...OWNER,
+      canonicalIdentity: { issuer: "https://idp.example/realm", subject: "owner-a" },
+    };
+    const authorizationStore = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    let authorizedOwner: AuthenticatedOwnPrincipal | undefined;
+
+    await expect(
+      makeLive(authorizationStore, {
+        authenticate: () => upperCaseIdentity,
+        authorize: ({ owner }) => {
+          authorizedOwner = owner;
+          return (
+            owner.canonicalIdentity.issuer === lowerCaseIdentity.canonicalIdentity.issuer &&
+            owner.canonicalIdentity.subject === lowerCaseIdentity.canonicalIdentity.subject
+          );
+        },
+      }).sign(REQUEST),
+    ).resolves.toEqual({ status: "not-done", reason: "authorization-denied" });
+    expect(authorizedOwner?.canonicalIdentity).toEqual(upperCaseIdentity.canonicalIdentity);
+    expect(authorizationStore.recordCount).toBe(0);
+
+    const uniquenessStore = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    const upperCaseResult = await makeLive(uniquenessStore, { authenticate: () => upperCaseIdentity }).sign({
+      ...REQUEST,
+      idempotencyKey: "case-sensitive-upper",
+    });
+    const lowerCaseResult = await makeLive(uniquenessStore, { authenticate: () => lowerCaseIdentity }).sign({
+      ...REQUEST,
+      idempotencyKey: "case-sensitive-lower",
+    });
+
+    expect(upperCaseResult).toMatchObject({ status: "signed", duplicate: false });
+    expect(lowerCaseResult).toMatchObject({ status: "signed", duplicate: false });
+    expect(uniquenessStore.recordCount).toBe(2);
   });
 
   it("cannot let caller-asserted relayer text replace the authenticated owner attester", async () => {

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -116,7 +116,11 @@ const expectNoIngest = async (
   expect(store.readAttempts).toBe(0);
 };
 
-class BarrierRacingTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
+/**
+ * Production-like test adapter: both writers cross the barrier, then one synchronous section
+ * models a database unique constraint/upsert on canonical owner + workspace + decision only.
+ */
+class BarrierSynchronizedDurableAtomicTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
   readonly contractVersion = FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION;
 
   private readonly records = new Map<string, PersistedOwnerSignature>();
@@ -124,6 +128,7 @@ class BarrierRacingTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
   private releaseBarrier: (() => void) | undefined;
   private waiting = 0;
   appendAttempts = 0;
+  readonly receiptStatuses: TrackOwnerSignatureWriteResult["status"][] = [];
 
   constructor() {
     this.barrier = new Promise((resolve) => {
@@ -137,28 +142,29 @@ class BarrierRacingTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
 
   async appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult> {
     this.appendAttempts += 1;
-    const key = this.key(input.attestation.attester.canonicalIdentity, input.target, input.idempotencyKey);
-    if (this.records.has(key)) return { status: "duplicate", recordId: this.records.get(key)!.recordId };
-
     this.waiting += 1;
     if (this.waiting === 2) this.releaseBarrier?.();
     await this.barrier;
 
+    const key = this.key(input.attestation.attester.canonicalIdentity, input.target);
+    const existing = this.records.get(key);
+    if (existing !== undefined) {
+      this.receiptStatuses.push("duplicate");
+      return { status: "duplicate", recordId: existing.recordId };
+    }
+
     const persisted = persistedFromWrite(input, `racy-owner-signature-${this.appendAttempts}`);
     this.records.set(key, persisted);
+    this.receiptStatuses.push("written");
     return { status: "written", recordId: persisted.recordId };
   }
 
   readOwnerSignature(input: Parameters<TrackOwnerSignaturePort["readOwnerSignature"]>[0]) {
-    return Promise.resolve(this.records.get(this.key(input.ownerCanonicalIdentity, input.target, input.idempotencyKey)));
+    return Promise.resolve(this.records.get(this.key(input.ownerCanonicalIdentity, input.target)));
   }
 
-  private key(
-    owner: AuthenticatedOwnPrincipal["canonicalIdentity"],
-    target: TrackNativeDecisionTarget,
-    idempotencyKey: string,
-  ): string {
-    return `${owner.issuer}\u0000${owner.subject}\u0000${target.workspace}\u0000${target.decisionId}\u0000${idempotencyKey}`;
+  private key(owner: AuthenticatedOwnPrincipal["canonicalIdentity"], target: TrackNativeDecisionTarget): string {
+    return `${owner.issuer}\u0000${owner.subject}\u0000${target.workspace}\u0000${target.decisionId}`;
   }
 }
 
@@ -499,18 +505,20 @@ describe("FocusLiveSession owner-signature gate", () => {
     });
   });
 
-  it("documents that atomic uniqueness is enforced by the durable Track port, not this driver", async () => {
-    const racyPort = new BarrierRacingTrackOwnerSignaturePort();
-    const live = makeLive(racyPort);
+  it("returns one duplicate from a barrier-synchronized durable atomic owner-decision write", async () => {
+    const atomicPort = new BarrierSynchronizedDurableAtomicTrackOwnerSignaturePort();
+    const live = makeLive(atomicPort);
     const [first, second] = await Promise.all([
       live.sign({ ...REQUEST, idempotencyKey: "race-key-one" }),
       live.sign({ ...REQUEST, idempotencyKey: "race-key-two" }),
     ]);
 
-    expect(first).toMatchObject({ status: "signed", duplicate: false });
-    expect(second).toMatchObject({ status: "signed", duplicate: false });
-    expect(racyPort.appendAttempts).toBe(2);
-    expect(racyPort.recordCount).toBe(2);
+    expect([first, second].filter((result) => result.status === "signed" && !result.duplicate)).toHaveLength(1);
+    expect([first, second].filter((result) => result.status === "signed" && result.duplicate)).toHaveLength(1);
+    expect(atomicPort.appendAttempts).toBe(2);
+    expect(atomicPort.recordCount).toBe(1);
+    expect(atomicPort.receiptStatuses.filter((status) => status === "written")).toHaveLength(1);
+    expect(atomicPort.receiptStatuses.filter((status) => status === "duplicate")).toHaveLength(1);
   });
 
   it("uses the test-only adapter's synchronous atomic owner-decision uniqueness for same-key replay", async () => {

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -1,15 +1,17 @@
 import { describe, expect, it } from "vitest";
 
-import { FocusLiveSessionDriver } from "../src/index.js";
+import {
+  FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+  FocusLiveSessionDriver,
+  InMemoryTrackOwnerSignaturePort,
+} from "../src/index.js";
 import type {
   AuthenticatedOwnPrincipal,
   OwnerSignatureRequest,
   PersistedOwnerSignature,
   TrackOwnerSignaturePort,
-  TrackOwnerSignatureWrite,
 } from "../src/index.js";
 
-const CONTRACT = "track-owner-signature/1.0.0";
 const OWNER: AuthenticatedOwnPrincipal = {
   principalId: "owner-verified",
   authenticatedAt: "2026-08-08T12:00:00.000Z",
@@ -21,114 +23,88 @@ const REQUEST: OwnerSignatureRequest = {
   idempotencyKey: "focus-signature:decision-track-native:owner-verified",
 };
 
-const keyOf = (input: { target: OwnerSignatureRequest["target"]; idempotencyKey: string }): string =>
-  `${input.target.workspace}:${input.target.decisionId}:${input.idempotencyKey}`;
+interface LiveOptions {
+  readonly owner?: AuthenticatedOwnPrincipal | null;
+  readonly authenticate?: (input: OwnerSignatureRequest) => Promise<AuthenticatedOwnPrincipal | undefined>;
+  readonly authorize?: (input: {
+    readonly owner: AuthenticatedOwnPrincipal;
+    readonly target: TrackNativeDecisionTarget;
+  }) => boolean | Promise<boolean>;
+}
 
-function makeTrack(options: { contractVersion?: string; readError?: Error } = {}) {
-  const records = new Map<string, PersistedOwnerSignature>();
-  let writes = 0;
-  const track: TrackOwnerSignaturePort = {
-    contractVersion: options.contractVersion ?? CONTRACT,
-    async appendOwnerSignature(write: TrackOwnerSignatureWrite) {
-      writes += 1;
-      const key = keyOf(write);
-      const existing = records.get(key);
-      if (existing !== undefined) return { status: "duplicate", recordId: existing.recordId } as const;
-      const persisted = { ...write, recordId: `signature-${records.size + 1}` };
-      records.set(key, persisted);
-      return { status: "written", recordId: persisted.recordId } as const;
+const makeLive = (track: TrackOwnerSignaturePort, options: LiveOptions = {}) => {
+  const configuredOwner = options.owner === undefined ? OWNER : options.owner;
+  return new FocusLiveSessionDriver({
+    ownPrincipal: {
+      authenticate: options.authenticate ?? (async () => configuredOwner ?? undefined),
     },
-    async readOwnerSignature(input) {
-      if (options.readError !== undefined) throw options.readError;
-      return records.get(keyOf(input));
+    authorizer: {
+      authorize: async (input) => (options.authorize ?? (() => true))(input),
+    },
+    track,
+  });
+};
+
+const asPersisted = (value: unknown): PersistedOwnerSignature => value as PersistedOwnerSignature;
+
+const makeWrongReadBackPort = (
+  change: (persisted: PersistedOwnerSignature) => PersistedOwnerSignature,
+) => {
+  const store = new InMemoryTrackOwnerSignaturePort();
+  const track: TrackOwnerSignaturePort = {
+    contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+    appendOwnerSignature: (input) => store.appendOwnerSignature(input),
+    async readOwnerSignature(identity) {
+      const persisted = await store.readOwnerSignature(identity);
+      return persisted === undefined ? undefined : change(persisted);
     },
   };
-  return { track, records, writeCount: () => writes };
-}
-
-function makeLive(
-  track: TrackOwnerSignaturePort,
-  owner: AuthenticatedOwnPrincipal | null = OWNER,
-  authorize: (request: OwnerSignatureRequest) => boolean = () => true,
-) {
-  return new FocusLiveSessionDriver({
-    ownPrincipal: { authenticate: async () => owner ?? undefined },
-    authorizer: { authorize: async ({ target }) => authorize({ ...REQUEST, target }) },
-    track,
-    expectedTrackContractVersion: CONTRACT,
-  });
-}
+  return { store, track };
+};
 
 describe("FocusLiveSession owner-signature gate", () => {
-  it("returns not-done and does not write when own-principal authentication is required", async () => {
-    const store = makeTrack();
-    const result = await makeLive(store.track, null).sign(REQUEST);
+  it("records the authenticated owner as attester and retains distinct relayer provenance", async () => {
+    const store = new InMemoryTrackOwnerSignaturePort();
+    const result = await makeLive(store).sign(REQUEST);
 
-    expect(result).toEqual({ status: "not-done", reason: "owner-authentication-required" });
-    expect(store.writeCount()).toBe(0);
-  });
-
-  it("records the authenticated owner as attester and rejects an identity-colliding relayer", async () => {
-    const store = makeTrack();
-    const signed = await makeLive(store.track).sign({
-      ...REQUEST,
-      relayer: { transport: "http", relayerId: "relayer-claiming-owner" },
-    });
-
-    expect(signed.status).toBe("signed");
-    if (signed.status === "signed") {
-      expect(signed.persisted.attestation.attester.principalId).toBe(OWNER.principalId);
-      expect(signed.persisted.relayer.relayerId).toBe("relayer-claiming-owner");
+    expect(result.status).toBe("signed");
+    if (result.status === "signed") {
+      expect(result.persisted.attestation.attester).toEqual(OWNER);
+      expect(result.persisted.relayer).toEqual(REQUEST.relayer);
     }
-    const forged = await makeLive(store.track).sign({
-      ...REQUEST,
-      idempotencyKey: "different-key",
-      relayer: { transport: "http", relayerId: OWNER.principalId },
-    });
-    expect(forged).toEqual({ status: "not-done", reason: "attester-relayer-conflict" });
-  });
-
-  it("persists one record and reports duplicate on idempotent double-submit", async () => {
-    const store = makeTrack();
-    const live = makeLive(store.track);
-
-    const first = await live.sign(REQUEST);
-    const second = await live.sign(REQUEST);
-
-    expect(first.status).toBe("signed");
-    expect(second).toMatchObject({ status: "signed", duplicate: true });
-    expect(store.records).toHaveLength(1);
-    expect(store.writeCount()).toBe(2);
-  });
-
-  it("returns not-done after a successful write whose persisted read-back fails", async () => {
-    const store = makeTrack({ readError: new Error("read unavailable") });
-    const result = await makeLive(store.track).sign(REQUEST);
-
-    expect(result).toEqual({ status: "not-done", reason: "persisted-attestation-not-confirmed" });
-    expect(store.records).toHaveLength(1);
   });
 
   it.each([
-    ["workspace", { ...REQUEST, target: { ...REQUEST.target, workspace: "other-workspace" } }],
-    ["decision", { ...REQUEST, target: { ...REQUEST.target, decisionId: "other-decision" } }],
-  ])("denies an unauthorized %s before Track ingest", async (_scope, request) => {
-    const store = makeTrack();
-    const result = await makeLive(
-      store.track,
-      OWNER,
-      (candidate) => candidate.target.workspace === REQUEST.target.workspace && candidate.target.decisionId === REQUEST.target.decisionId,
-    ).sign(request);
+    ["target workspace", (record: PersistedOwnerSignature) => asPersisted({ ...record, target: { ...record.target, workspace: "other" } })],
+    ["target decision", (record: PersistedOwnerSignature) => asPersisted({ ...record, target: { ...record.target, decisionId: "other" } })],
+    ["record id", (record: PersistedOwnerSignature) => asPersisted({ ...record, recordId: "other-record" })],
+    ["contract version", (record: PersistedOwnerSignature) => asPersisted({ ...record, contractVersion: "track-owner-signature/other" })],
+    ["attester principal", (record: PersistedOwnerSignature) => asPersisted({ ...record, attestation: { attester: { ...record.attestation.attester, principalId: "other-owner" } } })],
+    ["attester authentication time", (record: PersistedOwnerSignature) => asPersisted({ ...record, attestation: { attester: { ...record.attestation.attester, authenticatedAt: "2026-08-08T13:00:00.000Z" } } })],
+    ["relayer transport", (record: PersistedOwnerSignature) => asPersisted({ ...record, relayer: { ...record.relayer, transport: "cli" } })],
+    ["relayer identity", (record: PersistedOwnerSignature) => asPersisted({ ...record, relayer: { ...record.relayer, relayerId: "other-relayer" } })],
+    ["idempotency key", (record: PersistedOwnerSignature) => asPersisted({ ...record, idempotencyKey: "other-key" })],
+  ])("returns not-done when read-back has the wrong %s", async (_field, change) => {
+    const { store, track } = makeWrongReadBackPort(change);
+    const result = await makeLive(track).sign(REQUEST);
 
-    expect(result).toEqual({ status: "not-done", reason: "authorization-denied" });
-    expect(store.writeCount()).toBe(0);
+    expect(result).toEqual({ status: "not-done", reason: "persisted-attestation-not-confirmed" });
+    expect(store.recordCount).toBe(1);
   });
 
-  it("returns not-done when the supplied Track signature contract is not the pinned version", async () => {
-    const store = makeTrack({ contractVersion: "track-owner-signature/2.0.0" });
-    const result = await makeLive(store.track).sign(REQUEST);
+  it("returns not-done when the port returns no persisted read-back", async () => {
+    const store = new InMemoryTrackOwnerSignaturePort();
+    const track: TrackOwnerSignaturePort = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      appendOwnerSignature: (input) => store.appendOwnerSignature(input),
+      readOwnerSignature: async () => undefined,
+    };
 
-    expect(result).toEqual({ status: "not-done", reason: "track-contract-mismatch" });
-    expect(store.writeCount()).toBe(0);
+    await expect(makeLive(track).sign(REQUEST)).resolves.toEqual({
+      status: "not-done",
+      reason: "persisted-attestation-not-confirmed",
+    });
+    expect(store.recordCount).toBe(1);
   });
+
 });

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -150,11 +150,20 @@ describe("FocusLiveSession owner-signature gate", () => {
   });
 
   it("does not ingest for every pre-ingest denial", async () => {
-    const invalidRequest = { ...REQUEST, idempotencyKey: " " };
+    const invalidRequests: readonly OwnerSignatureRequest[] = [
+      { ...REQUEST, target: { ...REQUEST.target, workspace: " " } },
+      { ...REQUEST, target: { ...REQUEST.target, decisionId: " " } },
+      { ...REQUEST, idempotencyKey: " " },
+      { ...REQUEST, relayer: { ...REQUEST.relayer, relayerId: " " } },
+      { ...REQUEST, relayer: { ...REQUEST.relayer, transport: "smtp" as never } },
+      { ...REQUEST, authentication: { ...REQUEST.authentication, kind: "other" as never } },
+    ];
     const relayerCollision = { ...REQUEST, relayer: { ...REQUEST.relayer, relayerId: OWNER.principalId } };
 
-    const invalid = new InMemoryTrackOwnerSignaturePort();
-    await expectNoIngest(makeLive(invalid), invalid, invalidRequest, "invalid-signature-request");
+    for (const invalidRequest of invalidRequests) {
+      const invalid = new InMemoryTrackOwnerSignaturePort();
+      await expectNoIngest(makeLive(invalid), invalid, invalidRequest, "invalid-signature-request");
+    }
 
     const authenticationRequired = new InMemoryTrackOwnerSignaturePort();
     await expectNoIngest(makeLive(authenticationRequired, { owner: null }), authenticationRequired, REQUEST, "owner-authentication-required");

--- a/packages/focus/tests/live.spec.ts
+++ b/packages/focus/tests/live.spec.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from "vitest";
 import {
   FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
   FocusLiveSessionDriver,
-  InMemoryTrackOwnerSignaturePort,
 } from "../src/index.js";
+import { TestOnlyInMemoryTrackOwnerSignaturePort } from "../src/live/in-memory.js";
 import type {
   AuthenticatedOwnPrincipal,
   OwnerSignatureRequest,
   PersistedOwnerSignature,
+  RelayerProvenance,
   TrackNativeDecisionTarget,
   TrackOwnerSignaturePort,
   TrackOwnerSignatureWrite,
@@ -17,43 +18,81 @@ import type {
 
 const OWNER: AuthenticatedOwnPrincipal = {
   principalId: "owner-verified",
+  canonicalIdentity: { issuer: "https://auth.example", subject: "owner-verified" },
   authenticatedAt: "2026-08-08T12:00:00.000Z",
+};
+const RELAYER: RelayerProvenance = {
+  transport: "http",
+  relayerId: "signature-gateway",
+  canonicalIdentity: { issuer: "https://gateway.example", subject: "signature-gateway" },
 };
 const REQUEST: OwnerSignatureRequest = {
   target: { workspace: "focus", decisionId: "decision-track-native" },
   authentication: { kind: "own-principal", proof: { session: "verified" } },
-  relayer: { transport: "http", relayerId: "signature-gateway" },
   idempotencyKey: "focus-signature:decision-track-native:owner-verified",
 };
 
 interface LiveOptions {
-  readonly owner?: AuthenticatedOwnPrincipal | null;
-  readonly authenticate?: (input: OwnerSignatureRequest) => Promise<AuthenticatedOwnPrincipal | undefined>;
+  readonly authenticate?: (input: OwnerSignatureRequest) => unknown | Promise<unknown>;
+  readonly getRelayerProvenance?: () => unknown | Promise<unknown>;
   readonly authorize?: (input: {
     readonly owner: AuthenticatedOwnPrincipal;
     readonly target: TrackNativeDecisionTarget;
-  }) => boolean | Promise<boolean>;
+  }) => unknown | Promise<unknown>;
 }
 
-const makeLive = (track: TrackOwnerSignaturePort, options: LiveOptions = {}) => {
-  const configuredOwner = options.owner === undefined ? OWNER : options.owner;
-  return new FocusLiveSessionDriver({
+const makeLive = (track: TrackOwnerSignaturePort, options: LiveOptions = {}) =>
+  new FocusLiveSessionDriver({
     ownPrincipal: {
-      authenticate: options.authenticate ?? (async () => configuredOwner ?? undefined),
+      authenticate: async (input) =>
+        ((options.authenticate === undefined ? OWNER : await options.authenticate(input)) as AuthenticatedOwnPrincipal | undefined),
+    },
+    relayerProvenance: {
+      getRelayerProvenance: async () =>
+        ((options.getRelayerProvenance === undefined
+          ? RELAYER
+          : await options.getRelayerProvenance()) as RelayerProvenance),
     },
     authorizer: {
-      authorize: async (input) => (options.authorize ?? (() => true))(input),
+      authorize: async (input) => ((options.authorize === undefined ? true : await options.authorize(input)) as boolean),
     },
     track,
   });
-};
 
 const asPersisted = (value: unknown): PersistedOwnerSignature => value as PersistedOwnerSignature;
+
+const persistedFromWrite = (write: TrackOwnerSignatureWrite, recordId: string): PersistedOwnerSignature =>
+  asPersisted(
+    Object.freeze({
+      contractVersion: write.contractVersion,
+      target: Object.freeze({ workspace: write.target.workspace, decisionId: write.target.decisionId }),
+      attestation: Object.freeze({
+        attester: Object.freeze({
+          principalId: write.attestation.attester.principalId,
+          canonicalIdentity: Object.freeze({
+            issuer: write.attestation.attester.canonicalIdentity.issuer,
+            subject: write.attestation.attester.canonicalIdentity.subject,
+          }),
+          authenticatedAt: write.attestation.attester.authenticatedAt,
+        }),
+      }),
+      relayer: Object.freeze({
+        transport: write.relayer.transport,
+        relayerId: write.relayer.relayerId,
+        canonicalIdentity: Object.freeze({
+          issuer: write.relayer.canonicalIdentity.issuer,
+          subject: write.relayer.canonicalIdentity.subject,
+        }),
+      }),
+      idempotencyKey: write.idempotencyKey,
+      recordId,
+    }),
+  );
 
 const makeWrongReadBackPort = (
   change: (persisted: PersistedOwnerSignature) => PersistedOwnerSignature,
 ) => {
-  const store = new InMemoryTrackOwnerSignaturePort();
+  const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
   const track: TrackOwnerSignaturePort = {
     contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
     appendOwnerSignature: (input) => store.appendOwnerSignature(input),
@@ -67,24 +106,71 @@ const makeWrongReadBackPort = (
 
 const expectNoIngest = async (
   live: FocusLiveSessionDriver,
-  store: InMemoryTrackOwnerSignaturePort,
+  store: TestOnlyInMemoryTrackOwnerSignaturePort,
   request: OwnerSignatureRequest,
   reason: string,
 ) => {
   await expect(live.sign(request)).resolves.toEqual({ status: "not-done", reason });
   expect(store.appendAttempts).toBe(0);
   expect(store.recordCount).toBe(0);
+  expect(store.readAttempts).toBe(0);
 };
 
+class BarrierRacingTrackOwnerSignaturePort implements TrackOwnerSignaturePort {
+  readonly contractVersion = FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION;
+
+  private readonly records = new Map<string, PersistedOwnerSignature>();
+  private readonly barrier: Promise<void>;
+  private releaseBarrier: (() => void) | undefined;
+  private waiting = 0;
+  appendAttempts = 0;
+
+  constructor() {
+    this.barrier = new Promise((resolve) => {
+      this.releaseBarrier = resolve;
+    });
+  }
+
+  get recordCount(): number {
+    return this.records.size;
+  }
+
+  async appendOwnerSignature(input: TrackOwnerSignatureWrite): Promise<TrackOwnerSignatureWriteResult> {
+    this.appendAttempts += 1;
+    const key = this.key(input.attestation.attester.canonicalIdentity, input.target, input.idempotencyKey);
+    if (this.records.has(key)) return { status: "duplicate", recordId: this.records.get(key)!.recordId };
+
+    this.waiting += 1;
+    if (this.waiting === 2) this.releaseBarrier?.();
+    await this.barrier;
+
+    const persisted = persistedFromWrite(input, `racy-owner-signature-${this.appendAttempts}`);
+    this.records.set(key, persisted);
+    return { status: "written", recordId: persisted.recordId };
+  }
+
+  readOwnerSignature(input: Parameters<TrackOwnerSignaturePort["readOwnerSignature"]>[0]) {
+    return Promise.resolve(this.records.get(this.key(input.ownerCanonicalIdentity, input.target, input.idempotencyKey)));
+  }
+
+  private key(
+    owner: AuthenticatedOwnPrincipal["canonicalIdentity"],
+    target: TrackNativeDecisionTarget,
+    idempotencyKey: string,
+  ): string {
+    return `${owner.issuer}\u0000${owner.subject}\u0000${target.workspace}\u0000${target.decisionId}\u0000${idempotencyKey}`;
+  }
+}
+
 describe("FocusLiveSession owner-signature gate", () => {
-  it("records the authenticated owner as attester and retains distinct relayer provenance", async () => {
-    const store = new InMemoryTrackOwnerSignaturePort();
+  it("records the authenticated owner as attester and trusted relayer provenance separately", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     const result = await makeLive(store).sign(REQUEST);
 
     expect(result.status).toBe("signed");
     if (result.status === "signed") {
       expect(result.persisted.attestation.attester).toEqual(OWNER);
-      expect(result.persisted.relayer).toEqual(REQUEST.relayer);
+      expect(result.persisted.relayer).toEqual(RELAYER);
     }
   });
 
@@ -94,9 +180,11 @@ describe("FocusLiveSession owner-signature gate", () => {
     ["record id", (record: PersistedOwnerSignature) => asPersisted({ ...record, recordId: "other-record" })],
     ["contract version", (record: PersistedOwnerSignature) => asPersisted({ ...record, contractVersion: "track-owner-signature/other" })],
     ["attester principal", (record: PersistedOwnerSignature) => asPersisted({ ...record, attestation: { attester: { ...record.attestation.attester, principalId: "other-owner" } } })],
+    ["attester canonical identity", (record: PersistedOwnerSignature) => asPersisted({ ...record, attestation: { attester: { ...record.attestation.attester, canonicalIdentity: { ...record.attestation.attester.canonicalIdentity, subject: "other-owner" } } } })],
     ["attester authentication time", (record: PersistedOwnerSignature) => asPersisted({ ...record, attestation: { attester: { ...record.attestation.attester, authenticatedAt: "2026-08-08T13:00:00.000Z" } } })],
     ["relayer transport", (record: PersistedOwnerSignature) => asPersisted({ ...record, relayer: { ...record.relayer, transport: "cli" } })],
     ["relayer identity", (record: PersistedOwnerSignature) => asPersisted({ ...record, relayer: { ...record.relayer, relayerId: "other-relayer" } })],
+    ["relayer canonical identity", (record: PersistedOwnerSignature) => asPersisted({ ...record, relayer: { ...record.relayer, canonicalIdentity: { ...record.relayer.canonicalIdentity, subject: "other-relayer" } } })],
     ["idempotency key", (record: PersistedOwnerSignature) => asPersisted({ ...record, idempotencyKey: "other-key" })],
   ])("returns not-done when read-back has the wrong %s", async (_field, change) => {
     const { store, track } = makeWrongReadBackPort(change);
@@ -107,7 +195,7 @@ describe("FocusLiveSession owner-signature gate", () => {
   });
 
   it("returns not-done when the port returns no persisted read-back", async () => {
-    const store = new InMemoryTrackOwnerSignaturePort();
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     const track: TrackOwnerSignaturePort = {
       contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
       appendOwnerSignature: (input) => store.appendOwnerSignature(input),
@@ -127,20 +215,20 @@ describe("FocusLiveSession owner-signature gate", () => {
     ["blank record id", { status: "written", recordId: "   " }],
     ["missing record id", { status: "duplicate" }],
   ])("rejects a runtime-invalid %s without reading or persisting", async (_label, receipt) => {
-    const store = new InMemoryTrackOwnerSignaturePort();
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     let appendCalls = 0;
     let readCalls = 0;
-    const track = {
+    const track: TrackOwnerSignaturePort = {
       contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
       async appendOwnerSignature(): Promise<TrackOwnerSignatureWriteResult> {
         appendCalls += 1;
         return receipt as TrackOwnerSignatureWriteResult;
       },
-      async readOwnerSignature(identity: Parameters<TrackOwnerSignaturePort["readOwnerSignature"]>[0]) {
+      async readOwnerSignature(identity) {
         readCalls += 1;
         return store.readOwnerSignature(identity);
       },
-    } as TrackOwnerSignaturePort;
+    };
 
     await expect(makeLive(track).sign(REQUEST)).resolves.toEqual({ status: "not-done", reason: "track-write-failed" });
     expect(appendCalls).toBe(1);
@@ -149,41 +237,95 @@ describe("FocusLiveSession owner-signature gate", () => {
     expect(store.recordCount).toBe(0);
   });
 
+  it("fails honestly when append throws without durable records or read-back calls", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    let appendCalls = 0;
+    let readCalls = 0;
+    const track: TrackOwnerSignaturePort = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      async appendOwnerSignature() {
+        appendCalls += 1;
+        throw new Error("Track unavailable");
+      },
+      async readOwnerSignature(identity) {
+        readCalls += 1;
+        return store.readOwnerSignature(identity);
+      },
+    };
+
+    await expect(makeLive(track).sign(REQUEST)).resolves.toEqual({ status: "not-done", reason: "track-write-failed" });
+    expect(appendCalls).toBe(1);
+    expect(store.recordCount).toBe(0);
+    expect(readCalls).toBe(0);
+  });
+
+  it.each(["false", { authorized: false }, { authorized: true }])(
+    "denies truthy-malformed authorization results without append: %j",
+    async (authorizationResult) => {
+      const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+      await expectNoIngest(
+        makeLive(store, { authorize: () => authorizationResult }),
+        store,
+        REQUEST,
+        "authorization-denied",
+      );
+    },
+  );
+
   it("does not ingest for every pre-ingest denial", async () => {
     const invalidRequests: readonly OwnerSignatureRequest[] = [
       { ...REQUEST, target: { ...REQUEST.target, workspace: " " } },
       { ...REQUEST, target: { ...REQUEST.target, decisionId: " " } },
       { ...REQUEST, idempotencyKey: " " },
-      { ...REQUEST, relayer: { ...REQUEST.relayer, relayerId: " " } },
-      { ...REQUEST, relayer: { ...REQUEST.relayer, transport: "smtp" as never } },
       { ...REQUEST, authentication: { ...REQUEST.authentication, kind: "other" as never } },
     ];
-    const relayerCollision = { ...REQUEST, relayer: { ...REQUEST.relayer, relayerId: OWNER.principalId } };
 
     for (const invalidRequest of invalidRequests) {
-      const invalid = new InMemoryTrackOwnerSignaturePort();
+      const invalid = new TestOnlyInMemoryTrackOwnerSignaturePort();
       await expectNoIngest(makeLive(invalid), invalid, invalidRequest, "invalid-signature-request");
     }
 
-    const authenticationRequired = new InMemoryTrackOwnerSignaturePort();
-    await expectNoIngest(makeLive(authenticationRequired, { owner: null }), authenticationRequired, REQUEST, "owner-authentication-required");
+    const authenticationRequired = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(
+      makeLive(authenticationRequired, { authenticate: async () => undefined }),
+      authenticationRequired,
+      REQUEST,
+      "owner-authentication-required",
+    );
 
-    const authenticationInvalid = new InMemoryTrackOwnerSignaturePort();
-    await expectNoIngest(makeLive(authenticationInvalid, { owner: { ...OWNER, principalId: "" } }), authenticationInvalid, REQUEST, "owner-authentication-invalid");
+    const authenticationRejected = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(
+      makeLive(authenticationRejected, {
+        authenticate: async () => {
+          throw new Error("rejected");
+        },
+      }),
+      authenticationRejected,
+      REQUEST,
+      "owner-authentication-invalid",
+    );
 
-    const authenticationRejected = new InMemoryTrackOwnerSignaturePort();
-    await expectNoIngest(makeLive(authenticationRejected, { authenticate: async () => { throw new Error("rejected"); } }), authenticationRejected, REQUEST, "owner-authentication-invalid");
+    const authorizationRejected = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(
+      makeLive(authorizationRejected, { authorize: () => false }),
+      authorizationRejected,
+      REQUEST,
+      "authorization-denied",
+    );
 
-    const collision = new InMemoryTrackOwnerSignaturePort();
-    await expectNoIngest(makeLive(collision), collision, relayerCollision, "attester-relayer-conflict");
+    const authorizationError = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(
+      makeLive(authorizationError, {
+        authorize: () => {
+          throw new Error("denied");
+        },
+      }),
+      authorizationError,
+      REQUEST,
+      "authorization-denied",
+    );
 
-    const authorizationRejected = new InMemoryTrackOwnerSignaturePort();
-    await expectNoIngest(makeLive(authorizationRejected, { authorize: () => false }), authorizationRejected, REQUEST, "authorization-denied");
-
-    const authorizationError = new InMemoryTrackOwnerSignaturePort();
-    await expectNoIngest(makeLive(authorizationError, { authorize: () => { throw new Error("denied"); } }), authorizationError, REQUEST, "authorization-denied");
-
-    const contractStore = new InMemoryTrackOwnerSignaturePort();
+    const contractStore = new TestOnlyInMemoryTrackOwnerSignaturePort();
     const wrongContract: TrackOwnerSignaturePort = {
       contractVersion: "track-owner-signature/2.0.0" as never,
       appendOwnerSignature: (input) => contractStore.appendOwnerSignature(input),
@@ -192,8 +334,75 @@ describe("FocusLiveSession owner-signature gate", () => {
     await expectNoIngest(makeLive(wrongContract), contractStore, REQUEST, "track-contract-mismatch");
   });
 
-  it("snapshots caller values and gives the port a separate deeply frozen copy", async () => {
-    const store = new InMemoryTrackOwnerSignaturePort();
+  it.each([
+    ["raw null", null],
+    ["array", []],
+    ["wrong shape", { principalId: OWNER.principalId, authenticatedAt: OWNER.authenticatedAt }],
+    ["blank scalar", { ...OWNER, principalId: " " }],
+  ])("returns not-done for a runtime-invalid authentication result: %s", async (_label, owner) => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    await expectNoIngest(
+      makeLive(store, { authenticate: async () => owner }),
+      store,
+      REQUEST,
+      "owner-authentication-invalid",
+    );
+  });
+
+  it("captures a getter-backed request field once, so its changed second value cannot enter the signed write", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    let idempotencyKeyReads = 0;
+    const getterRequest = {
+      target: REQUEST.target,
+      authentication: REQUEST.authentication,
+      get idempotencyKey() {
+        idempotencyKeyReads += 1;
+        return idempotencyKeyReads === 1 ? REQUEST.idempotencyKey : " ";
+      },
+    } as OwnerSignatureRequest;
+
+    const result = await makeLive(store).sign(getterRequest);
+
+    expect(idempotencyKeyReads).toBe(1);
+    expect(result).toMatchObject({ status: "signed", persisted: { idempotencyKey: REQUEST.idempotencyKey } });
+  });
+
+  it("captures accessor-backed receipts once before validating and reading back", async () => {
+    let statusReads = 0;
+    let recordIdReads = 0;
+    let write: TrackOwnerSignatureWrite | undefined;
+    const track: TrackOwnerSignaturePort = {
+      contractVersion: FOCUS_OWNER_SIGNATURE_CONTRACT_VERSION,
+      async appendOwnerSignature(input) {
+        write = input;
+        return {
+          get status() {
+            statusReads += 1;
+            return statusReads === 1 ? "written" : "failed";
+          },
+          get recordId() {
+            recordIdReads += 1;
+            return recordIdReads === 1 ? "accessor-receipt" : " ";
+          },
+        } as TrackOwnerSignatureWriteResult;
+      },
+      async readOwnerSignature() {
+        if (write === undefined) throw new Error("expected append before read");
+        return persistedFromWrite(write, "accessor-receipt");
+      },
+    };
+
+    await expect(makeLive(track).sign(REQUEST)).resolves.toMatchObject({
+      status: "signed",
+      duplicate: false,
+      persisted: { recordId: "accessor-receipt" },
+    });
+    expect(statusReads).toBe(1);
+    expect(recordIdReads).toBe(1);
+  });
+
+  it("gives the port immutable request, owner, and trusted relayer copies", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     let authorizedTarget: TrackNativeDecisionTarget | undefined;
     let submitted: TrackOwnerSignatureWrite | undefined;
     let mutationRejected = false;
@@ -216,21 +425,14 @@ describe("FocusLiveSession owner-signature gate", () => {
         return true;
       },
     });
-    const mutableRequest: {
-      target: { workspace: string; decisionId: string };
-      authentication: OwnerSignatureRequest["authentication"];
-      relayer: { transport: OwnerSignatureRequest["relayer"]["transport"]; relayerId: string };
-      idempotencyKey: string;
-    } = {
+    const mutableRequest: OwnerSignatureRequest = {
       target: { ...REQUEST.target },
       authentication: REQUEST.authentication,
-      relayer: { ...REQUEST.relayer },
       idempotencyKey: REQUEST.idempotencyKey,
     };
 
     const pending = live.sign(mutableRequest);
     mutableRequest.target.workspace = "caller-mutated";
-    mutableRequest.relayer.relayerId = "caller-mutated";
     mutableRequest.idempotencyKey = "caller-mutated";
     const result = await pending;
 
@@ -241,17 +443,78 @@ describe("FocusLiveSession owner-signature gate", () => {
     expect(Object.isFrozen(submitted.target)).toBe(true);
     expect(Object.isFrozen(submitted.attestation)).toBe(true);
     expect(Object.isFrozen(submitted.attestation.attester)).toBe(true);
+    expect(Object.isFrozen(submitted.attestation.attester.canonicalIdentity)).toBe(true);
     expect(Object.isFrozen(submitted.relayer)).toBe(true);
+    expect(Object.isFrozen(submitted.relayer.canonicalIdentity)).toBe(true);
     expect(Object.isFrozen(authorizedTarget)).toBe(true);
     expect(submitted.target).not.toBe(authorizedTarget);
     expect(result).toMatchObject({
       status: "signed",
-      persisted: { target: REQUEST.target, relayer: REQUEST.relayer, idempotencyKey: REQUEST.idempotencyKey },
+      persisted: { target: REQUEST.target, relayer: RELAYER, idempotencyKey: REQUEST.idempotencyKey },
     });
   });
 
-  it("uses the reference adapter's atomic owner-decision uniqueness for concurrent double-submit", async () => {
-    const store = new InMemoryTrackOwnerSignaturePort();
+  it("rejects an owner-relayer canonical collision before authorization or append", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    let authorizationCalls = 0;
+    const collidingOwner: AuthenticatedOwnPrincipal = {
+      ...OWNER,
+      canonicalIdentity: { issuer: "HTTPS://AUTH.EXAMPLE", subject: "RELAY@EXAMPLE.COM" },
+    };
+    const collidingRelayer: RelayerProvenance = {
+      ...RELAYER,
+      canonicalIdentity: { issuer: "https://auth.example", subject: "relay@example.com" },
+    };
+
+    await expect(
+      makeLive(store, {
+        authenticate: async () => collidingOwner,
+        getRelayerProvenance: async () => collidingRelayer,
+        authorize: () => {
+          authorizationCalls += 1;
+          return true;
+        },
+      }).sign(REQUEST),
+    ).resolves.toEqual({ status: "not-done", reason: "attester-relayer-conflict" });
+    expect(authorizationCalls).toBe(0);
+    expect(store.appendAttempts).toBe(0);
+  });
+
+  it("cannot let caller-asserted relayer text replace the authenticated owner attester", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
+    const callerAssertedRelayer = {
+      ...REQUEST,
+      relayer: {
+        transport: "internal",
+        relayerId: OWNER.principalId,
+        canonicalIdentity: OWNER.canonicalIdentity,
+      },
+    } as unknown as OwnerSignatureRequest;
+
+    const result = await makeLive(store).sign(callerAssertedRelayer);
+
+    expect(result).toMatchObject({
+      status: "signed",
+      persisted: { attestation: { attester: OWNER }, relayer: RELAYER },
+    });
+  });
+
+  it("documents that atomic uniqueness is enforced by the durable Track port, not this driver", async () => {
+    const racyPort = new BarrierRacingTrackOwnerSignaturePort();
+    const live = makeLive(racyPort);
+    const [first, second] = await Promise.all([
+      live.sign({ ...REQUEST, idempotencyKey: "race-key-one" }),
+      live.sign({ ...REQUEST, idempotencyKey: "race-key-two" }),
+    ]);
+
+    expect(first).toMatchObject({ status: "signed", duplicate: false });
+    expect(second).toMatchObject({ status: "signed", duplicate: false });
+    expect(racyPort.appendAttempts).toBe(2);
+    expect(racyPort.recordCount).toBe(2);
+  });
+
+  it("uses the test-only adapter's synchronous atomic owner-decision uniqueness for same-key replay", async () => {
+    const store = new TestOnlyInMemoryTrackOwnerSignaturePort();
     const live = makeLive(store);
     const [first, second] = await Promise.all([live.sign(REQUEST), live.sign(REQUEST)]);
 
@@ -261,5 +524,4 @@ describe("FocusLiveSession owner-signature gate", () => {
     expect(store.appendAttempts).toBe(2);
     expect(store.recordCount).toBe(1);
   });
-
 });


### PR DESCRIPTION
## FocusLiveSession owner-signature gate

This hardens the public `@sentropic/focus` 0.4.0 live-write primitive for an existing **Track-native** decision.

### Fail-closed contract

- Captures request, authentication result, trusted relayer provenance, authorization result, ingest receipt, and persisted read-back once into frozen snapshots; validation never re-reads caller or port objects.
- Accepts authorization only when the runtime result is exactly `true`; every other shape is denied before append.
- The attester is always the authenticated owner. Relayer provenance comes from a trusted injected host port, uses normalized issuer+subject identity, and a canonical owner/relayer collision is denied before authorization.
- A write receipt alone never means signed: success requires a matching immutable persisted read-back.
- The public package no longer exports the Map adapter; it is explicitly test-only and non-durable.

### Required before live use

No production Track adapter is included here. Before wiring a live host, a co-specified Track primitive must persist the signature behind a **durable canonical-owner/workspace/decision unique constraint or upsert** and perform transactional read-back. The barrier-synchronized race test deliberately demonstrates that the driver relies on this port contract rather than faking durability.

### Held out of scope

- h2a-to-Track decision-dossier adapter/wire and h2a dossier rendering
- production tenancy cache invalidation/freshness repair
- fail-closed connector teardown and durable agentRef identity repair
- CLI/UI/API signature surfaces and V1 breadth
- direct wiring to the current `@sentropic/track/ingest@1.2.0`

### Validation

- `make typecheck-focus ENV=test-focus-sig-gate` — passed
- `make test-focus ENV=test-focus-sig-gate` — passed (4 files, 71 tests)
- `make build-focus ENV=test-focus-sig-gate` — passed
- `harness check scope` and `make scope-check ENV=test-focus-sig-gate` — passed

draft: independent build-review + owner UAT required before merge/live