### PR TITLE
docs(llm-mesh): recurring model-update runbook + add-model scaffold

### DIFF
--- a/.tmp/engage/model-update-runbook-report.md
+++ b/.tmp/engage/model-update-runbook-report.md
@@ -33,8 +33,8 @@ and mesh-lane launch packet. The branch was pushed; the PR was not merged.
 
 ## Evidence and validation
 
-- Canonical reference: PR #540 / `origin/feat/llm-mesh-gemini-37` inspected
-  against base `origin/main` merge PR #539.
+- Canonical reference: PR #540 / `origin/feat/llm-mesh-gemini-37`, now merged
+  into base `origin/main` at `28d57d098`.
 - Official OpenAI, Anthropic, and Google model registries returned HTTP 200.
 - `make llm-mesh-add-model MODEL=gpt-5.7-sol BASE=gpt-5.6-sol DRY_RUN=1` passed
   without changing model sources.
@@ -56,7 +56,8 @@ and mesh-lane launch packet. The branch was pushed; the PR was not merged.
   not the exact author model or effort. The harness forbids inferred identity,
   so no independent blind-consensus claim was fabricated. PR review remains
   required.
-- PR #540 is not merged into the branch base; its changes are evidence only.
+- PR #540 is merged into the branch base; its 0.16.0 package and lockfile state
+  is preserved as current-tree reference material.
 - Vendor documentation is mutable; each future update must retain dated
   official model-id evidence in its own PR.
 - h-cond/h2a-runtime host defaults, including agy, live outside this repo and

--- a/.tmp/engage/model-update-runbook-report.md
+++ b/.tmp/engage/model-update-runbook-report.md
@@ -1,0 +1,72 @@
+---
+protocol: sentropic.h2a
+version: "1.0"
+kind: report
+branch: feat/llm-model-update-runbook
+head: 090ad60c396c0b827b0e7e1f833b46118721d7db
+pull_request: https://github.com/rhanka/sentropic/pull/541
+review_status: selection-failed
+---
+
+# BR-75 recurring LLM model-update report
+
+## Outcome
+
+Draft PR #541 delivers the recurring owner runbook, a dry-run-safe and
+idempotent add-model scaffold, its focused tests, and the copy-ready drumbeat
+and mesh-lane launch packet. The branch was pushed; the PR was not merged.
+
+## Delivered surfaces
+
+- `spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md`: official-source anti-phantom gate,
+  catalog/provider/routing/council workflow, full internal consumer audit,
+  semver and mesh-before-gateway publication order, external host handoff, and
+  current-tree file/line map.
+- `make llm-mesh-add-model MODEL=<id> BASE=<id> [DRY_RUN=1]`: additive Make
+  entrypoint under `BR75-EX1`.
+- `packages/llm-mesh/scripts/add-model.mjs`: catalog, provider, and faithful
+  default-route stubs copied from `BASE`; safe retry and no-write dry run.
+- `packages/llm-mesh/tests/add-model-script.test.ts`: dry-run, valid-stub,
+  idempotence, partial-repair, and invalid-input coverage.
+- `docs/runbooks/model-update-launch-packet.md`: standard owner directive and
+  lane mandate with Codex 5.6 Sol xhigh build and blind Opus 4.8 review gates.
+
+## Evidence and validation
+
+- Canonical reference: PR #540 / `origin/feat/llm-mesh-gemini-37` inspected
+  against base `origin/main` merge PR #539.
+- Official OpenAI, Anthropic, and Google model registries returned HTTP 200.
+- `make llm-mesh-add-model MODEL=gpt-5.7-sol BASE=gpt-5.6-sol DRY_RUN=1` passed
+  without changing model sources.
+- Model-council freshness check passed.
+- `@sentropic/llm-mesh`: 147 tests passed; `@sentropic/llm-gateway`: 111 tests
+  passed; scaffold suite: 3 tests passed.
+- `make build`, `make typecheck`, and `make lint` passed with the isolated BR75
+  ports and `REGISTRY=local`.
+- Scope checks (`make scope-check` and `harness check scope`) passed.
+- The local full `make test` passed smoke, unit, endpoint, queue, and security
+  execution before reaching `api/tests/ai/**`. It then failed 18 AI tests with
+  `Provider auth source is not configured`: all five provider keys are unset
+  locally, while CI injects them explicitly. Runtime/auth paths are unchanged.
+  CI run 31964219134 is the authoritative remote test gate.
+
+## Open gates and source gaps
+
+- Review status is `selection-failed`: this session attests the Codex host but
+  not the exact author model or effort. The harness forbids inferred identity,
+  so no independent blind-consensus claim was fabricated. PR review remains
+  required.
+- PR #540 is not merged into the branch base; its changes are evidence only.
+- Vendor documentation is mutable; each future update must retain dated
+  official model-id evidence in its own PR.
+- h-cond/h2a-runtime host defaults, including agy, live outside this repo and
+  remain a notification handoff.
+- The current base contains stale consumer-version metadata in some lock and
+  template surfaces; future model-update PRs must update or explicitly defer
+  each audited consumer rather than copying those values blindly.
+
+## Owner handoff
+
+Review PR #541, require the remote CI result and an eligible blind reviewer,
+then use the launch packet for the next model update. Do not merge from this
+delivery lane.

--- a/.tmp/engage/pr541-rebase-report.md
+++ b/.tmp/engage/pr541-rebase-report.md
@@ -1,0 +1,51 @@
+---
+protocol: sentropic.h2a
+version: "1.0"
+kind: report
+branch: feat/llm-model-update-runbook
+validated_head: 6b144a35b26e6e3a58aaa961457b242f43be2819
+base: 28d57d098
+pull_request: https://github.com/rhanka/sentropic/pull/541
+ci_run: https://github.com/rhanka/sentropic/actions/runs/31966829799
+merged: false
+---
+
+# PR #541 rebase report
+
+## Outcome
+
+PR #541 was rebased onto `origin/main` after PR #540 merged. The runbook,
+`make llm-mesh-add-model` scaffold, focused tests, and launch packet remain
+present. Main's `@sentropic/llm-mesh` 0.16.0 package and lockfile state remain
+unchanged. The branch was force-pushed with lease and was not merged.
+
+## Rebase evidence
+
+- Verified branch: `feat/llm-model-update-runbook`.
+- Fetched `origin/main` at `28d57d098` and rebased all eight functional
+  runbook commits.
+- Resolved the `BRANCH.md` conflict by retaining the runbook scope while
+  aligning its base context with the merged Gemini 3.7 cutover.
+- Preserved package manifests and `package-lock.json` from main; the package
+  audit reports `@sentropic/llm-mesh` 0.16.0.
+- Added post-rebase documentation alignment commit `6b144a35b`.
+
+## Validation
+
+- `make build REGISTRY=local ENV=test-model-update-runbook`: passed.
+- `make typecheck API_PORT=9375 UI_PORT=5575 MAILDEV_UI_PORT=1475 REGISTRY=local ENV=test-model-update-runbook`: passed.
+- `make lint API_PORT=9375 UI_PORT=5575 MAILDEV_UI_PORT=1475 REGISTRY=local ENV=test-model-update-runbook`: passed with existing warnings and no errors.
+- Focused scaffold suite: 3 tests passed.
+- Scaffold dry run: passed without modifying model sources.
+- Scope checks: `make scope-check` and `harness check scope` passed.
+- CI run `31966829799`: passed. The first live-AI attempt timed out in
+  `initiative-generation-async`; its same-commit rerun passed in 5m24s under
+  the AI-flaky policy. `gh pr checks 541` exits zero.
+
+## Delivery state
+
+- Force-with-lease push completed for `feat/llm-model-update-runbook`.
+- Final PR state: open, `MERGEABLE` / `CLEAN`.
+- h2a envelope `env:pr541-rebase:6b144a35b:20260816T193136Z` was deposited
+  for dormant delivery to `claude:sentropic-drumbeat:21fe3355ad7d`.
+- No merge was performed.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -19,6 +19,7 @@
   - [x] `packages/llm-mesh/scripts/add-model.mjs`
   - [x] `packages/llm-mesh/tests/add-model-script.test.ts`
   - [x] `.tmp/engage/model-update-runbook-report.md`
+  - [x] `.tmp/engage/pr541-rebase-report.md`
 - [x] **Forbidden Paths (must not change in this branch)**
   - [x] `docker-compose*.yml`
   - [x] `.cursor/rules/**`
@@ -69,9 +70,9 @@
   - [x] Specify Codex 5.6 Sol xhigh build, blind Opus 4.8 review, exact evidence/scope/test/publish gates, stop conditions, and report contract.
   - [x] Gate: packet requires one directive, one make scaffold, one blind review, and no merge.
 
-- [ ] **Lot 4 — Final validation and PR-only delivery**
+- [x] **Lot 4 — Final validation and PR-only delivery**
   - [x] Run scope, council freshness, focused tests, dry run, build, typecheck, and lint gates; record the local provider-secret boundary for the full test gate.
   - [x] Record review selection failure: exact author model and effort are unattested, so independent blind peer eligibility cannot be proven without invention.
   - [x] Verify `git branch --show-current` immediately before every commit.
-  - [ ] Push `feat/llm-model-update-runbook`, open the requested PR without merging, and verify CI.
-  - [ ] Write `.tmp/engage/model-update-runbook-report.md` and deposit a valid `sentropic.h2a` v1.0 report to `claude:sentropic-drumbeat:21fe3355ad7d`.
+  - [x] Push `feat/llm-model-update-runbook`, open the requested PR without merging, and verify CI.
+  - [x] Write the delivery reports and deposit a valid `sentropic.h2a` v1.0 report to `claude:sentropic-drumbeat:21fe3355ad7d`.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -64,9 +64,9 @@
   - [ ] Gate: focused test and dry-run make invocation are green.
 
 - [ ] **Lot 3 — Standard MODEL UPDATE launch packet**
-  - [ ] Add copy-ready drumbeat and mesh-lane mandates for `MODEL=<X>` and `BASE=<Y>`.
-  - [ ] Specify Codex 5.6 Sol xhigh build, blind Opus 4.8 review, exact evidence/scope/test/publish gates, stop conditions, and report contract.
-  - [ ] Gate: packet requires one directive, one make scaffold, one blind review, and no merge.
+  - [x] Add copy-ready drumbeat and mesh-lane mandates for `MODEL=<X>` and `BASE=<Y>`.
+  - [x] Specify Codex 5.6 Sol xhigh build, blind Opus 4.8 review, exact evidence/scope/test/publish gates, stop conditions, and report contract.
+  - [x] Gate: packet requires one directive, one make scaffold, one blind review, and no merge.
 
 - [ ] **Lot 4 — Final validation and PR-only delivery**
   - [ ] Run `make scope-check`, `harness check scope`, council freshness, focused tests, dry run, build, typecheck, lint, and test gates.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -59,7 +59,7 @@
 - [ ] **Lot 2 — Safe add-model scaffold**
   - [x] Add an idempotent script that plans or applies catalog, provider, and default-route stubs copied from `BASE`.
   - [x] Make dry-run side-effect free and print the manual evidence, council, consumer, test, version, publication, and host-default checklist.
-  - [ ] Add focused tests for valid stubs, dry-run immutability, idempotence, partial repair, and invalid input.
+  - [x] Add focused tests for valid stubs, dry-run immutability, idempotence, partial repair, and invalid input.
   - [x] Add `make llm-mesh-add-model MODEL=<id> BASE=<id>` under `BR75-EX1`.
   - [ ] Gate: focused test and dry-run make invocation are green.
 

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -52,9 +52,9 @@
 
 - [ ] **Lot 1 — Owner runbook**
   - [x] Add the anti-phantom evidence gate and copy-from-BASE procedure.
-  - [x] Document catalog, provider, routing, and council refresh/check gates.
-  - [ ] Add a precise current-tree file-and-line table and mark every unresolved external/source gap.
-  - [ ] Gate: Markdown paths and cited line anchors verified against the current tree.
+  - [x] Document catalog, provider, routing, council refresh/check, tests, all consumer bumps, semver, ordered publication, and external host notification.
+  - [x] Add a precise current-tree file-and-line table and mark every unresolved external/source gap.
+  - [x] Gate: Markdown paths and cited line anchors verified against the current tree.
 
 - [ ] **Lot 2 — Safe add-model scaffold**
   - [x] Add an idempotent script that plans or applies catalog, provider, and default-route stubs copied from `BASE`.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -1,124 +1,76 @@
-# Feature: Real Gemini 3.7 Flash Integration
+# Feature: BR-75 Recurring LLM Model Update Runbook
 
 ## Objective
-- [x] Add the real `gemini-3.7-flash` profile to `@sentropic/llm-mesh` with verified limits and input modalities.
-- [x] Route agy Cloud Code execution to the real model without resolving through Gemini 3.5 Flash.
+- [x] Make recurring LLM model updates repeatable through one owner directive, one safe scaffold command, explicit evidence gates, and blind review.
 
 ## Scope / Guardrails
-- [x] Keep implementation under `packages/llm-mesh/**` except owner-required gateway dependency and generated artifact paths.
-- [x] Use only make targets for build, typecheck, lint, test, and generated artifacts.
-- [x] Use `ENV=test-llm-mesh-g37`, always as the last make argument.
-- [x] Keep root `ENV=dev` untouched and perform no merge, deploy, publication, or in-branch review.
-- [x] Keep each commit under 150 changed lines and stage explicit files only.
-- [x] Use owner-supplied verified specifications only; add no unverified capability or GCP variant.
+- [x] Base is `origin/main` at merge PR #539; PR #540 is the canonical model-cutover reference only.
+- [x] Scope is facilitation documentation, one additive scaffold script, its unit test, and one Make target.
+- [x] Preserve existing catalog, provider, routing, equivalence, package publication, and consumer behavior.
+- [x] Require official model-id evidence before any scaffold is applied.
+- [x] Use make-only commands, dedicated `ENV=test-model-update-runbook` for tests, selective staging, and sub-150-line commits.
+- [x] Keep all code, documentation, commit text, and PR text in English.
 
 ## Branch Scope Boundaries (MANDATORY)
 - [x] **Allowed Paths (implementation scope)**
   - [x] `BRANCH.md`
-  - [x] `packages/llm-mesh/**`
-  - [x] `packages/llm-gateway/package.json` — owner-required workspace consumer dependency correction under `G37-EX5`.
-  - [x] `packages/llm-gateway/tests/target.test.ts` — downstream workspace routing assertion under `G37-EX5`.
-  - [ ] `scripts/llm-model-equivalences/council.source.json` — owner-required generated-council source under `G37-EX1`.
-  - [x] `package-lock.json` — required workspace version synchronization under `G37-EX2`.
-  - [ ] `api/tests/unit/llm-runtime-stream.test.ts` — exhaustive advertised-model stream fixture under `G37-EX3`.
-  - [ ] `api/tests/api/models.test.ts` — exact public catalog response under `G37-EX4`.
-- [ ] **Forbidden Paths (must not change in this branch)**
-  - [ ] `Makefile`
-  - [ ] `docker-compose*.yml`
-  - [ ] `.cursor/rules/**`
-- [ ] **Conditional Paths**
-  - [ ] No additional conditional paths.
-- [ ] **Exception process**
-  - [ ] Declare reason, impact, and rollback before changing a conditional path.
+  - [x] `spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md`
+  - [x] `docs/runbooks/model-update-launch-packet.md`
+  - [x] `packages/llm-mesh/scripts/add-model.mjs`
+  - [x] `packages/llm-mesh/tests/add-model-script.test.ts`
+  - [x] `.tmp/engage/model-update-runbook-report.md`
+- [x] **Forbidden Paths (must not change in this branch)**
+  - [x] `docker-compose*.yml`
+  - [x] `.cursor/rules/**`
+  - [x] `.github/workflows/**`
+  - [x] Existing `packages/llm-mesh/src/**` model data and generated council output.
+  - [x] Package manifests and lockfiles; this branch does not ship a model or package runtime change.
+- [x] **Conditional Paths**
+  - [x] `Makefile` only under `BR75-EX1`.
+- [x] **Exception process**
+  - [x] Declare an exception before changing any other conditional or forbidden path.
 
 ## Feedback Loop
-- [x] `G37-EX1` (`acknowledge`, GRANTED) — the owner requires regeneration of the model council instead of manual generated-file edits.
-  - [x] Reason: the generator reads its canonical exclusions from `scripts/llm-model-equivalences/council.source.json`.
-  - [x] Impact: classify the new Gemini profile as non-equivalent without modifying council policy or generator code.
-  - [x] Rollback: remove the new exclusion and regenerate the artifact with the existing make target.
-- [x] `G37-EX2` (`acknowledge`, GRANTED) — the owner requires a publishable 0.16.0 workspace package.
-  - [x] Reason: root `npm ci` rejects the package bump while the workspace lock still records 0.15.1.
-  - [x] Impact: synchronize only the llm-mesh workspace version through `make lock-root`.
-  - [x] Rollback: restore the lock entry together with the package version.
-- [x] `G37-EX3` (`acknowledge`, GRANTED) — the owner requires green aggregate tests for the advertised model.
-  - [x] Reason: the API stream contract rejects any catalog model without a normalization fixture.
-  - [x] Impact: add one Gemini 3.7 row to the exhaustive fixture matrix; production API code is unchanged.
-  - [x] Rollback: remove the row together with the Gemini 3.7 catalog profile.
-- [x] `G37-EX4` (`acknowledge`, GRANTED) — the owner requires Gemini 3.7 in the public model catalog.
-  - [x] Reason: the endpoint contract asserts its exact provider/model response and total.
-  - [x] Impact: add Gemini 3.7 to the expected Gemini list and increment the expected total only.
-  - [x] Rollback: restore both expectations together with the catalog profile.
-- [x] `G37-EX5` (`acknowledge`, GRANTED) — the owner requires the sole gateway consumer to use mesh 0.16.0.
-  - [x] Reason: the gateway dependency range resolves an obsolete nested registry tarball instead of the workspace package.
-  - [x] Impact: raise the gateway mesh dependency floor, regenerate the root lockfile, and align its workspace routing assertion.
-  - [x] Rollback: restore the dependency range and regenerate the lockfile together.
-- [x] Keep `gemini-3.6-flash` as a compatibility-only capability alias repointed to 3.7; do not advertise it in the default Cloud Code inventory.
-- [x] Keep `gemini-3.1-pro` as a compatibility-only capability alias repointed to 3.7; no Claude route may target either legacy alias.
-- [x] Omit `google/gemini-3.7-flash@gcp`; agy uses Cloud Code and no supplied evidence verifies a GCP Model Garden key.
-- [x] Skip peer review in this branch because the owner explicitly reserved blind Opus review as a separate activity.
+- [x] `BR75-EX1` accepted by owner request: change the normally forbidden `Makefile` because the repository's make-only policy requires an entrypoint for this recurring job; impact is one additive target plus one script; rollback removes that target and script.
+- [x] Source gap: PR #540 is not merged into this branch base, so its Gemini 3.7 changes are evidence, not files to copy into this deliverable.
+- [x] Source gap: vendor documentation is mutable; every future update must capture its dated official model-id evidence in its PR.
+- [x] Source gap: host defaults for h-cond/h2a-runtime, including agy, live outside this repository and require a notification handoff rather than an in-repo edit.
 
 ## AI Flaky tests
-- [ ] Accept no deterministic failure or additive timeout as flaky.
-- [ ] Record eligible provider or network nondeterminism only with same-commit pass evidence and owner sign-off.
+- [x] Accept no deterministic scaffold, generation-freshness, typecheck, lint, build, or package test failure as flaky.
 
 ## Orchestration Mode
-- [x] **Mono-branch**
-- [x] Keep all implementation on `feat/llm-mesh-gemini-37` with no subagent or review lane.
+- [x] **Mono-branch** with no implementation sub-agent; two independent blind h2a review legs are read-only gates.
 
 ## Plan / Todo (lot-based)
-- [x] **Lot 0 — Assessment and decisions**
-  - [x] Read project rules, package documentation, catalog, providers, routing targets, generated council, account service, and Cloud Code transport.
-  - [x] Verify the isolated worktree branch with `harness check branch`.
-  - [x] Trace agy from launch aliases through route selection, eligible Cloud Code accounts, runtime client, and the Antigravity wire envelope.
-  - [x] Decide direct Gemini profile plus Cloud Code transport; omit the unverified GCP variant.
-  - [x] Decide the 3.6 compatibility alias behavior and record it in the delivery report.
-  - [x] Run `make scope-check ENV=test-llm-mesh-g37` after defining branch scope.
+- [x] **Lot 0 — Baseline and exact scope**
+  - [x] Read project rules, workflow, sub-agent contract, project context, PLAN model-council constraint, and branch template.
+  - [x] Verify `feat/llm-model-update-runbook` mechanically with `harness check branch`.
+  - [x] Confirm HEAD equals `origin/main` merge PR #539 and study the complete PR #540 delta.
+  - [x] Locate catalog, providers, route definitions, capability sources, council generator/check, publish order, and internal consumers.
+  - [x] Confirm official OpenAI, Anthropic, and Gemini model registries are reachable.
 
-- [x] **Lot 1 — Real model profile and council coverage**
-  - [x] Add `gemini-3.7-flash` to provider lists and the catalog with 1,000,000 input tokens, 65,536 output tokens, and text, image, audio, and video inputs.
-  - [x] Add no GCP catalog profile without verified GCP availability.
-  - [x] Classify the new profile as non-equivalent and regenerate `generated-model-council.ts` through `make refresh-llm-model-equivalences ENV=test-llm-mesh-g37`.
-  - [x] Add facade catalog tests for identity, limits, modalities, and provider capability inheritance.
-  - [x] Bump `@sentropic/llm-mesh` from `0.15.1` to `0.16.0`.
-  - [x] Gate: `make test-llm-mesh ENV=test-llm-mesh-g37` and `make check-llm-model-equivalences ENV=test-llm-mesh-g37`.
+- [ ] **Lot 1 — Owner runbook**
+  - [ ] Add the anti-phantom evidence gate and copy-from-BASE procedure.
+  - [ ] Document catalog, provider, routing, council refresh/check, tests, all consumer bumps, semver, ordered publication, and external host notification.
+  - [ ] Add a precise current-tree file-and-line table and mark every unresolved external/source gap.
+  - [ ] Gate: Markdown paths and cited line anchors verified against the current tree.
 
-- [x] **Lot 2 — Faithful agy Cloud Code routing**
-  - [x] Add the faithful canonical `gemini-3.7-flash` Cloud Code target.
-  - [x] Route standard agy candidates and the Cloud Code default to `gemini-3.7-flash`.
-  - [x] Replace the default Cloud Code account inventory entry for 3.6 with 3.7.
-  - [x] Repoint the 3.6 compatibility capability source from 3.5 to 3.7.
-  - [x] Add routing, account inventory, and Cloud Code wire-default tests proving no 3.5 resolution.
-  - [x] Gate: `make test-llm-mesh ENV=test-llm-mesh-g37` and `make typecheck-llm-mesh ENV=test-llm-mesh-g37`.
+- [ ] **Lot 2 — Safe add-model scaffold**
+  - [ ] Add an idempotent script that plans or applies catalog, provider, and default-route stubs copied from `BASE`.
+  - [ ] Make dry-run side-effect free and print the manual evidence, council, consumer, test, version, publication, and host-default checklist.
+  - [ ] Add focused tests for valid stubs, dry-run immutability, idempotence, partial repair, and invalid input.
+  - [ ] Add `make llm-mesh-add-model MODEL=<id> BASE=<id>` under `BR75-EX1`.
+  - [ ] Gate: focused test and dry-run make invocation are green.
 
-- [x] **Lot 3 — PR review fixes**
-  - [x] Raise the gateway dependency floor to `@sentropic/llm-mesh@^0.16.0` and regenerate the root lockfile.
-  - [x] Prove the gateway lock entry links the workspace and run the real workspace gateway validation.
-  - [x] Route every Claude-tier Gemini equivalent directly to `gemini-3.7-flash`.
-  - [x] Repoint the retained 3.6 and 3.1 compatibility aliases to the real 3.7 capability source.
-  - [x] Add exhaustive Claude-tier candidate and capability-resolution regression coverage.
+- [ ] **Lot 3 — Standard MODEL UPDATE launch packet**
+  - [ ] Add copy-ready drumbeat and mesh-lane mandates for `MODEL=<X>` and `BASE=<Y>`.
+  - [ ] Specify Codex 5.6 Sol xhigh build, blind Opus 4.8 review, exact evidence/scope/test/publish gates, stop conditions, and report contract.
+  - [ ] Gate: packet requires one directive, one make scaffold, one blind review, and no merge.
 
-- [x] **Lot 4 — Final validation and delivery**
-  - [x] Run `make build ENV=test-llm-mesh-g37`.
-  - [x] Run `make typecheck ENV=test-llm-mesh-g37`.
-  - [x] Run `make lint ENV=test-llm-mesh-g37`.
-  - [x] Run deterministic `make test ENV=test-llm-mesh-g37` suites; record the isolated live-AI auth failure.
-  - [x] Run `make pack-llm-mesh ENV=test-llm-mesh-g37`; leave publication verification to CI.
-  - [x] Run `make scope-check ENV=test-llm-mesh-g37` and `harness check scope`.
-  - [x] Push `feat/llm-mesh-gemini-37` to the existing PR without merge.
-  - [x] Wait for green CI including `enforce-package-bump`, `validate-llm-mesh`, and `validate-llm-gateway`.
-  - [x] Write `.tmp/engage/g37-fix-report.md` with assessment first.
-  - [x] Deposit a valid `sentropic.h2a` v1.0 report for `claude:sentropic-drumbeat:21fe3355ad7d`.
-
-## Verification Evidence
-- [x] `make test-llm-mesh ENV=test-llm-mesh-g37`: 25 files and 145 tests passed after Lot 1.
-- [x] `make test-llm-mesh ENV=test-llm-mesh-g37`: 25 files and 147 tests passed after Lot 2.
-- [x] `make test-llm-mesh ENV=test-llm-mesh-g37`: 25 files and 148 tests passed after the PR review fixes.
-- [x] Gateway workspace validation: typecheck and build passed; 16 files and 111 tests passed against `@sentropic/llm-mesh@0.16.0`.
-- [x] `make typecheck-llm-mesh ENV=test-llm-mesh-g37`: passed after Lot 2.
-- [x] `make build`, `make typecheck`, and `make lint`: passed in isolated `test-llm-mesh-g37`.
-- [x] Aggregate deterministic suites: unit 874 passed / 2 skipped; endpoints 658 passed aside from one parallel ARCH-11 isolation flake that passed scoped and with one worker.
-- [x] Targeted public catalog and exhaustive stream contracts: 4 and 94 tests passed respectively.
-- [x] `make pack-llm-mesh`: packed `@sentropic/llm-mesh@0.16.0`; council drift and scope gates passed.
-- [x] Live-AI aggregate attempted: 18 tests stopped uniformly because all provider auth variables are unset in this worktree.
-- [x] PR #540 CI run `31962450752`: success, including both LLM validations and the package-bump gate.
-- [x] Record exact commands, results, commit SHAs, PR URL, and CI run in `.tmp/engage/g37-fix-report.md`.
+- [ ] **Lot 4 — Final validation and PR-only delivery**
+  - [ ] Run `make scope-check`, `harness check scope`, council freshness, focused tests, dry run, build, typecheck, lint, and test gates.
+  - [ ] Run two eligible independent blind review legs on the exact diff and reconcile all findings.
+  - [ ] Verify `git branch --show-current` immediately before every commit.
+  - [ ] Push `feat/llm-model-update-runbook`, open the requested PR without merging, and verify CI.
+  - [ ] Write `.tmp/engage/model-update-runbook-report.md` and deposit a valid `sentropic.h2a` v1.0 report to `claude:sentropic-drumbeat:21fe3355ad7d`.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -4,7 +4,7 @@
 - [x] Make recurring LLM model updates repeatable through one owner directive, one safe scaffold command, explicit evidence gates, and blind review.
 
 ## Scope / Guardrails
-- [x] Base is `origin/main` at merge PR #539; PR #540 is the canonical model-cutover reference only.
+- [x] Base is `origin/main` at merge PR #540; its Gemini 3.7 cutover is the canonical model-update reference.
 - [x] Scope is facilitation documentation, one additive scaffold script, its unit test, and one Make target.
 - [x] Preserve existing catalog, provider, routing, equivalence, package publication, and consumer behavior.
 - [x] Require official model-id evidence before any scaffold is applied.
@@ -32,7 +32,7 @@
 
 ## Feedback Loop
 - [x] `BR75-EX1` accepted by owner request: change the normally forbidden `Makefile` because the repository's make-only policy requires an entrypoint for this recurring job; impact is one additive target plus one script; rollback removes that target and script.
-- [x] Source gap: PR #540 is not merged into this branch base, so its Gemini 3.7 changes are evidence, not files to copy into this deliverable.
+- [x] Post-rebase context: PR #540 is merged into this branch base; preserve its `@sentropic/llm-mesh` 0.16.0 package and lockfile state while keeping this branch documentation/scaffold-only.
 - [x] Source gap: vendor documentation is mutable; every future update must capture its dated official model-id evidence in its PR.
 - [x] Source gap: host defaults for h-cond/h2a-runtime, including agy, live outside this repository and require a notification handoff rather than an in-repo edit.
 
@@ -47,7 +47,7 @@
 - [x] **Lot 0 — Baseline and exact scope**
   - [x] Read project rules, workflow, sub-agent contract, project context, PLAN model-council constraint, and branch template.
   - [x] Verify `feat/llm-model-update-runbook` mechanically with `harness check branch`.
-  - [x] Confirm HEAD equals `origin/main` merge PR #539 and study the complete PR #540 delta.
+  - [x] Confirm the original base at merge PR #539, study the complete PR #540 delta, then rebase onto merge PR #540 without losing the runbook commits.
   - [x] Locate catalog, providers, route definitions, capability sources, council generator/check, publish order, and internal consumers.
   - [x] Confirm official OpenAI, Anthropic, and Gemini model registries are reachable.
 

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -8,7 +8,7 @@
 - [x] Scope is facilitation documentation, one additive scaffold script, its unit test, and one Make target.
 - [x] Preserve existing catalog, provider, routing, equivalence, package publication, and consumer behavior.
 - [x] Require official model-id evidence before any scaffold is applied.
-- [x] Use make-only commands, dedicated `ENV=test-model-update-runbook` for tests, selective staging, and sub-150-line commits.
+- [x] Use make-only commands, dedicated `ENV=test-model-update-runbook` with API `9375`, UI `5575`, and Maildev UI `1475`, selective staging, and sub-150-line commits.
 - [x] Keep all code, documentation, commit text, and PR text in English.
 
 ## Branch Scope Boundaries (MANDATORY)
@@ -38,6 +38,7 @@
 
 ## AI Flaky tests
 - [x] Accept no deterministic scaffold, generation-freshness, typecheck, lint, build, or package test failure as flaky.
+- [x] Local `make test` reached `api/tests/ai/**` then failed 18 tests because all five provider keys were unset (`Provider auth source is not configured`); runtime/auth paths are unchanged and CI injects those secrets, so the remote AI gate remains authoritative and owner sign-off is required before merge if it repeats.
 
 ## Orchestration Mode
 - [x] **Mono-branch** with no implementation sub-agent; two independent blind h2a review legs are read-only gates.
@@ -50,27 +51,27 @@
   - [x] Locate catalog, providers, route definitions, capability sources, council generator/check, publish order, and internal consumers.
   - [x] Confirm official OpenAI, Anthropic, and Gemini model registries are reachable.
 
-- [ ] **Lot 1 — Owner runbook**
+- [x] **Lot 1 — Owner runbook**
   - [x] Add the anti-phantom evidence gate and copy-from-BASE procedure.
   - [x] Document catalog, provider, routing, council refresh/check, tests, all consumer bumps, semver, ordered publication, and external host notification.
   - [x] Add a precise current-tree file-and-line table and mark every unresolved external/source gap.
   - [x] Gate: Markdown paths and cited line anchors verified against the current tree.
 
-- [ ] **Lot 2 — Safe add-model scaffold**
+- [x] **Lot 2 — Safe add-model scaffold**
   - [x] Add an idempotent script that plans or applies catalog, provider, and default-route stubs copied from `BASE`.
   - [x] Make dry-run side-effect free and print the manual evidence, council, consumer, test, version, publication, and host-default checklist.
   - [x] Add focused tests for valid stubs, dry-run immutability, idempotence, partial repair, and invalid input.
   - [x] Add `make llm-mesh-add-model MODEL=<id> BASE=<id>` under `BR75-EX1`.
-  - [ ] Gate: focused test and dry-run make invocation are green.
+  - [x] Gate: focused test and dry-run make invocation are green.
 
-- [ ] **Lot 3 — Standard MODEL UPDATE launch packet**
+- [x] **Lot 3 — Standard MODEL UPDATE launch packet**
   - [x] Add copy-ready drumbeat and mesh-lane mandates for `MODEL=<X>` and `BASE=<Y>`.
   - [x] Specify Codex 5.6 Sol xhigh build, blind Opus 4.8 review, exact evidence/scope/test/publish gates, stop conditions, and report contract.
   - [x] Gate: packet requires one directive, one make scaffold, one blind review, and no merge.
 
 - [ ] **Lot 4 — Final validation and PR-only delivery**
-  - [ ] Run `make scope-check`, `harness check scope`, council freshness, focused tests, dry run, build, typecheck, lint, and test gates.
-  - [ ] Run two eligible independent blind review legs on the exact diff and reconcile all findings.
-  - [ ] Verify `git branch --show-current` immediately before every commit.
+  - [x] Run scope, council freshness, focused tests, dry run, build, typecheck, and lint gates; record the local provider-secret boundary for the full test gate.
+  - [x] Record review selection failure: exact author model and effort are unattested, so independent blind peer eligibility cannot be proven without invention.
+  - [x] Verify `git branch --show-current` immediately before every commit.
   - [ ] Push `feat/llm-model-update-runbook`, open the requested PR without merging, and verify CI.
   - [ ] Write `.tmp/engage/model-update-runbook-report.md` and deposit a valid `sentropic.h2a` v1.0 report to `claude:sentropic-drumbeat:21fe3355ad7d`.

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -57,10 +57,10 @@
   - [ ] Gate: Markdown paths and cited line anchors verified against the current tree.
 
 - [ ] **Lot 2 — Safe add-model scaffold**
-  - [ ] Add an idempotent script that plans or applies catalog, provider, and default-route stubs copied from `BASE`.
-  - [ ] Make dry-run side-effect free and print the manual evidence, council, consumer, test, version, publication, and host-default checklist.
+  - [x] Add an idempotent script that plans or applies catalog, provider, and default-route stubs copied from `BASE`.
+  - [x] Make dry-run side-effect free and print the manual evidence, council, consumer, test, version, publication, and host-default checklist.
   - [ ] Add focused tests for valid stubs, dry-run immutability, idempotence, partial repair, and invalid input.
-  - [ ] Add `make llm-mesh-add-model MODEL=<id> BASE=<id>` under `BR75-EX1`.
+  - [x] Add `make llm-mesh-add-model MODEL=<id> BASE=<id>` under `BR75-EX1`.
   - [ ] Gate: focused test and dry-run make invocation are green.
 
 - [ ] **Lot 3 — Standard MODEL UPDATE launch packet**

--- a/BRANCH.md
+++ b/BRANCH.md
@@ -51,8 +51,8 @@
   - [x] Confirm official OpenAI, Anthropic, and Gemini model registries are reachable.
 
 - [ ] **Lot 1 — Owner runbook**
-  - [ ] Add the anti-phantom evidence gate and copy-from-BASE procedure.
-  - [ ] Document catalog, provider, routing, council refresh/check, tests, all consumer bumps, semver, ordered publication, and external host notification.
+  - [x] Add the anti-phantom evidence gate and copy-from-BASE procedure.
+  - [x] Document catalog, provider, routing, and council refresh/check gates.
   - [ ] Add a precise current-tree file-and-line table and mark every unresolved external/source gap.
   - [ ] Gate: Markdown paths and cited line anchors verified against the current tree.
 

--- a/Makefile
+++ b/Makefile
@@ -590,6 +590,15 @@ refresh-llm-model-equivalences: ## Regenerate the pinned model-equivalence counc
 check-llm-model-equivalences: ## Check model-equivalence generation and freshness
 	@docker run --rm -v "$(CURDIR):/workspace" -w /workspace $(LLM_MESH_NODE_IMAGE) node scripts/llm-model-equivalences/refresh.mjs --check
 
+# BR75-EX1 — make-only entrypoint for the recurring LLM model-update scaffold.
+.PHONY: llm-mesh-add-model
+llm-mesh-add-model: ## Scaffold a model from BASE (set DRY_RUN=1 to preview)
+	@test -n "$(MODEL)" || { echo "ERROR: MODEL is required"; exit 1; }
+	@test -n "$(BASE)" || { echo "ERROR: BASE is required"; exit 1; }
+	@docker run --rm -u "$$(id -u):$$(id -g)" -v "$(CURDIR):/workspace" -w /workspace \
+		$(LLM_MESH_NODE_IMAGE) node packages/llm-mesh/scripts/add-model.mjs \
+		--model "$(MODEL)" --base "$(BASE)" $(if $(filter 1 true,$(DRY_RUN)),--dry-run,)
+
 .PHONY: audit-llm-routing-package-versions
 audit-llm-routing-package-versions: ## Compare local LLM routing package versions with npm latest
 	@docker run --rm -v "$(CURDIR):/workspace" -w /workspace $(LLM_MESH_NODE_IMAGE) sh -lc 'set -eu; for package_dir in llm-mesh llm-gateway; do package="$$(node -p "require(\"./packages/$$package_dir/package.json\").name")"; local_version="$$(node -p "require(\"./packages/$$package_dir/package.json\").version")"; registry_version="$$(npm view "$$package" version)"; printf "%s local=%s registry=%s\n" "$$package" "$$local_version" "$$registry_version"; done'

--- a/docs/runbooks/model-update-launch-packet.md
+++ b/docs/runbooks/model-update-launch-packet.md
@@ -1,0 +1,110 @@
+# MODEL UPDATE Launch Packet
+
+Use this packet for the recurring owner directive:
+
+> MODEL UPDATE: update model `<MODEL>` from base `<BASE>`.
+
+The intended owner experience is one directive, one make scaffold, and one blind consensus review. The conductor remains responsible for evidence, scope, integration, publication ordering, and external handoff.
+
+## Drumbeat mandate (copy/paste)
+
+```text
+MANDATE: MODEL UPDATE
+MODEL: <exact-provider-model-id>
+BASE: <existing-same-provider-model-id>
+REPOSITORY: <absolute-sentropic-worktree>
+BRANCH: feat/<model-update-slug>
+ENV: test-<model-update-slug>
+
+Outcome: ship one real, fully classified and routed model update through
+@sentropic/llm-mesh, every in-repo consumer, ordered npm publication, and the
+h-cond/h2a-runtime host-default handoff. PR only; do not merge.
+
+Conductor actions:
+1. Verify the branch mechanically and declare BRANCH.md scope/exceptions.
+2. Require primary vendor evidence for the exact MODEL id and target product.
+3. Dispatch the build lane with the packet below.
+4. Integrate only scoped, atomic commits and run every gate below.
+5. Dispatch blind review on the exact integrated commit/diff.
+6. Reconcile findings, push, open the PR, wait for CI, and report; never merge.
+
+Stop immediately for: marketing-only/unofficial id; ambiguous target product;
+unverified capabilities; BASE without a faithful route; council omission;
+unbumped publishable consumer; red deterministic test; scope failure; or a
+publication/default change outside this mandate.
+```
+
+## Mesh build lane (Codex 5.6 Sol xhigh)
+
+Dispatch through the installed h2a launch surface with `profile=codex`, `model=gpt-5.6-sol`, `effort=xhigh`, `gateway=auto`, `background=true`, and the absolute isolated worktree. The declared model/effort are a request; the current receipt does not attest effective post-routing identity.
+
+```text
+ROLE: implementation lane for MODEL UPDATE <MODEL> from BASE <BASE>.
+
+Read, in order: rules/MASTER.md, rules/workflow.md, rules/subagents.md,
+BRANCH.md, spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md, and the relevant testing
+rules. Work only in <ABSOLUTE_WORKTREE> on <BRANCH>. Use only make targets;
+ENV=test-<slug> is last. Stage explicit files and commit only through
+make commit MSG="...". Keep every commit under 150 changed lines.
+
+Evidence gate: quote the exact official MODEL id, URL, retrieval date, target
+API/account transport, availability, and each claimed capability. Do not run
+the scaffold until this gate passes. Never infer a version from MODEL or BASE.
+
+Run exactly one scaffold preview, inspect it, then apply:
+make llm-mesh-add-model MODEL=<MODEL> BASE=<BASE> DRY_RUN=1
+make llm-mesh-add-model MODEL=<MODEL> BASE=<BASE>
+
+Replace every scaffold marker with verified data. Explicitly review catalog,
+both provider registries, DEFAULT_TARGET_MAPPINGS, STANDARD_ROUTE_DEFINITIONS,
+CLOUD_CODE_CAPABILITY_SOURCE_BY_MODEL, council classification and generation,
+all internal consumers/lockfiles, package versions, API/stream fixtures, and
+host inventory/default tests. Do not alter standard aliases without an owner
+cutover decision. Do not hand-edit generated-model-council.ts.
+
+Deliver atomic commits plus a report containing: evidence; changed files;
+consumer inventory; exact tests/results; versions; source gaps; rollback;
+scope exception ids; and the external h-cond/h2a-runtime handoff payload.
+Do not push, publish, merge, or change external host defaults unless the
+conductor explicitly grants that action.
+```
+
+## Mandatory gates before review
+
+- Anti-phantom evidence names the exact model and exact product/transport.
+- No `[VERIFY]` label or `MODEL UPDATE SCAFFOLD` comment remains.
+- The new catalog model is classified exactly once; generated council is fresh.
+- Faithful routes and every changed alias/capability source have exhaustive tests.
+- Gateway dependency and version, root/API locks, API contracts, and build-cli template are updated or explicitly owner-deferred.
+- Mesh is versioned before gateway; publishable manifests have new versions.
+- Focused tests, mesh/gateway tests, `make build`, `make typecheck`, `make lint`, `make test`, `make scope-check`, and `harness check scope` are green.
+- Candidate tarballs and hashes exist; no manual npm publication occurred.
+- Every commit is scoped, atomic, and made on the named branch.
+
+## Blind review lane (Claude Opus 4.8)
+
+The primary review request uses h2a with `profile=claude`, `model=claude-opus-4-8`, `effort=xhigh`, `gateway=required`, and `background=true`. Follow `harness/review`: record author metadata, exact target ref and diff SHA-256, create the repo-local review stub first, keep the reviewer blind to other reviews, and add a second eligible independent Claude-hosted leg when consensus policy requires it.
+
+```text
+ROLE: blind adversarial reviewer for MODEL UPDATE <MODEL> from BASE <BASE>.
+TARGET: <EXACT_COMMIT_OR_DIFF_SHA256>
+WRITE ONLY: <REVIEW_ARTIFACT_PATH>
+
+Do not read author explanations or another review. Read the repository rules,
+the runbook, the exact target diff, PR #540 only as a historical pattern, and
+the cited current-tree sources. Refute by default.
+
+Audit: official model-id evidence and surface availability; copied capability
+accuracy; provider registry completeness; faithful/default/alias routing;
+council classification and generated freshness; all consumer/version/lock
+bumps; mesh-before-gateway publication; test coverage; scaffold idempotence and
+dry-run immutability; source-gap honesty; rollback; and external host handoff.
+
+Write the required machine-readable review header, findings with severity and
+file:line evidence, and APPROVE / REQUEST_CHANGES. Never edit implementation,
+push, publish, merge, or inspect another review artifact.
+```
+
+## PR and report contract
+
+Open the PR with the branch plan as body and title appropriate to the concrete model. Require green CI and resolved consensus findings. Report the PR URL, head SHA, CI run, npm plan, external handoff status, and explicit `PR only — not merged` state to the drumbeat. A future host-default cutover is a separate acknowledged action after published-artifact smoke.

--- a/packages/llm-mesh/scripts/add-model.mjs
+++ b/packages/llm-mesh/scripts/add-model.mjs
@@ -64,19 +64,20 @@ if (!catalog.includes(`    modelId: '${model}',`)) {
 }
 
 let providers = original.providers;
-const addProviderId = (source, startMarker, endMarker, indentation) => {
-  const start = source.indexOf(startMarker);
+const addProviderId = (source, startMarker, endMarker, indentation, offset = 0) => {
+  const start = source.indexOf(startMarker, offset);
   const end = source.indexOf(endMarker, start);
   if (start < 0 || end < 0) throw new Error(`Could not isolate provider list: ${startMarker}`);
   const segment = source.slice(start, end);
   if (segment.includes(`'${model}'`)) return source;
-  const pattern = new RegExp(`^${indentation}'${quoted(base)}',\\s*$`, 'm');
+  const pattern = new RegExp(`^${indentation}'${quoted(base)}',[ \\t]*$`, 'm');
   if (!pattern.test(segment)) throw new Error(`BASE ${base} not found in ${startMarker}`);
   const updated = segment.replace(pattern, (line) => `${line}\n${indentation}'${model}',`);
   return `${source.slice(0, start)}${updated}${source.slice(end)}`;
 };
 providers = addProviderId(providers, 'export const knownModelIds = [', '] as const', '  ');
-providers = addProviderId(providers, `  ${provider}: [`, '],', '    ');
+providers = addProviderId(providers, `  ${provider}: [`, '],', '    ',
+  providers.indexOf('export const knownModelIdsByProvider = {'));
 
 let routing = original.routing;
 const routingSectionEnd = routing.indexOf('\n};', routing.indexOf('DEFAULT_TARGET_MAPPINGS'));

--- a/packages/llm-mesh/scripts/add-model.mjs
+++ b/packages/llm-mesh/scripts/add-model.mjs
@@ -1,0 +1,99 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const values = new Map();
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index];
+  if (arg === '--dry-run') values.set('dryRun', true);
+  else if (arg?.startsWith('--')) values.set(arg.slice(2), process.argv[++index]);
+  else throw new Error(`Unexpected argument: ${arg}`);
+}
+
+const model = values.get('model');
+const base = values.get('base');
+const root = resolve(values.get('root') ?? process.cwd());
+const dryRun = values.get('dryRun') === true;
+const validId = /^[a-z0-9][a-z0-9._@/-]*$/;
+if (typeof model !== 'string' || !validId.test(model)) {
+  throw new Error('--model must be a lowercase provider model id');
+}
+if (typeof base !== 'string' || !validId.test(base)) {
+  throw new Error('--base must be a lowercase provider model id');
+}
+if (model === base) throw new Error('--model and --base must differ');
+
+const paths = {
+  catalog: resolve(root, 'packages/llm-mesh/src/catalog.ts'),
+  providers: resolve(root, 'packages/llm-mesh/src/providers.ts'),
+  routing: resolve(root, 'packages/llm-mesh/src/routing-targets.ts'),
+};
+const original = Object.fromEntries(await Promise.all(
+  Object.entries(paths).map(async ([key, path]) => [key, await readFile(path, 'utf8')]),
+));
+
+const quoted = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const blockContaining = (source, marker, endIndent = 2) => {
+  const markerIndex = source.indexOf(marker);
+  if (markerIndex < 0) throw new Error(`BASE entry not found: ${marker}`);
+  const start = source.lastIndexOf(`${' '.repeat(endIndent)}{\n`, markerIndex);
+  const endMarker = `\n${' '.repeat(endIndent)}},`;
+  const end = source.indexOf(endMarker, markerIndex);
+  if (start < 0 || end < 0) throw new Error(`Could not isolate BASE entry: ${marker}`);
+  return { start, end: end + endMarker.length, text: source.slice(start, end + endMarker.length) };
+};
+const insertAfter = (source, block, addition) =>
+  `${source.slice(0, block.end)}\n${addition}${source.slice(block.end)}`;
+const keyedBlock = (source, marker) => {
+  const start = source.indexOf(marker);
+  const endMarker = '\n  },';
+  const end = source.indexOf(endMarker, start);
+  if (start < 0 || end < 0) throw new Error(`BASE route not found: ${marker}`);
+  return { start, end: end + endMarker.length, text: source.slice(start, end + endMarker.length) };
+};
+
+let catalog = original.catalog;
+const baseProfile = blockContaining(catalog, `    modelId: '${base}',`);
+const provider = baseProfile.text.match(/providerId: '([^']+)'/)?.[1];
+if (!provider) throw new Error(`Could not resolve provider for BASE ${base}`);
+if (!catalog.includes(`    modelId: '${model}',`)) {
+  const copied = baseProfile.text
+    .replace(`modelId: '${base}'`, `modelId: '${model}'`)
+    .replace(/label: '[^']*'/, `label: '[VERIFY] ${model}'`);
+  catalog = insertAfter(catalog, baseProfile,
+    `  // MODEL UPDATE SCAFFOLD: copied from ${base}; verify every field.\n${copied}`);
+}
+
+let providers = original.providers;
+const addProviderId = (source, startMarker, endMarker, indentation) => {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start);
+  if (start < 0 || end < 0) throw new Error(`Could not isolate provider list: ${startMarker}`);
+  const segment = source.slice(start, end);
+  if (segment.includes(`'${model}'`)) return source;
+  const pattern = new RegExp(`^${indentation}'${quoted(base)}',\\s*$`, 'm');
+  if (!pattern.test(segment)) throw new Error(`BASE ${base} not found in ${startMarker}`);
+  const updated = segment.replace(pattern, (line) => `${line}\n${indentation}'${model}',`);
+  return `${source.slice(0, start)}${updated}${source.slice(end)}`;
+};
+providers = addProviderId(providers, 'export const knownModelIds = [', '] as const', '  ');
+providers = addProviderId(providers, `  ${provider}: [`, '],', '    ');
+
+let routing = original.routing;
+const routingSectionEnd = routing.indexOf('\n};', routing.indexOf('DEFAULT_TARGET_MAPPINGS'));
+const routingSection = routing.slice(0, routingSectionEnd);
+if (!routingSection.includes(`  '${model}': {`)) {
+  const baseRoute = keyedBlock(routingSection, `  '${base}': {`);
+  const copied = baseRoute.text.split(base).join(model);
+  routing = insertAfter(routing, baseRoute,
+    `  // MODEL UPDATE SCAFFOLD: copied from ${base}; verify transport.\n${copied}`);
+}
+
+const next = { catalog, providers, routing };
+const changed = Object.keys(paths).filter((key) => next[key] !== original[key]);
+if (!dryRun) await Promise.all(changed.map((key) => writeFile(paths[key], next[key])));
+
+console.log(`${dryRun ? 'Dry run' : 'Applied'}: ${changed.length ? changed.join(', ') : 'no changes'}`);
+console.log('Manual gates: verify official model id and every copied capability; remove scaffold comments.');
+console.log('Review STANDARD_ROUTE_DEFINITIONS and CLOUD_CODE_CAPABILITY_SOURCE_BY_MODEL explicitly.');
+console.log('Update or exclude the council, refresh/check generation, tests, consumers, semver, and lockfiles.');
+console.log('Publish llm-mesh before llm-gateway, then notify h-cond/h2a-runtime host-default owners.');

--- a/packages/llm-mesh/tests/add-model-script.test.ts
+++ b/packages/llm-mesh/tests/add-model-script.test.ts
@@ -1,0 +1,108 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const script = resolve(process.cwd(), 'scripts/add-model.mjs');
+const roots: string[] = [];
+
+const fixture = async () => {
+  const root = await mkdtemp(join(tmpdir(), 'llm-model-scaffold-'));
+  roots.push(root);
+  const sourceDir = join(root, 'packages/llm-mesh/src');
+  await mkdir(sourceDir, { recursive: true });
+  const files = {
+    catalog: join(sourceDir, 'catalog.ts'),
+    providers: join(sourceDir, 'providers.ts'),
+    routing: join(sourceDir, 'routing-targets.ts'),
+  };
+  await writeFile(files.catalog, `export const modelProfiles = [
+  {
+    providerId: 'openai',
+    modelId: 'gpt-base',
+    label: 'GPT Base',
+    reasoningTier: 'advanced',
+    defaultTaskHints: ['chat'],
+    capabilities: modelCapabilities('openai', 'advanced'),
+  },
+] as const;
+`);
+  await writeFile(files.providers, `export const knownModelIds = [
+  'gpt-base',
+] as const;
+
+export const knownModelIdsByProvider = {
+  openai: [
+    'gpt-base',
+  ],
+} as const;
+`);
+  await writeFile(files.routing, `export const DEFAULT_TARGET_MAPPINGS = {
+  'gpt-base': {
+    providerId: 'openai', transportProviderId: 'codex', model: 'gpt-base',
+  },
+};
+
+const STANDARD_ROUTE_DEFINITIONS = [];
+`);
+  return { root, files };
+};
+
+const run = (root: string, ...extra: string[]) => spawnSync(process.execPath, [
+  script, '--root', root, '--model', 'gpt-next', '--base', 'gpt-base', ...extra,
+], { encoding: 'utf8' });
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('add-model scaffold', () => {
+  it('should leave every source unchanged in dry-run mode', async () => {
+    const { root, files } = await fixture();
+    const before = await Promise.all(Object.values(files).map((file) => readFile(file, 'utf8')));
+
+    const result = run(root, '--dry-run');
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('Dry run: catalog, providers, routing');
+    await expect(Promise.all(
+      Object.values(files).map((file) => readFile(file, 'utf8')),
+    )).resolves.toEqual(before);
+  });
+
+  it('should copy valid stubs once and repair a missing provider entry', async () => {
+    const { root, files } = await fixture();
+
+    const first = run(root);
+    expect(first.status, first.stderr).toBe(0);
+    expect(await readFile(files.catalog, 'utf8')).toContain("modelId: 'gpt-next'");
+    expect(await readFile(files.catalog, 'utf8')).toContain("label: '[VERIFY] gpt-next'");
+    expect(await readFile(files.routing, 'utf8')).toContain("'gpt-next': {");
+
+    const second = run(root);
+    expect(second.status, second.stderr).toBe(0);
+    expect(second.stdout).toContain('Applied: no changes');
+
+    const providers = await readFile(files.providers, 'utf8');
+    await writeFile(files.providers, providers.replace("    'gpt-next',\n", ''));
+    const repair = run(root);
+    expect(repair.status, repair.stderr).toBe(0);
+    expect(repair.stdout).toContain('Applied: providers');
+    expect(await readFile(files.providers, 'utf8')).toContain("    'gpt-next',");
+  });
+
+  it('should reject invalid ids and a BASE without a faithful route before writing', async () => {
+    const { root, files } = await fixture();
+    const invalid = spawnSync(process.execPath, [
+      script, '--root', root, '--model', '../bad', '--base', 'gpt-base',
+    ], { encoding: 'utf8' });
+    expect(invalid.status).not.toBe(0);
+
+    await writeFile(files.routing, 'export const DEFAULT_TARGET_MAPPINGS = {\n};\n');
+    const unrouted = run(root);
+    expect(unrouted.status).not.toBe(0);
+    expect(unrouted.stderr).toContain('BASE route not found');
+    expect(await readFile(files.catalog, 'utf8')).not.toContain("modelId: 'gpt-next'");
+  });
+});

--- a/spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md
+++ b/spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md
@@ -4,7 +4,7 @@
 
 Use this procedure for a real provider model addition or cutover, such as `3.7 -> 3.8` or a new Claude, GPT, or Gemini generation. It is an owner facilitation runbook, not evidence that a named model exists.
 
-Canonical repository example: PR #540, branch `origin/feat/llm-mesh-gemini-37`, based on `84512941a`. Its useful pattern is catalog -> providers -> council -> routes -> package version -> consumers -> tests. Do not copy its model specifications into another update: limits, modalities, endpoints, and identifiers are model-specific.
+Canonical repository example: PR #540, merged into `origin/main` as `28d57d098` after originating from base `84512941a`. Its useful pattern is catalog -> providers -> council -> routes -> package version -> consumers -> tests. Do not copy its model specifications into another update: limits, modalities, endpoints, and identifiers are model-specific.
 
 ## Required inputs
 
@@ -31,7 +31,7 @@ The evidence block must include a retrieval date because vendor pages are mutabl
 ### 1. Establish scope and inspect the reference
 
 - Verify the worktree with `harness check branch` before editing and `git branch --show-current` immediately before every commit.
-- Read the current model paths and the complete reference delta. Do not assume PR #540 is merged.
+- Read the current model paths and the complete reference delta. Confirm the reference merge state; this runbook branch now includes PR #540 in its base.
 - Declare exceptions for `Makefile`, workflows, lockfiles, API contracts, or generated sources before editing them.
 
 ### 2. Preview and apply the mechanical scaffold
@@ -142,23 +142,23 @@ Send h-cond/h2a-runtime a handoff containing: exact published mesh/gateway versi
 
 ## Current-tree file map
 
-Line anchors below refer to base `84512941a` plus this runbook/scaffold branch; re-resolve them after a rebase.
+Line anchors below refer to base `28d57d098` plus this runbook/scaffold branch.
 
 | Concern | Current file:line | Why it changes |
 |---|---|---|
-| Profile contract and profiles | `packages/llm-mesh/src/catalog.ts:27`, `:222`, `:260` | Profile shape, inherited capabilities, real model record. |
-| Provider registries | `packages/llm-mesh/src/providers.ts:13`, `:58` | Known id union and provider-indexed list. |
+| Profile contract and profiles | `packages/llm-mesh/src/catalog.ts:27`, `:227`, `:266` | Profile shape, inherited capabilities, real model record. |
+| Provider registries | `packages/llm-mesh/src/providers.ts:13`, `:59` | Known id union and provider-indexed list. |
 | Faithful/default targets | `packages/llm-mesh/src/routing-targets.ts:28` | Callable canonical host target. |
-| Standard alias candidates | `packages/llm-mesh/src/routing-targets.ts:53` | Owner-ratified Codex/Cloud Code route cutover. |
-| Capability aliases | `packages/llm-mesh/src/routing-targets.ts:77` | Resolve transport-only ids to verified catalog capabilities. |
+| Standard alias candidates | `packages/llm-mesh/src/routing-targets.ts:56` | Owner-ratified Codex/Cloud Code route cutover. |
+| Capability aliases | `packages/llm-mesh/src/routing-targets.ts:80` | Resolve transport-only ids to verified catalog capabilities. |
 | Council source | `scripts/llm-model-equivalences/council.source.json:1` | Explicit exclusion and review metadata. |
 | Council generator/output | `scripts/llm-model-equivalences/refresh.mjs:5`, `packages/llm-mesh/src/generated-model-council.ts:1` | Regenerate; never hand-edit output. |
-| Scaffold entrypoint | `Makefile:593`, `packages/llm-mesh/scripts/add-model.mjs:1` | Preview/apply the mechanical copy. |
-| Council CI gate | `.github/workflows/ci.yml:493` | Freshness runs before typecheck/test/build/pack. |
+| Scaffold entrypoint | `Makefile:595`, `packages/llm-mesh/scripts/add-model.mjs:1` | Preview/apply the mechanical copy. |
+| Council CI gate | `.github/workflows/ci.yml:502` | Freshness runs before typecheck/test/build/pack. |
 | Mesh/gateway publish order | `.github/workflows/ci.yml:1418`, `:1442` | Gateway depends on successful/skipped mesh publication. |
 | Mesh/gateway publish recipes | `Makefile:749`, `:661` | Both include council freshness; gateway waits for mesh. |
 | Package versions | `packages/llm-mesh/package.json:3`, `packages/llm-gateway/package.json:3` | Publishable semver identities. |
-| Gateway dependency | `packages/llm-gateway/package.json:36`, `package-lock.json:18204` | New mesh floor and root lock. |
+| Gateway dependency | `packages/llm-gateway/package.json:36`, `package-lock.json:18209` | New mesh floor and root lock. |
 | API workspace consumer | `api/package.json:73`, `api/package-lock.json:86` | File link plus synchronized workspace metadata. |
 | Generated-app consumer | `packages/build-cli/templates/chat-app/package.json:20`, `packages/build-cli/tests/generator-golden.spec.ts:77` | New app dependency and golden contract. |
 | Public API contract | `api/tests/api/models.test.ts:20` | Exact catalog response. |
@@ -167,7 +167,7 @@ Line anchors below refer to base `84512941a` plus this runbook/scaffold branch; 
 
 ## Source gaps and stop conditions
 
-- PR #540 is reference evidence but is not merged into this runbook's base; do not assume its ids or limits exist on `main`.
+- PR #540 is merged into this runbook's base; its Gemini 3.7 ids, routes, and `@sentropic/llm-mesh` 0.16.0 state are current-tree reference material, not specifications to copy blindly into a future model update.
 - `api/package-lock.json` currently records an older mesh workspace version than the root manifest. A future update must regenerate and review it rather than preserving the drift.
 - The build-cli template currently pins an older pre-1.0 mesh range. Updating or explicitly deferring it is mandatory consumer review.
 - Host defaults for h-cond/h2a-runtime and agy live outside this repository; the job stops at a documented handoff until that owner acknowledges it.

--- a/spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md
+++ b/spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md
@@ -1,0 +1,84 @@
+# Recurring LLM Model Update Runbook
+
+## Purpose and reference
+
+Use this procedure for a real provider model addition or cutover, such as `3.7 -> 3.8` or a new Claude, GPT, or Gemini generation. It is an owner facilitation runbook, not evidence that a named model exists.
+
+Canonical repository example: PR #540, branch `origin/feat/llm-mesh-gemini-37`, based on `84512941a`. Its useful pattern is catalog -> providers -> council -> routes -> package version -> consumers -> tests. Do not copy its model specifications into another update: limits, modalities, endpoints, and identifiers are model-specific.
+
+## Required inputs
+
+- `MODEL`: exact provider model id, including any provider-required date/version suffix.
+- `BASE`: an existing catalog model from the same provider and transport family.
+- Official evidence URL(s), retrieval date, quoted exact id, target endpoint/product, and availability scope.
+- Owner decision: catalog-only addition, faithful host target, or default/alias cutover.
+- Branch/worktree, dedicated `ENV=test-<slug>`, and a `BRANCH.md` scope exception before touching conditional paths.
+
+## Gate 0: prove the model is real (anti-phantom)
+
+Stop before scaffolding until the PR records primary vendor evidence for the exact model id:
+
+1. Search the vendor's official model registry, release notes, and API documentation. Start with [OpenAI models](https://developers.openai.com/api/docs/models), [Anthropic models](https://platform.claude.com/docs/en/about-claude/models/overview), or [Gemini models](https://ai.google.dev/gemini-api/docs/models).
+2. Copy the exact machine id, not a marketing label or an inferred version sequence. A blog headline alone is insufficient.
+3. Record whether the id applies to the direct API, Codex, Claude Code, Gemini API, Cloud Code/agy, GCP Model Garden, or another surface. Availability on one surface does not prove another.
+4. Confirm every claimed capability independently: context and output limits, modalities, tools, structured output, reasoning controls, and streaming wire shape. Unknown values remain `unknown`; never inherit them silently from `BASE`.
+5. When credentials and vendor policy allow, add a minimal live discovery/call receipt with secrets redacted. A failed or unavailable target is a stop condition, not a reason to mint a plausible id.
+
+The evidence block must include a retrieval date because vendor pages are mutable. If sources disagree, the narrowest official claim wins and the source gap remains explicit in the PR.
+
+## Procedure
+
+### 1. Establish scope and inspect the reference
+
+- Verify the worktree with `harness check branch` before editing and `git branch --show-current` immediately before every commit.
+- Read the current model paths and the complete reference delta. Do not assume PR #540 is merged.
+- Declare exceptions for `Makefile`, workflows, lockfiles, API contracts, or generated sources before editing them.
+
+### 2. Preview and apply the mechanical scaffold
+
+Preview first; it must not modify the tree:
+
+```sh
+make llm-mesh-add-model MODEL=<exact-id> BASE=<existing-id> DRY_RUN=1
+```
+
+After Gate 0 evidence and review of the preview:
+
+```sh
+make llm-mesh-add-model MODEL=<exact-id> BASE=<existing-id>
+```
+
+The scaffold copies three structural stubs: the catalog profile, both provider registries, and a faithful default target. It is idempotent and repairs missing provider-list entries. It deliberately does not change standard aliases, capability aliases, the council, versions, consumers, or lockfiles. It refuses a `BASE` without a faithful route so a human must design that transport rather than guess it.
+
+### 3. Replace the catalog stub with verified specifications
+
+- In `packages/llm-mesh/src/catalog.ts`, compare the new object field-by-field with `BASE`.
+- Replace the `[VERIFY]` label and remove the scaffold comment.
+- Verify `providerId`, `reasoningTier`, task hints, all capability support levels, context/output limits, and input/output modalities.
+- Add a small model-specific capability constant only when the official model differs from the provider/base template. Do not broaden the provider profile to fit one model.
+- Add no GCP/provider variant without independent evidence for that exact surface and wire id.
+
+### 4. Complete the provider registries
+
+Confirm the exact id occurs once in `knownModelIds` and once in the matching `knownModelIdsByProvider` list in `packages/llm-mesh/src/providers.ts`. Preserve GCP qualified-key rules and do not advertise transport-only compatibility ids as catalog models.
+
+### 5. Make routing decisions explicitly
+
+Review all three routing concerns in `packages/llm-mesh/src/routing-targets.ts`:
+
+- `DEFAULT_TARGET_MAPPINGS`: retain the scaffolded entry only if the model has a faithful callable host transport.
+- `STANDARD_ROUTE_DEFINITIONS`: change a Codex/Cloud Code candidate only for an owner-ratified default or fallback cutover. Preserve effort tiers and add exhaustive alias tests.
+- `CLOUD_CODE_CAPABILITY_SOURCE_BY_MODEL`: map only transport ids absent from the catalog to a verified catalog capability source. When a legacy transport alias remains, repoint it deliberately and test the compatibility behavior.
+
+Launch routing is not benchmark equivalence. Never use a route change as evidence that two models are interchangeable.
+
+### 6. Classify the model in the equivalence council
+
+Every catalog model must be classified exactly once. The current safe path is explicit exclusion:
+
+1. Add `<provider>:<MODEL>` to `excludedModelKeys` in `scripts/llm-model-equivalences/council.source.json`.
+2. Update the revision, reviewer, provenance, and expiry when required by the council review.
+3. Run `make refresh-llm-model-equivalences ENV=test-<slug>`; never edit `generated-model-council.ts` by hand.
+4. Run `make check-llm-model-equivalences ENV=test-<slug>` and the equivalence-council tests.
+
+The current generator emits exclusions only. Creating a benchmark-backed equivalence group requires a separately reviewed source/generator evolution; do not encode it as an ad hoc generated-file edit. Freshness is already enforced in mesh validation and in both publication targets, so a model addition that omits this step must fail closed.

--- a/spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md
+++ b/spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md
@@ -82,3 +82,97 @@ Every catalog model must be classified exactly once. The current safe path is ex
 4. Run `make check-llm-model-equivalences ENV=test-<slug>` and the equivalence-council tests.
 
 The current generator emits exclusions only. Creating a benchmark-backed equivalence group requires a separately reviewed source/generator evolution; do not encode it as an ad hoc generated-file edit. Freshness is already enforced in mesh validation and in both publication targets, so a model addition that omits this step must fail closed.
+
+### 7. Update every repository consumer
+
+Inventory consumers on every update; the current tree has these distinct obligations:
+
+| Consumer | Required action |
+|---|---|
+| `packages/llm-gateway` | Raise the `@sentropic/llm-mesh` dependency floor to the new mesh version, bump gateway at least patch so the new manifest can publish, update route fixtures, then regenerate the root lock. |
+| `api` | Its manifest is a `file:` workspace link, so normally keep that specifier; regenerate `api/package-lock.json` so workspace version metadata is current, and update the exact public catalog plus stream fixtures. |
+| Root workspace | Run `make lock-root`; verify the linked mesh version and gateway dependency range changed together. |
+| `packages/build-cli/templates/chat-app` | Raise the generated app's published mesh range and its golden assertion so newly generated apps can select the model. If intentionally held back, record an owner-approved source gap and compatibility reason. |
+| External h-cond / h2a-runtime hosts | No in-repo dependency exists. Send a handoff after publication for host catalog/default changes, especially agy/Cloud Code. |
+
+Use `make lock-root ENV=test-<slug>` and `make lock-api ENV=test-<slug>`; never hand-edit lockfiles. Re-run the consumer inventory rather than assuming this list is permanent.
+
+### 8. Add model-specific and regression tests
+
+At minimum, cover each touched behavior:
+
+- `packages/llm-mesh/tests/facade.test.ts`: exact identity and every verified capability that differs from `BASE`.
+- `packages/llm-mesh/tests/equivalence-council.test.ts`: classification remains exhaustive and fail-closed.
+- `packages/llm-mesh/tests/routing-targets.test.ts`: faithful target, all changed aliases, effort preservation, and capability-source resolution.
+- Account inventory and transport client tests when a host default or wire id changes.
+- `packages/llm-gateway/tests/target.test.ts`: downstream canonical route view.
+- `api/tests/api/models.test.ts`: exact provider list and total.
+- `api/tests/unit/llm-runtime-stream.test.ts`: advertised model's content, tool, reasoning, status, and usage normalization.
+- `packages/build-cli/tests/generator-golden.spec.ts` when the template dependency changes.
+
+Run focused tests while editing, then the package and repository gates:
+
+```sh
+make check-llm-model-equivalences ENV=test-<slug>
+make test-llm-mesh ENV=test-<slug>
+make test-llm-gateway ENV=test-<slug>
+make build ENV=test-<slug>
+make typecheck ENV=test-<slug>
+make lint ENV=test-<slug>
+make test ENV=test-<slug>
+make scope-check ENV=test-<slug>
+```
+
+Also run `harness check scope`. Live provider tests may be classified as AI-flaky only under the repository rule: an identical same-commit command must also pass and the owner must sign off. Missing credentials are a source gap, not a passing result.
+
+### 9. Version, package, publish, and verify in order
+
+1. Run `make audit-llm-routing-package-versions` before choosing versions and again after any rebase.
+2. A new catalog model is a mesh feature: bump `packages/llm-mesh/package.json` minor while pre-1.0, unless the public contract requires a major bump.
+3. Bump `packages/llm-gateway/package.json` at least patch whenever its mesh dependency or published route contract changes. Merely changing its dependency without a new gateway version leaves the registry manifest unpublished.
+4. Regenerate both required lockfiles and run `make package-llm-routing-candidates` plus pack gates.
+5. Open the PR and require green mesh, gateway, API, package-bump, council-freshness, and full repository gates. Do not publish manually from the branch.
+6. After merge, CI publishes mesh first. Gateway publication waits for the mesh version to be visible, then builds and publishes against it.
+7. Confirm npm versions and required tags `@sentropic/llm-mesh@<version>` and `@sentropic/llm-gateway@<version>`. Publication without the release tag is incomplete under repository policy.
+8. Smoke the published artifacts, not only workspace links, before changing external host defaults.
+
+### 10. Notify external host-default owners
+
+Send h-cond/h2a-runtime a handoff containing: exact published mesh/gateway versions and tarball hashes, official model evidence, old/new ids, affected aliases and effort tiers, transport/product availability, smoke results, rollback ids, and PR/CI links. Explicitly name agy when Cloud Code inventory or its default changes. This repository cannot apply that default; acknowledgement from the external owner is the acceptance evidence.
+
+## Current-tree file map
+
+Line anchors below refer to base `84512941a` plus this runbook/scaffold branch; re-resolve them after a rebase.
+
+| Concern | Current file:line | Why it changes |
+|---|---|---|
+| Profile contract and profiles | `packages/llm-mesh/src/catalog.ts:27`, `:222`, `:260` | Profile shape, inherited capabilities, real model record. |
+| Provider registries | `packages/llm-mesh/src/providers.ts:13`, `:58` | Known id union and provider-indexed list. |
+| Faithful/default targets | `packages/llm-mesh/src/routing-targets.ts:28` | Callable canonical host target. |
+| Standard alias candidates | `packages/llm-mesh/src/routing-targets.ts:53` | Owner-ratified Codex/Cloud Code route cutover. |
+| Capability aliases | `packages/llm-mesh/src/routing-targets.ts:77` | Resolve transport-only ids to verified catalog capabilities. |
+| Council source | `scripts/llm-model-equivalences/council.source.json:1` | Explicit exclusion and review metadata. |
+| Council generator/output | `scripts/llm-model-equivalences/refresh.mjs:5`, `packages/llm-mesh/src/generated-model-council.ts:1` | Regenerate; never hand-edit output. |
+| Scaffold entrypoint | `Makefile:593`, `packages/llm-mesh/scripts/add-model.mjs:1` | Preview/apply the mechanical copy. |
+| Council CI gate | `.github/workflows/ci.yml:493` | Freshness runs before typecheck/test/build/pack. |
+| Mesh/gateway publish order | `.github/workflows/ci.yml:1418`, `:1442` | Gateway depends on successful/skipped mesh publication. |
+| Mesh/gateway publish recipes | `Makefile:749`, `:661` | Both include council freshness; gateway waits for mesh. |
+| Package versions | `packages/llm-mesh/package.json:3`, `packages/llm-gateway/package.json:3` | Publishable semver identities. |
+| Gateway dependency | `packages/llm-gateway/package.json:36`, `package-lock.json:18204` | New mesh floor and root lock. |
+| API workspace consumer | `api/package.json:73`, `api/package-lock.json:86` | File link plus synchronized workspace metadata. |
+| Generated-app consumer | `packages/build-cli/templates/chat-app/package.json:20`, `packages/build-cli/tests/generator-golden.spec.ts:77` | New app dependency and golden contract. |
+| Public API contract | `api/tests/api/models.test.ts:20` | Exact catalog response. |
+| Council and route tests | `packages/llm-mesh/tests/equivalence-council.test.ts:9`, `packages/llm-mesh/tests/routing-targets.test.ts:9` | Exhaustiveness and canonical routing. |
+| Gateway route contract | `packages/llm-gateway/tests/target.test.ts:143` | Consumer sees the same canonical targets. |
+
+## Source gaps and stop conditions
+
+- PR #540 is reference evidence but is not merged into this runbook's base; do not assume its ids or limits exist on `main`.
+- `api/package-lock.json` currently records an older mesh workspace version than the root manifest. A future update must regenerate and review it rather than preserving the drift.
+- The build-cli template currently pins an older pre-1.0 mesh range. Updating or explicitly deferring it is mandatory consumer review.
+- Host defaults for h-cond/h2a-runtime and agy live outside this repository; the job stops at a documented handoff until that owner acknowledges it.
+- Stop on absent official id evidence, a `BASE` without a faithful route, unclassified council membership, stale generated output, an unbumped publishable consumer, red tests, or unpublished dependency ordering.
+
+## Done definition
+
+The update is done only when evidence, catalog, provider registries, council, routes, consumers, lockfiles, tests, semver, ordered npm publication, release tags, published-artifact smoke, external host notification, and rollback notes are all recorded. The PR remains unmerged until its requested blind review and CI gates are complete.


### PR DESCRIPTION
# Feature: BR-75 Recurring LLM Model Update Runbook

## Objective
- [x] Make recurring LLM model updates repeatable through one owner directive, one safe scaffold command, explicit evidence gates, and blind review.

## Scope / Guardrails
- [x] Base is `origin/main` at merge PR #539; PR #540 is the canonical model-cutover reference only.
- [x] Scope is facilitation documentation, one additive scaffold script, its unit test, and one Make target.
- [x] Preserve existing catalog, provider, routing, equivalence, package publication, and consumer behavior.
- [x] Require official model-id evidence before any scaffold is applied.
- [x] Use make-only commands, dedicated `ENV=test-model-update-runbook` with API `9375`, UI `5575`, and Maildev UI `1475`, selective staging, and sub-150-line commits.
- [x] Keep all code, documentation, commit text, and PR text in English.

## Branch Scope Boundaries (MANDATORY)
- [x] **Allowed Paths (implementation scope)**
  - [x] `BRANCH.md`
  - [x] `spec/SPEC_RUNBOOK_LLM_MODEL_UPDATE.md`
  - [x] `docs/runbooks/model-update-launch-packet.md`
  - [x] `packages/llm-mesh/scripts/add-model.mjs`
  - [x] `packages/llm-mesh/tests/add-model-script.test.ts`
  - [x] `.tmp/engage/model-update-runbook-report.md`
- [x] **Forbidden Paths (must not change in this branch)**
  - [x] `docker-compose*.yml`
  - [x] `.cursor/rules/**`
  - [x] `.github/workflows/**`
  - [x] Existing `packages/llm-mesh/src/**` model data and generated council output.
  - [x] Package manifests and lockfiles; this branch does not ship a model or package runtime change.
- [x] **Conditional Paths**
  - [x] `Makefile` only under `BR75-EX1`.
- [x] **Exception process**
  - [x] Declare an exception before changing any other conditional or forbidden path.

## Feedback Loop
- [x] `BR75-EX1` accepted by owner request: change the normally forbidden `Makefile` because the repository's make-only policy requires an entrypoint for this recurring job; impact is one additive target plus one script; rollback removes that target and script.
- [x] Source gap: PR #540 is not merged into this branch base, so its Gemini 3.7 changes are evidence, not files to copy into this deliverable.
- [x] Source gap: vendor documentation is mutable; every future update must capture its dated official model-id evidence in its PR.
- [x] Source gap: host defaults for h-cond/h2a-runtime, including agy, live outside this repository and require a notification handoff rather than an in-repo edit.

## AI Flaky tests
- [x] Accept no deterministic scaffold, generation-freshness, typecheck, lint, build, or package test failure as flaky.
- [x] Local `make test` reached `api/tests/ai/**` then failed 18 tests because all five provider keys were unset (`Provider auth source is not configured`); runtime/auth paths are unchanged and CI injects those secrets, so the remote AI gate remains authoritative and owner sign-off is required before merge if it repeats.

## Orchestration Mode
- [x] **Mono-branch** with no implementation sub-agent; two independent blind h2a review legs are read-only gates.

## Plan / Todo (lot-based)
- [x] **Lot 0 — Baseline and exact scope**
  - [x] Read project rules, workflow, sub-agent contract, project context, PLAN model-council constraint, and branch template.
  - [x] Verify `feat/llm-model-update-runbook` mechanically with `harness check branch`.
  - [x] Confirm HEAD equals `origin/main` merge PR #539 and study the complete PR #540 delta.
  - [x] Locate catalog, providers, route definitions, capability sources, council generator/check, publish order, and internal consumers.
  - [x] Confirm official OpenAI, Anthropic, and Gemini model registries are reachable.

- [x] **Lot 1 — Owner runbook**
  - [x] Add the anti-phantom evidence gate and copy-from-BASE procedure.
  - [x] Document catalog, provider, routing, council refresh/check, tests, all consumer bumps, semver, ordered publication, and external host notification.
  - [x] Add a precise current-tree file-and-line table and mark every unresolved external/source gap.
  - [x] Gate: Markdown paths and cited line anchors verified against the current tree.

- [x] **Lot 2 — Safe add-model scaffold**
  - [x] Add an idempotent script that plans or applies catalog, provider, and default-route stubs copied from `BASE`.
  - [x] Make dry-run side-effect free and print the manual evidence, council, consumer, test, version, publication, and host-default checklist.
  - [x] Add focused tests for valid stubs, dry-run immutability, idempotence, partial repair, and invalid input.
  - [x] Add `make llm-mesh-add-model MODEL=<id> BASE=<id>` under `BR75-EX1`.
  - [x] Gate: focused test and dry-run make invocation are green.

- [x] **Lot 3 — Standard MODEL UPDATE launch packet**
  - [x] Add copy-ready drumbeat and mesh-lane mandates for `MODEL=<X>` and `BASE=<Y>`.
  - [x] Specify Codex 5.6 Sol xhigh build, blind Opus 4.8 review, exact evidence/scope/test/publish gates, stop conditions, and report contract.
  - [x] Gate: packet requires one directive, one make scaffold, one blind review, and no merge.

- [ ] **Lot 4 — Final validation and PR-only delivery**
  - [x] Run scope, council freshness, focused tests, dry run, build, typecheck, and lint gates; record the local provider-secret boundary for the full test gate.
  - [x] Record review selection failure: exact author model and effort are unattested, so independent blind peer eligibility cannot be proven without invention.
  - [x] Verify `git branch --show-current` immediately before every commit.
  - [ ] Push `feat/llm-model-update-runbook`, open the requested PR without merging, and verify CI.
  - [ ] Write `.tmp/engage/model-update-runbook-report.md` and deposit a valid `sentropic.h2a` v1.0 report to `claude:sentropic-drumbeat:21fe3355ad7d`.
