### PR TITLE
fix(security): bump fast-uri to 3.1.7 to clear 4 HIGH advisories

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -5085,9 +5085,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/api/package.json
+++ b/api/package.json
@@ -7,7 +7,7 @@
     "fast-xml-parser": "^5.3.6",
     "fast-xml-builder": "^1.1.7",
     "@xmldom/xmldom": "0.9.10",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "ip-address": "^10.3.1",
     "brace-expansion": "^2.1.4",
     "js-yaml": "^3.15.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9351,9 +9351,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mermaid": "^11.15.0",
     "uuid": "^11.1.1",
     "ws": "^8.21.0",
-    "fast-uri": "^3.1.5",
+    "fast-uri": "^3.1.7",
     "linkify-it": "^5.0.2",
     "js-yaml": "^3.15.1",
     "brace-expansion": "^5.0.8",


### PR DESCRIPTION
## What
Bump `fast-uri` from **3.1.5** to **3.1.7** (workspace + api `overrides`, and both `package-lock.json`) to clear four HIGH advisories that now fail the API Docker `npm audit` gate (`.security/audit-gate.mjs`, step 29/48 of the API build).

## Advisories cleared (all HIGH, `first_patched_version = 3.1.6`)
- `GHSA-5jgf-p345-68v8` — host confusion via skipped IDN canonicalization
- `GHSA-f65p-4m7j-42xc` — SSRF via malformed IPv6 normalization
- `GHSA-fph4-wmhf-6fwf` — SSRF via repeated hostname percent-decoding
- `GHSA-jqff-g426-hqxp` — host confusion via percent-encoded scheme normalization

`fast-uri` is not a direct dependency; it is forced across the transitive tree (ajv wants `^3.0.1`) via the `overrides` blocks in the root and `api` `package.json`. Those were `^3.1.5`; raised to `^3.1.7` and both lockfiles resolved to 3.1.7 with the official integrity hash.

## Why now
This is a freshly published advisory wave: `origin/main` (`fb0d37b04`, the dependabot security-sweep merge) still pins `^3.1.5`, so `main` fails the same gate today — this is not specific to any feature branch.

## Scope
- `package.json`, `package-lock.json`, `api/package.json`, `api/package-lock.json` — fast-uri only (8 insertions / 8 deletions).
- No source, schema, migration, Makefile, or Compose changes.

## Verification
The local audit gate could not be executed under the no-direct-docker policy; CI runs the authoritative `.security/audit-gate.mjs` in the API image build on this PR. Change is minimal and version/integrity are the official 3.1.7 registry values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)