### PR TITLE
fix(sec): invalidate tenant-resolver cache on membership transitions (authz-staleness bypass)

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,35 +1,36 @@
-# Fix(sec): bump vitest 4.0.18 -> 4.1.0 (clear GHSA-5xrq-8626-4rwp) — unblock api-image audit
+# Fix(sec): tenant-resolver cache invalidation on membership transitions (authz-staleness)
 
 ## Objective
-- [x] Clear the CRITICAL vitest advisory `GHSA-5xrq-8626-4rwp` (CVSS 9.8) that reds the api-image npm-audit gate for ALL PRs (found repo-wide by the #526 build-review; inherited from main, not #526's).
-- [x] Real fix (not an exception): the only vulnerable vitest in the tree was `4.0.18` (packages/focus, packages/harness, packages/skills). The advisory is fixed in 4.1.0 (4.x) / 3.2.6 (3.x). ui is already 3.2.7, api 4.1.5, 18 packages 4.1.0 — all fixed.
+- [x] Close the pre-existing authorization-staleness bypass in `api/src/services/tenancy/resolve-tenant.ts`: the tenant-resolution cache was process-lifetime with NO invalidation/TTL, so a SUSPENDED/revoked user kept resolving as authorized until process restart. Found by the #526 independent build-review (verified NOT introduced by #526).
 
 ## Scope / Guardrails
-- [x] Bump the 3 vulnerable `"vitest": "4.0.18"` devDeps to `"4.1.0"` — the version 18 other packages already run (proven in-repo).
-- [x] Regenerate root `package-lock.json` (`make lock-root`): no vitest `4.0.18` remains -> advisory matches nothing -> gate passes with NO exception added.
-- [x] No new allowlist entry, no Dockerfile change. Dev-only test tool bump; zero runtime/API change.
+- [x] `resolve-tenant.ts`: bounded TTL (`CACHE_TTL_MS=30_000`), `invalidateResolveTenantCache()` (clear-all + generation bump), and a generation-guard so a resolve in flight during an invalidation cannot repopulate a stale entry (TOCTOU). No change to `reconcileTenantId` mode logic (alias/shadow/strict) or the resolution queries.
+- [x] `tenant-membership.ts`: `decideMembership()` calls `invalidateResolveTenantCache()` after the status-update (approve/reject/suspend). No import cycle (one-way `auth -> tenancy`).
+- [x] Test `api/tests/unit/tenant-resolver-invalidation.test.ts`: suspension-deny (approve -> resolve OK -> suspend -> resolve DENIED). In `tests/unit/` so CI globs it.
 
 ## Branch Scope Boundaries (MANDATORY)
-- **Allowed Paths**: `packages/focus/package.json`, `packages/harness/package.json`, `packages/skills/package.json`, `package-lock.json`, `BRANCH.md`
-- **Forbidden Paths**: `Makefile`, `docker-compose*.yml`, `api/src/**`, `ui/src/**`, `packages/*/src/**`, `.security/**`
+- **Allowed Paths**: `api/src/services/tenancy/resolve-tenant.ts`, `api/src/services/auth/tenant-membership.ts`, `api/tests/unit/tenant-resolver-invalidation.test.ts`, `BRANCH.md`
+- **Forbidden Paths**: everything else (routes, other services, packages, Makefile, Dockerfiles, migrations).
 - **Conditional Paths**: none.
 
 ## Feedback Loop
-- [x] `SEC-VITEST-RCA` — GHSA-5xrq-8626-4rwp affects vitest (arbitrary file read on Windows when the Vitest UI server is exposed to network), fixed in 4.1.0 / 3.2.6. Only `4.0.18` (focus/harness/skills) was vulnerable; the rest of the tree is already >= 4.1.0 / 3.2.7.
-- [x] `SEC-VITEST-VERIFY` — `make build-api-image` green: `audit-gate: OK` (api base + production), no vitest advisory remains (only the pre-existing image-size allowlist from #519), api image `Successfully built`.
-- [ ] `SEC-VITEST-CI` — PR CI must confirm the focus/harness/skills test suites pass on vitest 4.1.0 (non-breaking) before merge.
-- [ ] `SEC-VITEST-SYSTEMIC` — NOTE for a separate follow-up: dev-only tooling (vitest) trips the prod-image `npm audit --omit=dev --workspaces` gate because npm's `--omit=dev` does not exclude workspace devDeps. Future dev-tool advisories will recur; the real hardening is making the gate exclude workspace devDeps (or the wrapper distinguishing dev-only). Out of scope for this urgent unblock.
+- [x] `SEC-TENANT-BUILD` — Built by codex terra (xhigh); builder != reviewer.
+- [x] `SEC-TENANT-REVIEW` — Independent adversarial review (2 passes, reviewer != builder != orchestrator): VERDICT SHIP-WITH-NOTES. In-process bypass closed; the TOCTOU cache-poisoning race is retired by the generation-guard (capture-before-read + conditional-set, both interleavings traced); no regression, no import cycle; test is non-vacuous (fails on origin/main).
+- [x] `SEC-TENANT-SEVERITY` — Recalibrated: default `TENANT_RESOLUTION_MODE=shadow`, and the only prod consumer `reconcileTenantId` is shadow/measure-only, so this bypass is LATENT (authz-live only at/after the strict cutover), not live authz bleed today. This fix is the prerequisite for a safe strict cutover.
+- [ ] `SEC-TENANT-CROSSPOD` — The invalidation is PER-PROCESS; on a multi-replica deploy the 30s TTL is the true cross-pod revocation guarantee (a suspended user can still resolve on other pods for <=30s). Documented in-code. OWNER SIGN-OFF on the 30s window required before the strict-mode cutover (owner may want a shorter TTL).
+- [ ] `SEC-TENANT-TESTGAP` — Follow-up: the 30s TTL-expiry branch and the generation-guard race path have no unit test (a clean test needs injectable time; fake-timers + real DB is not a proven-safe pattern in this suite). Add a TTL-expiry + concurrent resolve-vs-invalidate test via a small time-injection refactor.
+- [ ] `SEC-TENANT-CASCADE` — Follow-up: FK cascade user-deletion (`admin.ts:366`, `me.ts:306`) deletes memberships WITHOUT calling `invalidateResolveTenantCache()`; bounded by the 30s TTL. Add invalidation there (or accept the TTL bound).
 
 ## AI Flaky tests
-- Not applicable: devDependency version bump only.
+- Not applicable: service + unit test only.
 
 ## Orchestration Mode (AI-selected)
 - [x] Mono-branch + cherry-pick.
 - [ ] Multi-branch.
-- Rationale: one atomic security devDep bump; real fix, no exception.
+- Rationale: one atomic security fix (2 files + 1 test); codex-built, independently reviewed, conductor-gated.
 
 ## Plan / Todo (lot-based)
-- [x] Lot 0 — RCA: only vitest 4.0.18 (3 packages) vulnerable; 4.1.0 is the repo standard + a fixed version.
-- [x] Lot 1 — Bump the 3 pins to 4.1.0; regen root lockfile; confirm no 4.0.18 remains.
-- [x] Lot 2 — Verify api-image audit green via `make build-api-image`.
-- [ ] Lot 3 — PR CI green (gate + package tests) -> merge -> report api-image audit green on main to conductor.
+- [x] Lot 0 — RCA: process-lifetime cache bakes membership status; `decideMembership` is the single transition point; no import cycle.
+- [x] Lot 1 — codex terra builds invalidation + TTL + generation-guard + suspension-deny test.
+- [x] Lot 2 — Independent review (2 passes, SHIP-WITH-NOTES; TOCTOU retired); accurate cross-pod doc comment.
+- [ ] Lot 3 — PR CI green (suspension-deny test + build) -> conductor gate -> merge -> report; owner sign-off on the 30s window before strict cutover.

--- a/api/src/services/auth/tenant-membership.ts
+++ b/api/src/services/auth/tenant-membership.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { db } from '../../db/client';
 import { oauthClients, tenantMemberships, tenants } from '../../db/schema';
+import { invalidateResolveTenantCache } from '../tenancy/resolve-tenant';
 
 // BR-39e Lot 2 — tenant-scoped membership acceptance.
 //
@@ -158,6 +159,7 @@ export async function decideMembership(
     .update(tenantMemberships)
     .set({ status: to, approvedByUserId: callerId, decidedAt: now, updatedAt: now })
     .where(and(eq(tenantMemberships.tenantId, tenantId), eq(tenantMemberships.userId, targetUserId)));
+  invalidateResolveTenantCache();
   return { status: to };
 }
 

--- a/api/src/services/tenancy/resolve-tenant.ts
+++ b/api/src/services/tenancy/resolve-tenant.ts
@@ -53,12 +53,26 @@ export class TenantResolutionError extends Error {
 }
 
 // -----------------------------------------------------------------------------
-// In-process cache (spec §3 invariant 3: idempotent + cacheable).
-// Process-lifetime Map — invalidation/TTL is a STRICT-mode (G1c) follow-up; in shadow the
-// only consequence of staleness is a mismeasured divergence, never wrong behavior. Tests
-// clear it via `resetResolveTenantCache()`.
+// In-process cache (spec §3 invariant 3: idempotent + cacheable). Both successful resolutions
+// and fail-closed denials are cached.
+// AUTHZ REVOCATION: `invalidateResolveTenantCache()` (called on every membership transition)
+// clears ONLY the calling process's map. On a multi-replica deploy it clears just the acting
+// pod, so `CACHE_TTL_MS` — NOT the invalidation — is the true CROSS-POD guarantee: a suspended
+// user can still resolve on other pods for up to that TTL. That bounded revocation latency is
+// the accepted property (owner-signed before any strict-mode cutover; today the only prod
+// consumer, `reconcileTenantId`, is shadow/measure-only, so this is latent). A generation
+// counter additionally prevents a resolve in flight during an invalidation from repopulating a
+// stale entry (TOCTOU guard). Tests clear it via `resetResolveTenantCache()`.
 // -----------------------------------------------------------------------------
-const cache = new Map<string, ResolveTenantResult>();
+const CACHE_TTL_MS = 30_000;
+let cacheGeneration = 0;
+
+type CacheEntry = {
+  insertedAt: number;
+  result: ResolveTenantResult;
+};
+
+const cache = new Map<string, CacheEntry>();
 
 function cacheKey(input: ResolveTenantInput): string {
   if ('clientId' in input) return `cl:${input.clientId}`;
@@ -68,9 +82,15 @@ function cacheKey(input: ResolveTenantInput): string {
   return `u:${input.userId}`;
 }
 
+/** Clear cached tenant resolutions after an authorization-affecting tenancy change. */
+export function invalidateResolveTenantCache(): void {
+  cacheGeneration += 1;
+  cache.clear();
+}
+
 /** Test/ops helper: clear the in-process resolution cache. */
 export function resetResolveTenantCache(): void {
-  cache.clear();
+  invalidateResolveTenantCache();
 }
 
 async function resolveByWorkspace(workspaceId: string, userId?: string): Promise<ResolveTenantResult> {
@@ -118,13 +138,17 @@ async function resolveByUser(userId: string): Promise<ResolveTenantResult> {
 
 /**
  * Resolve the real tenant for one input (spec §3). Fail-closed: an unresolved input returns an
- * `error`, never a `workspaceId`. Cached in-process (idempotent). Only successful resolutions
- * AND fail-closed denials are cached — both are stable given the current DB row set.
+ * `error`, never a `workspaceId`. Cached in-process (idempotent) with a bounded TTL. Both
+ * successful resolutions AND fail-closed denials are cached.
  */
 export async function resolveTenant(input: ResolveTenantInput): Promise<ResolveTenantResult> {
   const key = cacheKey(input);
   const cached = cache.get(key);
-  if (cached) return cached;
+  if (cached) {
+    if (Date.now() - cached.insertedAt <= CACHE_TTL_MS) return cached.result;
+    cache.delete(key);
+  }
+  const cacheGenerationAtStart = cacheGeneration;
 
   let result: ResolveTenantResult;
   if ('clientId' in input) {
@@ -135,7 +159,10 @@ export async function resolveTenant(input: ResolveTenantInput): Promise<ResolveT
     result = await resolveByUser(input.userId);
   }
 
-  cache.set(key, result);
+  // Do not let a query started before invalidation repopulate the cache after a status change.
+  if (cacheGeneration === cacheGenerationAtStart) {
+    cache.set(key, { insertedAt: Date.now(), result });
+  }
   return result;
 }
 

--- a/api/tests/unit/tenant-resolver-invalidation.test.ts
+++ b/api/tests/unit/tenant-resolver-invalidation.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { eq } from 'drizzle-orm';
+
+import { db } from '../../src/db/client';
+import { tenantMemberships, tenants } from '../../src/db/schema';
+import { cleanupAuthData, createTestUser } from '../utils/auth-helper';
+import { decideMembership } from '../../src/services/auth/tenant-membership';
+import { resetResolveTenantCache, resolveTenant } from '../../src/services/tenancy/resolve-tenant';
+
+const tenantId = `tenant-resolver-invalidation-${crypto.randomUUID()}`;
+
+describe('resolveTenant membership invalidation', () => {
+  beforeEach(async () => {
+    resetResolveTenantCache();
+    await db.insert(tenants).values({ id: tenantId, name: tenantId, status: 'active' });
+  });
+
+  afterEach(async () => {
+    resetResolveTenantCache();
+    await db.delete(tenantMemberships).where(eq(tenantMemberships.tenantId, tenantId));
+    await db.delete(tenants).where(eq(tenants.id, tenantId));
+    await cleanupAuthData();
+  });
+
+  it('denies a suspended membership after it was previously resolved as approved', async () => {
+    const admin = await createTestUser({
+      email: `tenant-resolver-admin-${crypto.randomUUID()}@example.com`,
+      displayName: 'Tenant Resolver Admin',
+    });
+    const member = await createTestUser({
+      email: `tenant-resolver-member-${crypto.randomUUID()}@example.com`,
+      displayName: 'Tenant Resolver Member',
+    });
+    await db
+      .insert(tenantMemberships)
+      .values({ tenantId, userId: member.id, status: 'requested', role: 'member' });
+
+    expect(await decideMembership(admin.id, 'admin_app', tenantId, member.id, 'approve')).toEqual({ status: 'approved' });
+    expect(await resolveTenant({ userId: member.id })).toEqual({ tenantId });
+
+    expect(await decideMembership(admin.id, 'admin_app', tenantId, member.id, 'suspend')).toEqual({ status: 'suspended' });
+    expect(await resolveTenant({ userId: member.id })).toEqual({ error: 'unknown' });
+  });
+});


### PR DESCRIPTION
# Fix(sec): tenant-resolver cache invalidation on membership transitions (authz-staleness)

## Objective
- [x] Close the pre-existing authorization-staleness bypass in `api/src/services/tenancy/resolve-tenant.ts`: the tenant-resolution cache was process-lifetime with NO invalidation/TTL, so a SUSPENDED/revoked user kept resolving as authorized until process restart. Found by the #526 independent build-review (verified NOT introduced by #526).

## Scope / Guardrails
- [x] `resolve-tenant.ts`: bounded TTL (`CACHE_TTL_MS=30_000`), `invalidateResolveTenantCache()` (clear-all + generation bump), and a generation-guard so a resolve in flight during an invalidation cannot repopulate a stale entry (TOCTOU). No change to `reconcileTenantId` mode logic (alias/shadow/strict) or the resolution queries.
- [x] `tenant-membership.ts`: `decideMembership()` calls `invalidateResolveTenantCache()` after the status-update (approve/reject/suspend). No import cycle (one-way `auth -> tenancy`).
- [x] Test `api/tests/unit/tenant-resolver-invalidation.test.ts`: suspension-deny (approve -> resolve OK -> suspend -> resolve DENIED). In `tests/unit/` so CI globs it.

## Branch Scope Boundaries (MANDATORY)
- **Allowed Paths**: `api/src/services/tenancy/resolve-tenant.ts`, `api/src/services/auth/tenant-membership.ts`, `api/tests/unit/tenant-resolver-invalidation.test.ts`, `BRANCH.md`
- **Forbidden Paths**: everything else (routes, other services, packages, Makefile, Dockerfiles, migrations).
- **Conditional Paths**: none.

## Feedback Loop
- [x] `SEC-TENANT-BUILD` — Built by codex terra (xhigh); builder != reviewer.
- [x] `SEC-TENANT-REVIEW` — Independent adversarial review (2 passes, reviewer != builder != orchestrator): VERDICT SHIP-WITH-NOTES. In-process bypass closed; the TOCTOU cache-poisoning race is retired by the generation-guard (capture-before-read + conditional-set, both interleavings traced); no regression, no import cycle; test is non-vacuous (fails on origin/main).
- [x] `SEC-TENANT-SEVERITY` — Recalibrated: default `TENANT_RESOLUTION_MODE=shadow`, and the only prod consumer `reconcileTenantId` is shadow/measure-only, so this bypass is LATENT (authz-live only at/after the strict cutover), not live authz bleed today. This fix is the prerequisite for a safe strict cutover.
- [ ] `SEC-TENANT-CROSSPOD` — The invalidation is PER-PROCESS; on a multi-replica deploy the 30s TTL is the true cross-pod revocation guarantee (a suspended user can still resolve on other pods for <=30s). Documented in-code. OWNER SIGN-OFF on the 30s window required before the strict-mode cutover (owner may want a shorter TTL).
- [ ] `SEC-TENANT-TESTGAP` — Follow-up: the 30s TTL-expiry branch and the generation-guard race path have no unit test (a clean test needs injectable time; fake-timers + real DB is not a proven-safe pattern in this suite). Add a TTL-expiry + concurrent resolve-vs-invalidate test via a small time-injection refactor.
- [ ] `SEC-TENANT-CASCADE` — Follow-up: FK cascade user-deletion (`admin.ts:366`, `me.ts:306`) deletes memberships WITHOUT calling `invalidateResolveTenantCache()`; bounded by the 30s TTL. Add invalidation there (or accept the TTL bound).

## AI Flaky tests
- Not applicable: service + unit test only.

## Orchestration Mode (AI-selected)
- [x] Mono-branch + cherry-pick.
- [ ] Multi-branch.
- Rationale: one atomic security fix (2 files + 1 test); codex-built, independently reviewed, conductor-gated.

## Plan / Todo (lot-based)
- [x] Lot 0 — RCA: process-lifetime cache bakes membership status; `decideMembership` is the single transition point; no import cycle.
- [x] Lot 1 — codex terra builds invalidation + TTL + generation-guard + suspension-deny test.
- [x] Lot 2 — Independent review (2 passes, SHIP-WITH-NOTES; TOCTOU retired); accurate cross-pod doc comment.
- [ ] Lot 3 — PR CI green (suspension-deny test + build) -> conductor gate -> merge -> report; owner sign-off on the 30s window before strict cutover.
