### PR TITLE
fix(auth-idp): serve the brand mark instead of the SPA fallback

### DIFF
--- a/apps/auth-idp/idp-app.ts
+++ b/apps/auth-idp/idp-app.ts
@@ -168,7 +168,25 @@ export const createIdpApp = (): Hono => {
   // Serve the built static front (login/register/magic-link/consent screens)
   // same-origin with the OIDC API. Hashed assets under /_app are immutable.
   app.use('/_app/*', serveStatic({ root: IDP_WEB_BUILD_DIR }));
+  // Root-level assets from `web/static/` are NOT under /_app (they keep their plain names), so
+  // each one needs its own route: anything not matched here falls through to the SPA fallback
+  // below and is answered with `404.html`, i.e. HTML where the browser expects an image — which
+  // renders as a broken-image placeholder rather than as a visible 404.
+  //
+  // That is what happened to the brand mark: `+layout.svelte:27` asks for /SENT-logo-squared.svg,
+  // the file ships correctly in the build, and it was simply never routed. The bug was present in
+  // every tier from the start, production included. `favicon.ico` had already hit it and was
+  // patched file-by-file — the same trap, one file earlier.
+  //
+  // Kept file-by-file rather than serving the build root wholesale: a broad `serveStatic` here
+  // would also start answering route paths with prerendered HTML instead of the SPA fallback, and
+  // changing how the production auth screens resolve is not a change this fix should smuggle in.
+  // `web/static/` holds exactly these two files today; a third one needs a line here too.
   app.use('/favicon.ico', serveStatic({ path: join(IDP_WEB_BUILD_DIR, 'favicon.ico') }));
+  app.use(
+    '/SENT-logo-squared.svg',
+    serveStatic({ path: join(IDP_WEB_BUILD_DIR, 'SENT-logo-squared.svg') }),
+  );
 
   // SPA fallback: any other GET (e.g. /auth/login, /auth/oauth/consent) returns
   // the static `404.html` entry so client-side routing can take over. API and


### PR DESCRIPTION
The "Sentropic ID" logo renders as a broken-image placeholder on the IdP login screen — **in production as well as preprod**. Reported from an owner screenshot via the immo lane; diagnosed here.

## Not a missing asset

The file ships correctly: `apps/auth-idp/web/static/SENT-logo-squared.svg`, requested as `/SENT-logo-squared.svg` (`+layout.svelte:27`), copied into the build by the SvelteKit static adapter.

The server never routes it. `idp-app.ts` served exactly two static paths:

```js
app.use('/_app/*',      serveStatic({ root: IDP_WEB_BUILD_DIR }));
app.use('/favicon.ico', serveStatic({ path: join(IDP_WEB_BUILD_DIR, 'favicon.ico') }));
```

Root-level assets from `web/static/` keep their plain names, so they are not under `/_app`. The logo matched neither route and fell through to the SPA fallback.

**And the fallback answers `c.html(spaFallback)` — HTTP 200 with an HTML body.** So the request for an SVG returns 200 OK containing HTML, which the browser renders as a broken image rather than surfacing a 404. That is why this has been invisible in logs and monitoring while being plainly visible on screen.

`favicon.ico` had already hit this and was patched file-by-file. The same trap, one file earlier — which is why this is a hole from day one, not a regression, and why it affects every tier including production.

## The fix

One route, mirroring the favicon line, plus a comment naming the trap for the next root-level asset.

**Deliberately not** a wholesale `serveStatic` on the build root: that would also start answering route paths with prerendered HTML instead of the SPA fallback. Changing how the production auth screens resolve is not something this fix should smuggle in. `web/static/` contains exactly these two files today; the comment says a third one needs a line too.

## Verification

`make build-api` — exit 0, image built and tagged.

**No test added, and that is a statement rather than an omission**: `apps/auth-idp/package.json` has no scripts at all, and `ci.yml` references `apps/auth-idp/**` only as a path filter. A test file there would be silently orphaned — it would run nowhere and protect nothing. Wiring a test harness for this app is worth doing, and it is a bigger change than a one-line production fix should carry.

Post-deploy check, and note that the status code does **not** discriminate — it is 200 either way:

```
curl -sI https://auth.sent-tech.ca/SENT-logo-squared.svg | grep -i content-type
```
`image/svg+xml` means fixed; `text/html` means the fallback is still answering.

## Cost

Touches `apps/auth-idp`, so it rides the api image and needs a new `API_VERSION` — not an overlay, not a restart.