### PR TITLE
fix(preprod): pin the Google OAuth callback base like every other host value

### DIFF
--- a/deploy/k8s/base/30-api.yaml
+++ b/deploy/k8s/base/30-api.yaml
@@ -26,10 +26,25 @@ data:
   WEBAUTHN_RP_ID: "sent-tech.ca"
   WEBAUTHN_RP_NAME: "Sentropic"
   WEBAUTHN_ORIGIN: "https://sentropic.sent-tech.ca"
-  # Public base URL for user-facing callbacks. Builds magic-link login emails
-  # (auth/magic-link.ts, else defaults to http://localhost:5173) and the Google
-  # Drive OAuth redirect_uri base. Must be the public host.
+  # Public base URL for magic-link login emails (auth/magic-link.ts, else defaults to
+  # http://localhost:5173) and for the POST-OAuth app RETURN url
+  # (`resolveGoogleDriveAppReturnBaseUrl`, google-drive-oauth.ts:190). Must be the public host.
+  #
+  # It is NOT the Google OAuth `redirect_uri` base, contrary to what this comment claimed until now
+  # (and to the copy of it that had been carried into the preprod overlay). `resolveCallbackBaseUrl`
+  # (google-drive-oauth.ts:158) never reads this key — see the next one.
   AUTH_CALLBACK_BASE_URL: "https://sentropic.sent-tech.ca"
+  # The Google OAuth `redirect_uri` base, for BOTH connectors: Gmail resolves it through the same
+  # function (gmail-oauth.ts:29 reuses `resolveCallbackBaseUrl`), so this one key fixes
+  # `<base>/api/v1/google-drive/oauth/callback` and `<base>/api/v1/gmail/oauth/callback`. Both must
+  # be registered verbatim on the Google OAuth client — redirect matching is exact-string.
+  #
+  # Declared rather than derived, like every other host-shaped value here. Unset, the chain falls
+  # through to its last candidate, the REQUEST origin (`x-forwarded-host`, gmail.ts:49), which
+  # yields the right host behind the ingress but is not a property of the deployment: a call
+  # arriving without that header builds a redirect_uri Google has never seen, and the resulting
+  # `redirect_uri_mismatch` sends the investigation to the Console instead of here.
+  GOOGLE_DRIVE_AUTH_CALLBACK_BASE_URL: "https://sentropic.sent-tech.ca"
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/k8s/overlays/preprod/patch-api-config.yaml
+++ b/deploy/k8s/overlays/preprod/patch-api-config.yaml
@@ -15,9 +15,27 @@ metadata:
 data:
   WEBAUTHN_RP_ID: "preprod.sentropic.sent-tech.ca"
   WEBAUTHN_ORIGIN: "https://preprod.sentropic.sent-tech.ca"
-  # Public base URL for user-facing callbacks (magic-link login emails + Google
-  # Drive OAuth redirect_uri base) — must be the preprod product host.
+  # Public base URL for magic-link login emails, and the base of the POST-OAuth app RETURN url
+  # (`resolveGoogleDriveAppReturnBaseUrl`, google-drive-oauth.ts:190) — must be the preprod product
+  # host.
+  #
+  # It is NOT the Google OAuth `redirect_uri` base, contrary to what this comment claimed until now.
+  # `resolveCallbackBaseUrl` (google-drive-oauth.ts:158) never reads this key: its chain is
+  # GOOGLE_DRIVE_AUTH_CALLBACK_BASE_URL → the `google_drive_oauth_callback_base_url` setting → the
+  # request origin. The two keys look interchangeable and are not.
   AUTH_CALLBACK_BASE_URL: "https://preprod.sentropic.sent-tech.ca"
+  # The Google OAuth `redirect_uri` base, for BOTH connectors — Gmail resolves it through the same
+  # function (gmail-oauth.ts:29 reuses `resolveCallbackBaseUrl`), so this one key fixes:
+  #   https://preprod.sentropic.sent-tech.ca/api/v1/google-drive/oauth/callback
+  #   https://preprod.sentropic.sent-tech.ca/api/v1/gmail/oauth/callback
+  # Both must be registered verbatim on the Google OAuth client (exact-string match).
+  #
+  # Pinned for homogeneity with every other host-derived value in this overlay. Unpinned, the chain
+  # falls through to its last candidate, the REQUEST origin (`x-forwarded-host`), which happens to
+  # yield the right host behind this ingress — but it is derived rather than declared, so any call
+  # arriving without that header would build a redirect_uri Google has never seen, and the failure
+  # (`redirect_uri_mismatch`) would point at the Console rather than at the deployment.
+  GOOGLE_DRIVE_AUTH_CALLBACK_BASE_URL: "https://preprod.sentropic.sent-tech.ca"
   # Rollout condition A for owner UAT of the Gmail/Drive MCP resource server (L4,
   # PR #489). The surface is OFF by default (api/src/routes/api/mcp.ts reads this
   # flag at request time and 404s the whole /api/v1/mcp/* prefix while disabled);


### PR DESCRIPTION
# fix(preprod): pin the Google OAuth callback base like every other host value

Alignment only. Overlay-only (one ConfigMap key + a corrected comment), `API_VERSION` unchanged, no
image publish. **This does not fix the current `invalid_client`** — see *What this is not* below.

## A comment that was wrong

The preprod overlay stated:

> Public base URL for user-facing callbacks (magic-link login emails + **Google Drive OAuth
> redirect_uri base**) — must be the preprod product host.

`AUTH_CALLBACK_BASE_URL` is **not** the Google OAuth `redirect_uri` base. `resolveCallbackBaseUrl`
(`google-drive-oauth.ts:158`) never reads it. Its chain is:

1. `process.env.GOOGLE_DRIVE_AUTH_CALLBACK_BASE_URL`
2. the `google_drive_oauth_callback_base_url` setting
3. `options.requestApiBaseUrl` — the **request origin** (`x-forwarded-host`, `gmail.ts:49`)

`AUTH_CALLBACK_BASE_URL` feeds a different thing: `resolveGoogleDriveAppReturnBaseUrl`
(`google-drive-oauth.ts:190`), the post-OAuth **app return** URL. Two keys that read as
interchangeable and are not — the comment is corrected here.

## The alignment

Neither of the first two candidates is set in preprod, so the redirect base resolves from the
**request origin**. Behind this ingress that yields the right host, so nothing is broken today — it
is *derived* rather than *declared*, which is out of step with everything else in this overlay
(`WEBAUTHN_ORIGIN`, `AUTH_CALLBACK_BASE_URL`, `MCP_RESOURCE_URI`, `API_BASE_URL`,
`MCP_AUTHORIZATION_SERVER_URL` are all pinned to the product host).

```yaml
GOOGLE_DRIVE_AUTH_CALLBACK_BASE_URL: "https://preprod.sentropic.sent-tech.ca"
```

One key covers **both** connectors: Gmail resolves its redirect through the same function
(`gmail-oauth.ts:29` reuses `resolveCallbackBaseUrl`), so this pins

```
https://preprod.sentropic.sent-tech.ca/api/v1/google-drive/oauth/callback
https://preprod.sentropic.sent-tech.ca/api/v1/gmail/oauth/callback
```

Both must be registered **verbatim** on the Google OAuth client — redirect matching is exact-string,
so a trailing slash or an explicit `:443` is a different URI.

Why it matters beyond tidiness: a request reaching the api without `x-forwarded-host` would build a
`redirect_uri` Google has never seen, and the resulting `redirect_uri_mismatch` points the
investigation at the Console rather than at the deployment. Pinning removes that failure mode and
removes one variable from the current debugging.

## What this is not

The live failure is Google answering **`invalid_client`**, which is about the client id/secret pair,
not the redirect. A truly absent pair would make `resolveGoogleDriveOAuthConfig` return `null` and
the api would never call Google at all — so both values resolved non-empty and at least one is
wrong. That is fixed elsewhere:

- the prod client's id/secret into the preprod `sentropic-api` Secret (owner decision: reuse the
  prod client rather than a dedicated preprod one);
- the two preprod redirect URIs above, plus the `gmail.readonly` scope, on that same Google client.

Note for whoever writes the Secret: use a targeted `kubectl patch --type=merge` on
`sentropic-preprod` with the namespace spelled out. **Not** `make k8s-bundle-secret` — its
`K8S_NAMESPACE` defaults to `sentropic` (prod) and it rewrites the whole Secret from `.env`, turning
every key absent from that file into an empty string in production.

## Apply

`kubectl apply -k` updates the ConfigMap; a `rollout restart deploy/api -n sentropic-preprod` is
required for the pods to pick it up.

## Scope

One file. `BRANCH.md` untouched — it belongs to another lane's in-flight work.
