### PR TITLE
test(skills): align document_generate entityType assertion to organization schema

### DIFF
--- a/packages/skills/tests/bundles/foundation.test.ts
+++ b/packages/skills/tests/bundles/foundation.test.ts
@@ -740,7 +740,7 @@ describe('foundation bundle — Wave C step 3 content/action skills', () => {
         ?.properties;
       expect(props?.action?.enum).toEqual(['generate']);
       expect(props?.format?.enum).toEqual(['docx', 'pptx']);
-      expect(props?.entityType?.enum).toEqual(['initiative', 'folder']);
+      expect(props?.entityType?.enum).toEqual(['organization', 'initiative', 'folder']);
       expect(tool?.sideEffect).toBe(true);
       expect(tool?.requiresApproval).toBe(false);
     });


### PR DESCRIPTION
## Summary

- Fix a pre-existing skills baseline defect: the document_generate entityType assertion remained stale after the intentional organization schema addition in b8e91d67f.
- test-skills is outside the main CI matrix, so the stale assertion passed unnoticed.
- The cluster-mesh drumbeat gate discovered the mismatch.
- This is a one-line test assertion update only.

## Test

- Before: make test-skills ENV=fix-skills-foundation — 135/136 passed.
- After: make test-skills ENV=fix-skills-foundation — 136/136 passed.

No merge performed; merge remains an owner decision.