### PR TITLE
fix(llm-mesh): honor transport order for launch aliases

### DIFF
--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,9 +1,9 @@
 # BR-73: LLM mesh/gateway consumer-neutral routing
 
-Status: ACTIVE — implementation phase
-Branch: `feat/llm-mesh-gateway-routing`
-Worktree: `tmp/llm-mesh-gateway-routing`
-Base: `origin/main` at `feebc6769aac8bd313d84310b1f0d66d07b68ee1`
+Status: ACTIVE — post-merge UAT corrective phase
+Branch: `fix/llm-mesh-alias-transport-preference`
+Worktree: `/tmp/sentropic-br73-final`
+Base: `origin/main` at `9d67d60f832ca4ff6f12ac8a88ff9cd798033c15`
 Track feature: `01KZHZCNN1CR98NCE9KB7ZZM8G`
 Track imported branch root: `01KZHZDBD07V5DJ5TBW7WRHV1D` (workspace `br-73`)
 Canonical evolution spec: `spec/SPEC_EVOL_LLM_MESH_GATEWAY_ROUTING.md`
@@ -24,6 +24,9 @@ knowledge.
 - Routing policy and the model-equivalence council belong to `llm-mesh`.
 - Owner-ratified xhigh aliases include Opus 5/4.8 to Terra, Fable 5 to Sol,
   and Sonnet 5 to Luna; bare provider ids remain provider-faithful.
+- Those suffixed launch aliases expose both the ratified Codex target and the
+  executable Cloud Code Gemini target. Ordered policy selects between them;
+  this explicit alias contract is not general model-equivalence evidence.
 - Equivalence entries are benchmark-backed, overridable, and mandatory to
   update or explicitly exclude whenever a model is added to the mesh catalog.
 - The gateway remains usable in every direction: for Claude Code, Codex, AGY,
@@ -95,6 +98,15 @@ knowledge.
   the root lockfile only for the gateway dependency floor and the two package
   versions. Impact is lock metadata only; rollback is the matching lockfile
   hunk if either package bump is reverted.
+
+## Post-merge UAT corrective lot
+
+- [x] Reproduce the defect after 0.14.0/0.12.0 publication: Cloud-first still
+  selected Codex for `claude-opus-5-xhigh` although both accounts were ready.
+- [x] Preserve bare provider model fidelity and the evidence-gated council.
+- [x] Expose multi-transport candidates only for explicit suffixed aliases.
+- [x] Verify one real alias executes through Cloud Code first and Codex first.
+- [ ] Obtain one exact-head adversarial review, merge through CI and publish.
 
 ## Environment and agent slots
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18179,10 +18179,10 @@
     },
     "packages/llm-gateway": {
       "name": "@sentropic/llm-gateway",
-      "version": "0.11.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
-        "@sentropic/llm-mesh": "^0.14.0",
+        "@sentropic/llm-mesh": "^0.15.0",
         "hono": "^4.10.7"
       },
       "devDependencies": {
@@ -18421,7 +18421,7 @@
     },
     "packages/llm-mesh": {
       "name": "@sentropic/llm-mesh",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT"
     },
     "packages/mcp-auth": {

--- a/packages/llm-gateway/package.json
+++ b/packages/llm-gateway/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/llm-gateway",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Authenticated, pooled, metered LLM egress gateway for Sentropic (WP16 Layer B). Provider-compatible Anthropic/OpenAI wire over the @sentropic/llm-mesh account pool.",
   "type": "module",
   "license": "MIT",
@@ -33,7 +33,7 @@
     "test": "vitest run tests"
   },
   "dependencies": {
-    "@sentropic/llm-mesh": "^0.14.0",
+    "@sentropic/llm-mesh": "^0.15.0",
     "hono": "^4.10.7"
   },
   "devDependencies": {

--- a/packages/llm-gateway/src/personal-passthrough/target.ts
+++ b/packages/llm-gateway/src/personal-passthrough/target.ts
@@ -1,16 +1,20 @@
 /** @deprecated Routing values are direct re-exports from @sentropic/llm-mesh. */
 export {
   CANONICAL_TARGET_MAPPINGS,
+  CANONICAL_TARGET_ROUTE_MAPPINGS,
+  createCanonicalTargetCandidatesResolver,
   createCanonicalTargetResolver,
   createStaticTargetResolver,
   DEFAULT_TARGET_MAPPINGS,
   defineLaunchAliases,
   describeCanonicalTargetRoutes,
   describeTargetRoutes,
+  LAUNCH_ALIAS_ROUTE_MAPPINGS,
   LAUNCH_ALIAS_TARGET_MAPPINGS,
 } from '@sentropic/llm-mesh';
 export type {
   LaunchAliasDefinition,
+  ModelTargetCandidatesResolver,
   TargetMapping,
   TargetRouteDescription,
 } from '@sentropic/llm-mesh';

--- a/packages/llm-gateway/tests/target.test.ts
+++ b/packages/llm-gateway/tests/target.test.ts
@@ -6,19 +6,22 @@
  *   - Fable 5 high/xhigh/max  -> gpt-5.6-sol   at the same effort
  *   - Sonnet 5 xhigh          -> gpt-5.6-luna  xhigh
  *   - BARE ids stay provider-faithful (the real Anthropic models stay reachable)
- *   - no silent cross-pool fallback (unknown id -> undefined -> router 400)
+ *   - suffixed aliases expose ratified Codex + Cloud Code candidates to policy
+ *   - bare ids stay provider-faithful; unknown id -> undefined -> router 400
  * Consumers read `describeTargetRoutes()` instead of duplicating a route table.
  */
 
 import { describe, expect, it } from 'vitest';
 
 import {
+  createCanonicalTargetCandidatesResolver,
   createCanonicalTargetResolver,
   createStaticTargetResolver,
   defineLaunchAliases,
   describeCanonicalTargetRoutes,
   describeTargetRoutes,
   CANONICAL_TARGET_MAPPINGS,
+  CANONICAL_TARGET_ROUTE_MAPPINGS,
   DEFAULT_TARGET_MAPPINGS,
   LAUNCH_ALIAS_TARGET_MAPPINGS,
 } from '../src/index.js';
@@ -142,13 +145,29 @@ describe('describeTargetRoutes (discovery)', () => {
     // composing DEFAULT + LAUNCH_ALIAS is itself routing knowledge and must not
     // be re-implemented downstream.
     expect(CANONICAL_TARGET_MAPPINGS).toEqual(MERGED);
-    expect(describeCanonicalTargetRoutes()).toEqual(describeTargetRoutes(MERGED));
+    expect(CANONICAL_TARGET_ROUTE_MAPPINGS['claude-opus-5-xhigh']).toEqual([
+      MERGED['claude-opus-5-xhigh'],
+      {
+        providerId: 'gemini',
+        transportProviderId: 'cloud-code',
+        model: 'gemini-3.1-flash-lite',
+      },
+    ]);
+    expect(describeCanonicalTargetRoutes()).toHaveLength(
+      Object.keys(DEFAULT_TARGET_MAPPINGS).length
+        + (2 * Object.keys(LAUNCH_ALIAS_TARGET_MAPPINGS).length),
+    );
 
     const resolve = createCanonicalTargetResolver();
     expect(resolve('claude-opus-5-xhigh')?.model).toBe('gpt-5.6-terra');
     expect(resolve('claude-opus-5')?.model).toBe('claude-opus-5');
     expect(resolve('claude-opus-4-8-xhigh')?.model).toBe('gpt-5.6-terra');
     expect(resolve('claude-sonnet-5-xhigh')?.model).toBe('gpt-5.6-luna');
+
+    const resolveCandidates = createCanonicalTargetCandidatesResolver();
+    expect(resolveCandidates('claude-opus-5-xhigh').map(
+      (target) => target.transportProviderId,
+    )).toEqual(['codex', 'cloud-code']);
   });
 
   it('describes every servable id exactly once, sorted, with no credential data', () => {

--- a/packages/llm-mesh/README.md
+++ b/packages/llm-mesh/README.md
@@ -40,6 +40,12 @@ preferred route is suppressed until its TTL expires, then tested again.
 `one-way` promotes a successful fallback instead. Override `negativeCacheTtlMs`
 between 1 second and 1 hour.
 
+Suffixed Claude launch aliases expose the owner-ratified Codex and Cloud Code
+targets returned by `createCanonicalTargetCandidatesResolver()`. An ordered
+policy can therefore place either enrolled transport first and keep the other
+as bounded pre-byte fallback. Bare provider model ids remain provider-faithful;
+these explicit alias routes do not create general model equivalence.
+
 Equivalent-account rotation is disabled by default. Enabling
 `rotateEquivalentAccounts` may move an affinity to another account and lose
 provider-side prompt/session cache continuity; such a move is exposed as an

--- a/packages/llm-mesh/package.json
+++ b/packages/llm-mesh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentropic/llm-mesh",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "Provider-agnostic LLM access runtime SDK for Sentropic.",
   "type": "module",
   "license": "MIT",

--- a/packages/llm-mesh/src/route-selection.ts
+++ b/packages/llm-mesh/src/route-selection.ts
@@ -2,7 +2,7 @@ import { modelProfiles, type ModelProfile } from './catalog.js';
 import { modelSupportsCapability, type ModelEquivalenceCouncil } from './equivalence-council.js';
 import type { EligibleAccountDescriptor, PlannedRouteTarget, RoutePlanInput } from './routing-contracts.js';
 import { resolveRouteStrategy, type RoutePolicy, type RouteSelector } from './routing-policy.js';
-import { createCanonicalTargetResolver } from './routing-targets.js';
+import { createCanonicalTargetCandidatesResolver } from './routing-targets.js';
 export interface RankedRouteCandidate {
   readonly account: EligibleAccountDescriptor;
   readonly target: PlannedRouteTarget;
@@ -15,7 +15,7 @@ interface ResolvedRouteTarget {
   readonly transportPreferences?: readonly string[];
   readonly reason: PlannedRouteTarget['reason'];
 }
-const resolveCanonical = createCanonicalTargetResolver();
+const resolveCanonicalTargets = createCanonicalTargetCandidatesResolver();
 const supportsCapabilities = (
   profile: ModelProfile | undefined,
   required: RoutePlanInput['requiredCapabilities'],
@@ -35,21 +35,24 @@ const selectorMatches = (
   && (!selector.diagnosticAccountRef
     || selector.diagnosticAccountRef === candidate.account.diagnosticAccountRef);
 
-const resolveRequestedTarget = (requestedModel: string): {
+const resolveRequestedTargets = (requestedModel: string): readonly {
   providerId: string;
   model: string;
   transportProviderId?: string;
   effort?: string;
   reason: 'exact' | 'alias';
-} | undefined => {
-  const canonical = resolveCanonical(requestedModel);
-  if (canonical) return { ...canonical, reason: requestedModel === canonical.model ? 'exact' as const : 'alias' as const };
+}[] => {
+  const canonical = resolveCanonicalTargets(requestedModel);
+  if (canonical.length > 0) return canonical.map((target) => ({
+    ...target,
+    reason: requestedModel === target.model ? 'exact' as const : 'alias' as const,
+  }));
   const profile = modelProfiles.find((candidate) => candidate.modelId === requestedModel);
-  return profile ? {
+  return profile ? [{
     providerId: profile.providerId,
     model: profile.modelId,
     reason: 'exact' as const,
-  } : undefined;
+  }] : [];
 };
 
 export const selectRouteCandidates = (input: {
@@ -61,13 +64,9 @@ export const selectRouteCandidates = (input: {
   readonly now?: Date;
   readonly applyAttemptLimit?: boolean;
 }): readonly RankedRouteCandidate[] => {
-  const resolved = resolveRequestedTarget(input.request.requestedModel);
-  if (!resolved) return [];
-  const requestedProfile = modelProfiles.find((profile) =>
-    profile.providerId === resolved.providerId && profile.modelId === resolved.model);
-  if (!supportsCapabilities(requestedProfile, input.request.requiredCapabilities)) return [];
-
-  const targets: ResolvedRouteTarget[] = [{
+  const resolvedTargets = resolveRequestedTargets(input.request.requestedModel);
+  if (resolvedTargets.length === 0) return [];
+  const targets: ResolvedRouteTarget[] = resolvedTargets.map((resolved) => ({
     providerId: resolved.providerId,
     modelId: resolved.model,
     ...(resolved.effort ? { effort: resolved.effort } : {}),
@@ -75,26 +74,29 @@ export const selectRouteCandidates = (input: {
       ? { transportProviderId: resolved.transportProviderId }
       : {}),
     reason: resolved.reason,
-  }];
+  }));
   if (input.policy.allowEquivalentModels) {
     const now = (input.now ?? new Date()).getTime();
-    const group = input.council.groups.find((candidate) =>
-      Date.parse(candidate.expiresAt) > now
-      && candidate.evidence.length > 0
-      && candidate.members.some((member) =>
-        member.providerId === resolved.providerId && member.modelId === resolved.model));
-    group?.members.filter((member) =>
-      member.providerId !== resolved.providerId || member.modelId !== resolved.model)
-      .sort((left, right) => left.rank - right.rank)
-      .forEach((member) => targets.push({
-        providerId: member.providerId,
-        modelId: member.modelId,
-        ...(member.effort ? { effort: member.effort } : {}),
-        ...(member.transportPreferences
-          ? { transportPreferences: member.transportPreferences }
-          : {}),
-        reason: 'equivalent',
-      }));
+    for (const resolved of resolvedTargets) {
+      const group = input.council.groups.find((candidate) =>
+        Date.parse(candidate.expiresAt) > now
+        && candidate.evidence.length > 0
+        && candidate.members.some((member) =>
+          member.providerId === resolved.providerId && member.modelId === resolved.model));
+      group?.members.filter((member) =>
+        !targets.some((target) => target.providerId === member.providerId
+          && target.modelId === member.modelId))
+        .sort((left, right) => left.rank - right.rank)
+        .forEach((member) => targets.push({
+          providerId: member.providerId,
+          modelId: member.modelId,
+          ...(member.effort ? { effort: member.effort } : {}),
+          ...(member.transportPreferences
+            ? { transportPreferences: member.transportPreferences }
+            : {}),
+          reason: 'equivalent',
+        }));
+    }
   }
 
   let candidates = targets.flatMap((target) => {

--- a/packages/llm-mesh/src/routing-targets.ts
+++ b/packages/llm-mesh/src/routing-targets.ts
@@ -15,6 +15,9 @@ export interface TargetRouteDescription extends TargetMapping {
 }
 
 export type ModelTargetResolver = (model: string) => TargetMapping | undefined;
+export type ModelTargetCandidatesResolver = (
+  model: string,
+) => readonly TargetMapping[];
 
 export const defineLaunchAliases = (
   definitions: readonly LaunchAliasDefinition[],
@@ -56,9 +59,36 @@ export const LAUNCH_ALIAS_TARGET_MAPPINGS = defineLaunchAliases([
   { alias: 'claude-sonnet-5-xhigh', providerId: 'openai', transportProviderId: 'codex', model: 'gpt-5.6-luna', effort: 'xhigh' },
 ]);
 
+const CLOUD_CODE_LAUNCH_TARGET: TargetMapping = {
+  providerId: 'gemini',
+  transportProviderId: 'cloud-code',
+  model: 'gemini-3.1-flash-lite',
+};
+
+/**
+ * A launch alias is an explicit user-facing routing contract, not benchmark
+ * equivalence evidence. Keep the historical Codex target first for backwards
+ * compatibility while exposing the owner-ratified Cloud Code target to route
+ * policy ordering and bounded pre-byte fallback.
+ */
+export const LAUNCH_ALIAS_ROUTE_MAPPINGS: Readonly<
+  Record<string, readonly TargetMapping[]>
+> = Object.fromEntries(Object.entries(LAUNCH_ALIAS_TARGET_MAPPINGS).map(
+  ([alias, primary]) => [alias, [primary, CLOUD_CODE_LAUNCH_TARGET]],
+));
+
 export const CANONICAL_TARGET_MAPPINGS: Readonly<Record<string, TargetMapping>> = {
   ...DEFAULT_TARGET_MAPPINGS,
   ...LAUNCH_ALIAS_TARGET_MAPPINGS,
+};
+
+export const CANONICAL_TARGET_ROUTE_MAPPINGS: Readonly<
+  Record<string, readonly TargetMapping[]>
+> = {
+  ...Object.fromEntries(Object.entries(DEFAULT_TARGET_MAPPINGS).map(
+    ([requestedId, target]) => [requestedId, [target]],
+  )),
+  ...LAUNCH_ALIAS_ROUTE_MAPPINGS,
 };
 
 export const createStaticTargetResolver = (options: {
@@ -67,6 +97,10 @@ export const createStaticTargetResolver = (options: {
 
 export const createCanonicalTargetResolver = (): ModelTargetResolver =>
   createStaticTargetResolver({ mappings: CANONICAL_TARGET_MAPPINGS });
+
+export const createCanonicalTargetCandidatesResolver = (
+): ModelTargetCandidatesResolver => (model) =>
+  CANONICAL_TARGET_ROUTE_MAPPINGS[model] ?? [];
 
 export const describeTargetRoutes = (
   mappings: Readonly<Record<string, TargetMapping>>,
@@ -79,4 +113,11 @@ export const describeTargetRoutes = (
   .sort((left, right) => left.requestedId.localeCompare(right.requestedId));
 
 export const describeCanonicalTargetRoutes = (): readonly TargetRouteDescription[] =>
-  describeTargetRoutes(CANONICAL_TARGET_MAPPINGS);
+  Object.entries(CANONICAL_TARGET_ROUTE_MAPPINGS)
+    .flatMap(([requestedId, targets]) => targets.map((target) => ({
+      requestedId,
+      ...target,
+      kind: requestedId === target.model ? 'faithful' as const : 'alias' as const,
+    })))
+    .sort((left, right) => left.requestedId.localeCompare(right.requestedId)
+      || left.transportProviderId.localeCompare(right.transportProviderId));

--- a/packages/llm-mesh/tests/route-selection.test.ts
+++ b/packages/llm-mesh/tests/route-selection.test.ts
@@ -55,6 +55,86 @@ describe('route candidate selection', () => {
     expect(candidates[0]?.target.transportProviderId).toBe('cloud-code');
   });
 
+  it('inverts one launch alias between enrolled Codex and Cloud Code transports', () => {
+    const launchAccounts = [
+      {
+        accountRef: 'codex-internal',
+        diagnosticAccountRef: 'codex-redacted',
+        targetProviderId: 'openai',
+        transportProviderId: 'codex',
+        supportedModelIds: ['gpt-5.6-terra'],
+        enrollmentCompletedAt: '2026-08-01T00:00:00Z',
+        readiness: 'ready' as const,
+        revision: 'r1',
+      },
+      {
+        accountRef: 'cloud-internal',
+        diagnosticAccountRef: 'cloud-redacted',
+        targetProviderId: 'gemini',
+        transportProviderId: 'cloud-code',
+        supportedModelIds: ['gemini-3.1-flash-lite'],
+        enrollmentCompletedAt: '2026-08-02T00:00:00Z',
+        readiness: 'ready' as const,
+        revision: 'r1',
+      },
+    ];
+    const choose = (first: 'codex' | 'cloud-code') => selectRouteCandidates({
+      request: { requestedModel: 'claude-opus-5-xhigh' },
+      policy: {
+        ...DEFAULT_ROUTE_POLICY,
+        strategy: {
+          kind: 'ordered',
+          preferences: [
+            { transportProviderId: first },
+            { transportProviderId: first === 'codex' ? 'cloud-code' : 'codex' },
+          ],
+        },
+      },
+      council: DEFAULT_MODEL_EQUIVALENCE_COUNCIL,
+      accounts: launchAccounts,
+    });
+
+    expect(choose('codex').map((candidate) => candidate.target.transportProviderId))
+      .toEqual(['codex', 'cloud-code']);
+    expect(choose('cloud-code').map((candidate) => candidate.target.transportProviderId))
+      .toEqual(['cloud-code', 'codex']);
+  });
+
+  it('keeps a bare provider model faithful when another transport is preferred', () => {
+    const candidates = selectRouteCandidates({
+      request: { requestedModel: 'gpt-5.6-terra' },
+      policy: {
+        ...DEFAULT_ROUTE_POLICY,
+        strategy: {
+          kind: 'ordered',
+          preferences: [
+            { transportProviderId: 'cloud-code' },
+            { transportProviderId: 'codex' },
+          ],
+        },
+      },
+      council: DEFAULT_MODEL_EQUIVALENCE_COUNCIL,
+      accounts: [{
+        accountRef: 'codex-internal',
+        diagnosticAccountRef: 'codex-redacted',
+        targetProviderId: 'openai',
+        transportProviderId: 'codex',
+        supportedModelIds: ['gpt-5.6-terra'],
+        enrollmentCompletedAt: '2026-08-01T00:00:00Z',
+        readiness: 'ready',
+        revision: 'r1',
+      }],
+    });
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]?.target).toMatchObject({
+      providerId: 'openai',
+      modelId: 'gpt-5.6-terra',
+      transportProviderId: 'codex',
+      reason: 'exact',
+    });
+  });
+
   it('rotates only the starting candidate for a new affinity', () => {
     const policy = {
       ...DEFAULT_ROUTE_POLICY,

--- a/packages/llm-mesh/tests/routing-targets.test.ts
+++ b/packages/llm-mesh/tests/routing-targets.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  createCanonicalTargetCandidatesResolver,
   createCanonicalTargetResolver,
   describeCanonicalTargetRoutes,
 } from '../src/routing-targets.js';
 
 describe('canonical model targets', () => {
   const resolve = createCanonicalTargetResolver();
+  const resolveCandidates = createCanonicalTargetCandidatesResolver();
 
   it('keeps bare ids provider-faithful', () => {
     expect(resolve('claude-opus-5')).toEqual({
@@ -34,6 +36,29 @@ describe('canonical model targets', () => {
       model: 'gpt-5.6-luna',
       effort: 'xhigh',
     });
+  });
+
+  it('exposes owner-ratified Codex and Cloud Code candidates for launch aliases', () => {
+    expect(resolveCandidates('claude-opus-5-xhigh')).toEqual([
+      {
+        providerId: 'openai',
+        transportProviderId: 'codex',
+        model: 'gpt-5.6-terra',
+        effort: 'xhigh',
+      },
+      {
+        providerId: 'gemini',
+        transportProviderId: 'cloud-code',
+        model: 'gemini-3.1-flash-lite',
+      },
+    ]);
+    expect(resolveCandidates('gpt-5.6-terra')).toEqual([
+      {
+        providerId: 'openai',
+        transportProviderId: 'codex',
+        model: 'gpt-5.6-terra',
+      },
+    ]);
   });
 
   it('describes routes without account or credential fields', () => {

--- a/spec/SPEC_EVOL_LLM_MESH_GATEWAY_ROUTING.md
+++ b/spec/SPEC_EVOL_LLM_MESH_GATEWAY_ROUTING.md
@@ -263,21 +263,24 @@ provider/model/transport separately.
 
 The existing owner-ratified suffixed aliases migrate from gateway to mesh:
 
-| Requested alias | Canonical candidate | Effort |
-|---|---|---|
-| `claude-opus-5-high` | `openai:gpt-5.6-terra` | `high` |
-| `claude-opus-5-xhigh` | `openai:gpt-5.6-terra` | `xhigh` |
-| `claude-opus-4-8-xhigh` | `openai:gpt-5.6-terra` | `xhigh` |
-| `claude-fable-5-high` | `openai:gpt-5.6-sol` | `high` |
-| `claude-fable-5-xhigh` | `openai:gpt-5.6-sol` | `xhigh` |
-| `claude-fable-5-max` | `openai:gpt-5.6-sol` | `max` |
-| `claude-sonnet-5-xhigh` | `openai:gpt-5.6-luna` | `xhigh` |
+| Requested alias | Codex candidate | Cloud Code candidate | Effort |
+|---|---|---|---|
+| `claude-opus-5-high` | `openai:gpt-5.6-terra` | `gemini:gemini-3.1-flash-lite` | `high` |
+| `claude-opus-5-xhigh` | `openai:gpt-5.6-terra` | `gemini:gemini-3.1-flash-lite` | `xhigh` |
+| `claude-opus-4-8-xhigh` | `openai:gpt-5.6-terra` | `gemini:gemini-3.1-flash-lite` | `xhigh` |
+| `claude-fable-5-high` | `openai:gpt-5.6-sol` | `gemini:gemini-3.1-flash-lite` | `high` |
+| `claude-fable-5-xhigh` | `openai:gpt-5.6-sol` | `gemini:gemini-3.1-flash-lite` | `xhigh` |
+| `claude-fable-5-max` | `openai:gpt-5.6-sol` | `gemini:gemini-3.1-flash-lite` | `max` |
+| `claude-sonnet-5-xhigh` | `openai:gpt-5.6-luna` | `gemini:gemini-3.1-flash-lite` | `xhigh` |
 
-Bare provider model ids remain provider-faithful. Alias migration preserves
-existing behaviour but does not by itself authorize automatic fallback. Before
-automatic equivalence fallback is enabled for a group, its evidence must be
-fresh and its required capabilities must be satisfied. Stale evidence fails
-closed for automatic substitution while exact requested routes remain usable.
+Bare provider model ids remain provider-faithful. A suffixed launch alias is an
+explicit owner-ratified multi-transport route: its ordered policy may select the
+Codex or Cloud Code candidate above and bounded pre-byte fallback may try the
+other. This explicit alias contract is not benchmark equivalence evidence and
+does not make bare models interchangeable. Before any additional automatic
+equivalence fallback is enabled for a group, its evidence must be fresh and its
+required capabilities must be satisfied. Stale evidence fails closed for
+automatic substitution while exact requested routes remain usable.
 
 The first implementation ships a conservative coding council using only
 existing ratified aliases plus benchmark evidence available in the repository.


### PR DESCRIPTION
## Outcome

Make ordered transport preference effective for the same suffixed Claude launch alias across enrolled Codex and Cloud Code accounts.

## Root cause

`selectRouteCandidates()` previously resolved a launch alias to one Codex target before applying `RoutePolicy.strategy`. A `cloud-code, codex` order therefore had no Cloud Code candidate to rank, even when both accounts were ready.

## Fix

- expose the explicit owner-ratified Codex and Cloud Code candidates for suffixed launch aliases;
- preserve the existing single-target resolver as the compatibility-primary API;
- let ordered/last-enrolled/round-robin policy operate on the candidate list;
- keep bare provider model ids provider-faithful;
- keep general equivalence evidence-gated by the council;
- publish `@sentropic/llm-mesh@0.15.0` and aligned `@sentropic/llm-gateway@0.13.0` through merge-triggered CI.

## Verification

- `@sentropic/llm-mesh`: typecheck/build/pack; 25 test files, 142 tests passed
- `@sentropic/llm-gateway`: typecheck/build/pack; 16 test files, 109 tests passed
- model council freshness and `git diff --check` passed
- exact source UAT with both enrolled accounts and the same `claude-opus-5-xhigh` alias:
  - Cloud-first → `cloud-code` / `gemini-3.1-flash-lite` → `DIRECT_OK`
  - Codex-first → `codex` / `gpt-5.6-terra` → `DIRECT_OK`
- one exact-head Opus 4.8 xhigh adversarial review via `h2a run claude --no-gw`: `VERDICT: PASS`, no merge-blocking defect
- Track event containment: 325/325, no missing ids

PR #529 is already merged; this is the post-publication UAT follow-up. h2a PR #199 is unrelated and untouched.
